### PR TITLE
remove docker login on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
 before_script:
-  - docker login -u="$DOCKER_LOGIN" -p="$DOCKER_PASSWORD"
   - sh testdata/schema.sh
 script:
   - curl -sfL https://git.io/goreleaser | sh -s -- check
@@ -47,8 +46,3 @@ deploy:
       branch: master
       go: "1.15.x"
       condition: $TRAVIS_OS_NAME = linux
-
-notifications:
-  webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/edf464ac074390da55f9

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python"
+}

--- a/scripts/releaser-tag.sh
+++ b/scripts/releaser-tag.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 docker build . -t prest/prest:v1 && \
+docker login -u="$DOCKER_LOGIN" -p="$DOCKER_PASSWORD" && \
 docker push prest/prest:v1 && \
 docker tag prest/prest:v1 prest/prest:$TRAVIS_TAG && \
 docker push prest/prest:$TRAVIS_TAG && \


### PR DESCRIPTION
remove docker login when not generating a release
```
Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password
The command "docker login -u="$DOCKER_LOGIN" -p="$DOCKER_PASSWORD"" failed and exited with 1 during .
```