### PR TITLE
Fix typo in PREST_SSL_MODE environment variable name.

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -23,7 +23,7 @@ services:
             - PREST_PG_PASS=prest
             - PREST_PG_DATABASE=prest
             - PREST_PG_PORT=5432
-            - PREST_PSSL_MODE=disable
+            - PREST_SSL_MODE=disable
         depends_on:
             - postgres
         ports:


### PR DESCRIPTION
Fix typo in PREST_SSL_MODE environment variable name.