### PR TITLE
Add http headers support to SQL script templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   fast_finish: true
 env:
   - PREST_PG_USER=postgres PREST_PG_DATABASE=prest PREST_PG_PORT=5432 PREST_CONF=$TRAVIS_BUILD_DIR/testdata/prest.toml
+go_import_path: github.com/prest/prest
 before_install:
   - sudo apt-get -y install gcc-multilib
   - go get -v -d ./...

--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -3,7 +3,6 @@ package adapters
 import (
 	"database/sql"
 	"net/http"
-	"net/url"
 )
 
 //Adapter interface
@@ -31,7 +30,7 @@ type Adapter interface {
 	PaginateIfPossible(r *http.Request) (paginatedQuery string, err error)
 	ParseBatchInsertRequest(r *http.Request) (colsName string, colsValue string, values []interface{}, err error)
 	ParseInsertRequest(r *http.Request) (colsName string, colsValue string, values []interface{}, err error)
-	ParseScript(scriptPath string, queryURL url.Values) (sqlQuery string, values []interface{}, err error)
+	ParseScript(scriptPath string, templateData map[string]interface{}) (sqlQuery string, values []interface{}, err error)
 	Query(SQL string, params ...interface{}) (sc Scanner)
 	QueryCount(SQL string, params ...interface{}) (sc Scanner)
 	ReturningByRequest(r *http.Request) (returningSyntax string, err error)

--- a/adapters/mock/mock.go
+++ b/adapters/mock/mock.go
@@ -6,7 +6,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sync"
 	"testing"
 
@@ -29,6 +28,8 @@ type Mock struct {
 	conns map[string]*mockConn
 	Items []Item
 }
+
+var _ adapters.Adapter = (*Mock)(nil) // Verify that Mock implements Adapter.
 
 // New mock
 func New(t *testing.T) (m *Mock) {
@@ -107,7 +108,7 @@ func (m *Mock) GetScript(verb string, folder string, scriptName string) (script 
 }
 
 // ParseScript mock
-func (m *Mock) ParseScript(scriptPath string, queryURL url.Values) (sqlQuery string, values []interface{}, err error) {
+func (m *Mock) ParseScript(scriptPath string, data map[string]interface{}) (sqlQuery string, values []interface{}, err error) {
 	return
 }
 

--- a/adapters/mock/mock_test.go
+++ b/adapters/mock/mock_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
-	"net/url"
 	"reflect"
 	"sync"
 	"testing"
@@ -486,7 +485,7 @@ func TestMockEmptyMethods(t *testing.T) {
 	}
 
 	// ParseScript
-	_, _, err = mock.ParseScript("path/to/script", url.Values{"q": []string{"test"}})
+	_, _, err = mock.ParseScript("path/to/script", map[string]interface{}{"q": []string{"test"}})
 	if err != nil {
 		t.Errorf("expected empty return, got: %s", err)
 	}

--- a/adapters/postgres/queries.go
+++ b/adapters/postgres/queries.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -45,18 +44,10 @@ func (adapter *Postgres) GetScript(verb, folder, scriptName string) (script stri
 }
 
 // ParseScript use values sent by users and add on script
-func (adapter *Postgres) ParseScript(scriptPath string, queryURL url.Values) (sqlQuery string, values []interface{}, err error) {
+func (adapter *Postgres) ParseScript(scriptPath string, templateData map[string]interface{}) (sqlQuery string, values []interface{}, err error) {
 	_, tplName := path.Split(scriptPath)
-	q := make(map[string]interface{})
-	for key, value := range queryURL {
-		if len(value) == 1 {
-			q[key] = value[0]
-			continue
-		}
-		q[key] = value
-	}
 
-	funcs := &template.FuncRegistry{TemplateData: q}
+	funcs := &template.FuncRegistry{TemplateData: templateData}
 	tpl := gotemplate.New(tplName).Funcs(funcs.RegistryAllFuncs())
 
 	tpl, err = tpl.ParseFiles(scriptPath)

--- a/adapters/postgres/queries_test.go
+++ b/adapters/postgres/queries_test.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"fmt"
 	"log"
-	"net/url"
 	"os"
 	"os/user"
 	"testing"
@@ -69,8 +68,8 @@ func TestInvalidGetScript(t *testing.T) {
 }
 
 func TestParseScriptInvalid(t *testing.T) {
-	queryURL := url.Values{}
-	queryURL.Set("field1", "abc")
+	templateData := map[string]interface{}{}
+	templateData["field1"] = "abc"
 
 	user, err := user.Current()
 	if err != nil {
@@ -79,7 +78,7 @@ func TestParseScriptInvalid(t *testing.T) {
 	scriptPath := fmt.Sprint(user.HomeDir, "/queries/fulltable/%s")
 
 	t.Log("Parse script with get_all file")
-	sql, _, err := config.PrestConf.Adapter.ParseScript(fmt.Sprintf(scriptPath, "get_all.read.sql"), queryURL)
+	sql, _, err := config.PrestConf.Adapter.ParseScript(fmt.Sprintf(scriptPath, "get_all.read.sql"), templateData)
 	if err != nil {
 		t.Errorf("expected no error, but got: %v", err)
 	}
@@ -87,16 +86,11 @@ func TestParseScriptInvalid(t *testing.T) {
 	if sql != "SELECT * FROM test7 WHERE name = 'abc'" {
 		t.Errorf("SQL unexpected, got: %s", sql)
 	}
-
-	// Add new values
-	queryURL.Del("field1")
-	queryURL.Set("notable", "123")
 }
 
 func TestParseScript(t *testing.T) {
-	queryURL := url.Values{}
-	queryURL.Add("field1", "abc")
-	queryURL.Add("field1", "test")
+	templateData := map[string]interface{}{}
+	templateData["field1"] = []string{"abc", "test"}
 
 	user, err := user.Current()
 	if err != nil {
@@ -105,7 +99,7 @@ func TestParseScript(t *testing.T) {
 	scriptPath := fmt.Sprint(user.HomeDir, "/queries/fulltable/%s")
 
 	t.Log("Parse script with get_all_slice file")
-	sql, _, err := config.PrestConf.Adapter.ParseScript(fmt.Sprintf(scriptPath, "get_all_slice.read.sql"), queryURL)
+	sql, _, err := config.PrestConf.Adapter.ParseScript(fmt.Sprintf(scriptPath, "get_all_slice.read.sql"), templateData)
 	if err != nil {
 		t.Errorf("expected no error, but got: %v", err)
 	}

--- a/controllers/sql_test.go
+++ b/controllers/sql_test.go
@@ -77,6 +77,7 @@ func TestExecuteFromScripts(t *testing.T) {
 	}{
 		{"Get results using scripts and funcs by GET method", "/_QUERIES/fulltable/funcs", "GET", http.StatusOK},
 		{"Get results using scripts by GET method", "/_QUERIES/fulltable/get_all?field1=gopher", "GET", http.StatusOK},
+		{"Get results using scripts by GET method (2)", "/_QUERIES/fulltable/get_header", "GET", http.StatusOK},
 		{"Get results using scripts by POST method", "/_QUERIES/fulltable/write_all?field1=gopherzin&field2=pereira", "POST", http.StatusOK},
 		{"Get results using scripts by PUT method", "/_QUERIES/fulltable/put_all?field1=trump&field2=pereira", "PUT", http.StatusOK},
 		{"Get results using scripts by PATCH method", "/_QUERIES/fulltable/patch_all?field1=temer&field2=trump", "PATCH", http.StatusOK},

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -161,6 +161,8 @@ func doRequest(t *testing.T, url string, r interface{}, method string, expectedS
 		t.Error("error on New Request", err)
 	}
 
+	req.Header.Add("X-Application", "prest")
+
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -199,6 +201,11 @@ func createMockScripts(base string) {
 		log.Println(err)
 	}
 	_, err = os.Create(fmt.Sprint(base, "/fulltable/get_all.read.sql"))
+	if err != nil {
+		log.Println(err)
+	}
+
+	_, err = os.Create(fmt.Sprint(base, "/fulltable/get_header.read.sql"))
 	if err != nil {
 		log.Println(err)
 	}
@@ -255,6 +262,7 @@ func writeMockScripts(base string) {
 
 	write("SELECT * FROM test7 WHERE name = '{{defaultOrValue \"field1\" \"gopher\"}}'", "funcs.read.sql")
 	write("SELECT * FROM test7 WHERE name = '{{.field1}}'", "get_all.read.sql")
+	write("SELECT {{index .header \"X-Application\"}}", "get_header.read.sql")
 	write("INSERT INTO test7 (name, surname) VALUES ('{{.field1}}', '{{.field2}}')", "write_all.write.sql")
 	write("CREATE TABLE {{.field1}};", "create_table.write.sql")
 	write("UPDATE test7 SET name = '{{.field1}}' WHERE surname = '{{.field2}}'", "patch_all.update.sql")

--- a/docs/executing-sql-scripts/_index.en.md
+++ b/docs/executing-sql-scripts/_index.en.md
@@ -75,6 +75,40 @@ PATCH  /_QUERIES/bar/some_update?field1=foo
 DELETE /_QUERIES/bar/some_delete?field1=foo
 ```
 
+### Template data
+
+You can access the query parameters of the incoming HTTP request using the `.` notation.
+
+For instance, the following request:
+
+```
+GET    /_QUERIES/bar/some_get?field1=foo&field2=bar
+```
+
+makes available the fields `field1` and `field2` in the script:
+
+```
+{{.field1}}
+{{.field2}}
+```
+
+You can also access the query headers of the incoming HTTP requests using the `.header` notation.
+
+For instance, the following request:
+
+```
+GET    /_QUERIES/bar/some_get
+X-UserId: am9obi5kb2VAYW5vbnltb3VzLmNvbQ
+X-Application: prest
+```
+
+makes available the headers `X-UserId` and `X-Application` in the script:
+
+```
+{{index .header "X-UserId"}}
+{{index .header "X-Application"}}
+```
+
 ### Template functions
 
 


### PR DESCRIPTION
Implements #409.

The idea is to let the HTTP headers accessible from the SQL script templates.

As you'll see, I had to change the signature of the `ParseScript()` function to allow a broader  context to be transmitted. Consequently, the extraction of template data (either http query params or headers) is now performed by the `ExecuteScriptQuery()` function.

To avoid any risk of variable name collision, I'd suggest putting the headers values in the sub-context `{{ .header }}`.

Any feedbacks are welcome. I can make adjustments if necessary.