### PR TITLE
docs(readme): fix some spelling typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Serve a RESTful API from any PostgreSQL database
 
 ## Problem
 
-There is the PostgREST written in haskell, keep a haskell software in production is not easy job, with this need that was born the pREST, [read more](https://github.com/prest/prest/issues/41).
+There is PostgREST written in Haskell, but keeping Haskell software in production is not an easy job. With this need pREST was born. [Read more](https://github.com/prest/prest/issues/41).
 
 ## Documentation
 


### PR DESCRIPTION
Just a quick update to fix some typos in the readme.
