### PR TITLE
Fix admin bug report labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/admin_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/admin_bug_report.md
@@ -2,9 +2,8 @@
 name: 'Admin: Bug report'
 title: ''
 about: 'Create a report to help us improve - Admin'
-labels: 'Bug', 'Software: admin'
+labels: 'Bug, Software: admin'
 assignees: ''
-
 ---
 
 <!--


### PR DESCRIPTION
## Description

Follow up to #454. `admin_bug_report.md` label list is invalid at the moment and doesn't show up in the issue list either as seen in the below image:
![image](https://user-images.githubusercontent.com/12761692/102272696-10971080-3f19-11eb-8812-f35a95b38d1a.png)

