### PR TITLE
make image size smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.hub.docker.com/library/golang:1.15 as builder
 WORKDIR /workspace
 COPY . .
 RUN go mod download  \
-&& CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o prestd cmd/prestd/main.go \
+&& CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-s -w" -o prestd cmd/prestd/main.go \
 && apt-get update && apt-get install --no-install-recommends -yq netcat=1.10-41.1
 
 WORKDIR /app


### PR DESCRIPTION
Hi all:

we can use [`-s` and `-w` linker flags](https://golang.org/cmd/link/)  to strip the debugging info, we don't need these in our image, and  this can reduce image size.

because of my network problem, I can't build image on my laptop. but we can compare the binary executable file size.

1. without `ldflags "-s -w"`
```sh
$ CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build  -o prestd cmd/prestd/main.go                                                                                                                        
$ ls -sailh  prestd                                                                                                                                                                                                      
6302656 14M -rwxr-xr-x 1 brown users 14M Jan  4 00:40 prestd
```

2. with  `ldflags "-s -w" `
```sh
$ CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-s -w" -o prestd cmd/prestd/main.go                                                                                                    
$ ls -sailh  prestd                                                                                                                                                                                             
6302656 9.7M -rwxr-xr-x 1 brown users 9.7M Jan  4 00:39 prestd
```

we can save  **4.3MB**  disk space, and this should work in docker image, which will speed up download progress.


















