### PR TITLE
unescape url before to send it to database

### DIFF
--- a/vendor/github.com/prest/template/funcregistry.go
+++ b/vendor/github.com/prest/template/funcregistry.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"net/url"
 	"fmt"
 	"strings"
 	"text/template"
@@ -17,6 +18,7 @@ func (fr *FuncRegistry) RegistryAllFuncs() (funcs template.FuncMap) {
 		"isSet":          fr.isSet,
 		"defaultOrValue": fr.defaultOrValue,
 		"inFormat":       fr.inFormat,
+		"unEscape": fr.unEscape,
 	}
 	return
 }
@@ -41,5 +43,10 @@ func (fr *FuncRegistry) inFormat(key string) (query string) {
 		return
 	}
 	query = fmt.Sprintf("('%s')", strings.Join(items, "', '"))
+	return
+}
+
+func (fr *FuncRegistry) unEscape(key string) (value string) {
+	value, _ = url.QueryUnescape(key)
 	return
 }

--- a/vendor/github.com/prest/template/funcregistry.go
+++ b/vendor/github.com/prest/template/funcregistry.go
@@ -1,8 +1,8 @@
 package template
 
 import (
-	"net/url"
 	"fmt"
+	"net/url"
 	"strings"
 	"text/template"
 )
@@ -18,7 +18,7 @@ func (fr *FuncRegistry) RegistryAllFuncs() (funcs template.FuncMap) {
 		"isSet":          fr.isSet,
 		"defaultOrValue": fr.defaultOrValue,
 		"inFormat":       fr.inFormat,
-		"unEscape": fr.unEscape,
+		"unEscape":       fr.unEscape,
 	}
 	return
 }


### PR DESCRIPTION
For some special case, like querying accentuate string non escaped in database. I hacked it for one of my own need, but it could be useful for someone else, i guess.