### PR TITLE
Use PREST_SSL_MODE environment variable in our examples

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -23,6 +23,7 @@ services:
             - PREST_PG_PASS=prest
             - PREST_PG_DATABASE=prest
             - PREST_PG_PORT=5432
+            - PREST_PSSL_MODE=disable
         depends_on:
             - postgres
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
             - PREST_PG_DATABASE=prest
             - PREST_PG_PORT=5432
             - PREST_JWT_DEFAULT=false # remove if need jwt
+            - PREST_SSL_MODE=disable
         depends_on:
             - postgres
         ports:

--- a/docs/integrations/timescaledb.en.md
+++ b/docs/integrations/timescaledb.en.md
@@ -46,6 +46,7 @@ services:
       - PREST_PG_DATABASE=prest
       - PREST_PG_PORT=5432
       - PREST_JWT_DEFAULT=false  # remove if need jwt
+      - PREST_SSL_MODE=disable
     depends_on:
       - timescaledb
     ports:


### PR DESCRIPTION
Commit 336d868 changed SSLMode default value to 'require', but in PostgreSQL SSL is disabled by default so it broke some of our examples. (fix #524)
    
This commit fix this misbehavior setting the environment variable PREST_SSL_MODE=disable to teach pREST to don't require SSL on PostgreSQL connection.

Signed-off-by: Fabrízio de Royes Mello <fabriziomello@gmail.com>