### PR TITLE
Configure SourceLevel linters

### DIFF
--- a/.sourcelevel.yml
+++ b/.sourcelevel.yml
@@ -2,14 +2,19 @@
 engines:
   golint:
     enabled: true
+    channel: latest
   gofmt:
     enabled: true
+    channel: latest
   govet:
     enabled: true
+    channel: latest
   fixme:
     enabled: true
+    channel: latest
   duplication:
     enabled: true
+    channel: latest
     config:
       languages:
       - go

--- a/.sourcelevel.yml
+++ b/.sourcelevel.yml
@@ -1,0 +1,17 @@
+---
+engines:
+  golint:
+    enabled: true
+  gofmt:
+    enabled: true
+  govet:
+    enabled: true
+  fixme:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - go
+exclude_paths:
+- vendor/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/prest/prest)](https://goreportcard.com/report/github.com/prest/prest)
 [![Coverage Status](https://coveralls.io/repos/github/prest/prest/badge.svg?branch=master)](https://coveralls.io/github/prest/prest?branch=master)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prest/prest?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![SourceLevel](https://app.sourcelevel.io/github/prest/prest.svg)](https://app.sourcelevel.io/github/prest/prest)
 
 _p_**REST** (**P**_ostgreSQL_ **REST**), simplify and accelerate development, instant, realtime, high-performance on any **Postgres** application, **existing or new**
 
@@ -17,7 +18,7 @@ There is PostgREST written in Haskell, but keeping Haskell software in productio
 
 ## 1-Click Deploy
 
-### Heroku 
+### Heroku
 Deploy to Heroku and instantly get a realtime RESTFul API backed by Heroku Postgres:
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/prest/prest-heroku)


### PR DESCRIPTION
Seems that you're using [SourceLevel](https://sourcelevel.io) but the configuration file stills in `.codeclimate.yml`.

This PR rename linter configuration file to `.sourcelevel.yml` then configure to use latest versions for all engines.

Also I've added `SourceLevel` issues count badge to the `README` file and featured **pREST** in our [OSS page](https://app.sourcelevel.io/oss).

Any feedbacks are always welcome.

---

**nitpick:** remove extra trailing space for `Heroku` section in `README`