### PR TITLE
Remove dbname state in adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - go: master
   fast_finish: true
 env:
-  - PREST_PG_USER=postgres PREST_PG_DATABASE=prest-test PREST_PG_PORT=5432 PREST_CONF=$TRAVIS_BUILD_DIR/testdata/prest.toml
+  - PREST_SSL_MODE=disable PREST_PG_USER=postgres PREST_PG_DATABASE=prest-test PREST_PG_PORT=5432 PREST_CONF=$TRAVIS_BUILD_DIR/testdata/prest.toml
 go_import_path: github.com/prest/prest
 before_install:
   - sudo apt-get -y install gcc-multilib

--- a/CREATING_MODULES.md
+++ b/CREATING_MODULES.md
@@ -20,7 +20,7 @@ func main() {
 	// Get pREST app
 	config.Load()
 	// Set Adapter postgres
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 	middlewares.GetApp()
 
 	// Get pPREST router
@@ -58,7 +58,7 @@ import (
 func main() {
 	config.Load()
 	// Set Adapter postgres
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 
 	// Get pREST app
 	n := middlewares.GetApp()
@@ -105,7 +105,7 @@ import (
 func main() {
 	config.Load()
 	// Set Adapter postgres
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 	// Reorder middlewares
 	middlewares.MiddlewareStack = []negroni.Handler{
 		negroni.Handler(negroni.NewRecovery()),

--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -7,14 +7,14 @@ import (
 
 //Adapter interface
 type Adapter interface {
-	GetTransaction() (tx *sql.Tx, err error)
-	BatchInsertValues(SQL string, params ...interface{}) (sc Scanner)
+	GetTransaction(database string) (tx *sql.Tx, err error)
+	BatchInsertValues(database, SQL string, params ...interface{}) (sc Scanner)
 	BatchInsertCopy(dbname, schema, table string, keys []string, params ...interface{}) (sc Scanner)
 	CountByRequest(req *http.Request) (countQuery string, err error)
 	DatabaseClause(req *http.Request) (query string, hasCount bool)
 	DatabaseOrderBy(order string, hasCount bool) (orderBy string)
 	DatabaseWhere(requestWhere string) (whereSyntax string)
-	Delete(SQL string, params ...interface{}) (sc Scanner)
+	Delete(database, SQL string, params ...interface{}) (sc Scanner)
 	DeleteWithTransaction(tx *sql.Tx, SQL string, params ...interface{}) (sc Scanner)
 	DeleteSQL(database string, schema string, table string) string
 	DistinctClause(r *http.Request) (distinctQuery string, err error)
@@ -22,7 +22,7 @@ type Adapter interface {
 	FieldsPermissions(r *http.Request, table string, op string) (fields []string, err error)
 	GetScript(verb, folder, scriptName string) (script string, err error)
 	GroupByClause(r *http.Request) (groupBySQL string)
-	Insert(SQL string, params ...interface{}) (sc Scanner)
+	Insert(database, SQL string, params ...interface{}) (sc Scanner)
 	InsertWithTransaction(tx *sql.Tx, SQL string, params ...interface{}) (sc Scanner)
 	InsertSQL(database string, schema string, table string, names string, placeholders string) string
 	JoinByRequest(r *http.Request) (values []string, err error)
@@ -31,8 +31,8 @@ type Adapter interface {
 	ParseBatchInsertRequest(r *http.Request) (colsName string, colsValue string, values []interface{}, err error)
 	ParseInsertRequest(r *http.Request) (colsName string, colsValue string, values []interface{}, err error)
 	ParseScript(scriptPath string, templateData map[string]interface{}) (sqlQuery string, values []interface{}, err error)
-	Query(SQL string, params ...interface{}) (sc Scanner)
-	QueryCount(SQL string, params ...interface{}) (sc Scanner)
+	Query(database, SQL string, params ...interface{}) (sc Scanner)
+	QueryCount(database, SQL string, params ...interface{}) (sc Scanner)
 	ReturningByRequest(r *http.Request) (returningSyntax string, err error)
 	SchemaClause(req *http.Request) (query string, hasCount bool)
 	SchemaOrderBy(order string, hasCount bool) (orderBy string)
@@ -42,14 +42,13 @@ type Adapter interface {
 	SelectFields(fields []string) (sql string, err error)
 	SelectSQL(selectStr string, database string, schema string, table string) string
 	SetByRequest(r *http.Request, initialPlaceholderID int) (setSyntax string, values []interface{}, err error)
-	SetDatabase(name string)
 	TableClause() (query string)
 	TableOrderBy(order string) (orderBy string)
 	TablePermissions(table string, op string) bool
 	TableWhere(requestWhere string) (whereSyntax string)
-	Update(SQL string, params ...interface{}) (sc Scanner)
+	Update(database, SQL string, params ...interface{}) (sc Scanner)
 	UpdateWithTransaction(tx *sql.Tx, SQL string, params ...interface{}) (sc Scanner)
 	UpdateSQL(database string, schema string, table string, setSyntax string) string
 	WhereByRequest(r *http.Request, initialPlaceholderID int) (whereSyntax string, values []interface{}, err error)
-	ShowTable(schema, table string) (sc Scanner)
+	ShowTable(database, schema, table string) (sc Scanner)
 }

--- a/adapters/mock/mock.go
+++ b/adapters/mock/mock.go
@@ -148,7 +148,7 @@ func (m *Mock) PaginateIfPossible(r *http.Request) (paginatedQuery string, err e
 }
 
 // GetTransaction mock
-func (m *Mock) GetTransaction() (tx *sql.Tx, err error) {
+func (m *Mock) GetTransaction(database string) (tx *sql.Tx, err error) {
 	db, err := sql.Open("mock", "prest")
 	if err != nil {
 		return
@@ -157,7 +157,7 @@ func (m *Mock) GetTransaction() (tx *sql.Tx, err error) {
 }
 
 // Query mock
-func (m *Mock) Query(SQL string, params ...interface{}) (sc adapters.Scanner) {
+func (m *Mock) Query(database, SQL string, params ...interface{}) (sc adapters.Scanner) {
 	m.t.Helper()
 	sc = m.perform(true)
 	return
@@ -200,7 +200,7 @@ func (m *Mock) GroupByClause(r *http.Request) (groupBySQL string) {
 }
 
 // QueryCount mock
-func (m *Mock) QueryCount(SQL string, params ...interface{}) (sc adapters.Scanner) {
+func (m *Mock) QueryCount(database, SQL string, params ...interface{}) (sc adapters.Scanner) {
 	m.t.Helper()
 	sc = m.perform(false)
 	return
@@ -212,7 +212,7 @@ func (m *Mock) ParseInsertRequest(r *http.Request) (colsName string, colsValue s
 }
 
 // Insert mock
-func (m *Mock) Insert(SQL string, params ...interface{}) (sc adapters.Scanner) {
+func (m *Mock) Insert(database, SQL string, params ...interface{}) (sc adapters.Scanner) {
 	m.t.Helper()
 	sc = m.perform(false)
 	return
@@ -226,7 +226,7 @@ func (m *Mock) InsertWithTransaction(tx *sql.Tx, SQL string, params ...interface
 }
 
 // Delete mock
-func (m *Mock) Delete(SQL string, params ...interface{}) (sc adapters.Scanner) {
+func (m *Mock) Delete(database, SQL string, params ...interface{}) (sc adapters.Scanner) {
 	m.t.Helper()
 	sc = m.perform(false)
 	return
@@ -245,7 +245,7 @@ func (m *Mock) SetByRequest(r *http.Request, initialPlaceholderID int) (setSynta
 }
 
 // Update mock
-func (m *Mock) Update(SQL string, params ...interface{}) (sc adapters.Scanner) {
+func (m *Mock) Update(database, SQL string, params ...interface{}) (sc adapters.Scanner) {
 	m.t.Helper()
 	sc = m.perform(false)
 	return
@@ -261,10 +261,6 @@ func (m *Mock) UpdateWithTransaction(tx *sql.Tx, SQL string, params ...interface
 // DistinctClause mock
 func (m *Mock) DistinctClause(r *http.Request) (distinctQuery string, err error) {
 	return
-}
-
-// SetDatabase mock
-func (m *Mock) SetDatabase(name string) {
 }
 
 // SelectSQL mock
@@ -338,7 +334,7 @@ func (m *Mock) ParseBatchInsertRequest(r *http.Request) (colsName string, placeh
 }
 
 // BatchInsertValues mock
-func (m *Mock) BatchInsertValues(SQL string, params ...interface{}) (sc adapters.Scanner) {
+func (m *Mock) BatchInsertValues(database, SQL string, params ...interface{}) (sc adapters.Scanner) {
 	m.t.Helper()
 	sc = m.perform(true)
 	return
@@ -352,7 +348,7 @@ func (m *Mock) BatchInsertCopy(dbname, schema, table string, keys []string, valu
 }
 
 // ShowTable shows table structure
-func (m *Mock) ShowTable(schema, table string) (sc adapters.Scanner) {
+func (m *Mock) ShowTable(database, schema, table string) (sc adapters.Scanner) {
 	return
 }
 

--- a/adapters/mock/mock_test.go
+++ b/adapters/mock/mock_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/prest/prest/config"
 )
 
+const dbname = "prest"
+
 func TestMock_validate(t *testing.T) {
 	type fields struct {
 		mtx   *sync.RWMutex
@@ -221,7 +223,7 @@ func TestMock_Insert(t *testing.T) {
 				t:   t,
 			}
 			m.AddItem(tt.item.Body, tt.item.Error, tt.item.IsCount)
-			if gotSc := m.Insert(""); !reflect.DeepEqual(gotSc, tt.wantSc) {
+			if gotSc := m.Insert(config.PrestConf.PGDatabase, ""); !reflect.DeepEqual(gotSc, tt.wantSc) {
 				t.Errorf("Mock.Insert() = %v, want %v", gotSc, tt.wantSc)
 			}
 		})
@@ -263,7 +265,7 @@ func TestMock_BatchInsertValues(t *testing.T) {
 				t:   t,
 			}
 			m.AddItem(tt.item.Body, tt.item.Error, tt.item.IsCount)
-			if gotSc := m.BatchInsertValues(""); !reflect.DeepEqual(gotSc, tt.wantSc) {
+			if gotSc := m.BatchInsertValues(dbname, ""); !reflect.DeepEqual(gotSc, tt.wantSc) {
 				t.Errorf("Mock.BatchInsert() = %v, want %v", gotSc, tt.wantSc)
 			}
 		})
@@ -303,7 +305,7 @@ func TestMock_Delete(t *testing.T) {
 				t:   t,
 			}
 			m.AddItem(tt.item.Body, tt.item.Error, tt.item.IsCount)
-			if gotSc := m.Delete(""); !reflect.DeepEqual(gotSc, tt.wantSc) {
+			if gotSc := m.Delete(dbname, ""); !reflect.DeepEqual(gotSc, tt.wantSc) {
 				t.Errorf("Mock.Delete() = %v, want %v", gotSc, tt.wantSc)
 			}
 		})
@@ -343,7 +345,7 @@ func TestMock_Update(t *testing.T) {
 				t:   t,
 			}
 			m.AddItem(tt.item.Body, tt.item.Error, tt.item.IsCount)
-			if gotSc := m.Update(""); !reflect.DeepEqual(gotSc, tt.wantSc) {
+			if gotSc := m.Update(dbname, ""); !reflect.DeepEqual(gotSc, tt.wantSc) {
 				t.Errorf("Mock.Update() = %v, want %v", gotSc, tt.wantSc)
 			}
 		})
@@ -383,7 +385,7 @@ func TestMock_QueryCount(t *testing.T) {
 				t:   t,
 			}
 			m.AddItem(tt.item.Body, tt.item.Error, tt.item.IsCount)
-			if gotSc := m.QueryCount(""); !reflect.DeepEqual(gotSc, tt.wantSc) {
+			if gotSc := m.QueryCount(config.PrestConf.PGDatabase, ""); !reflect.DeepEqual(gotSc, tt.wantSc) {
 				t.Errorf("Mock.QueryCount() = %v, want %v", gotSc, tt.wantSc)
 			}
 		})
@@ -425,7 +427,7 @@ func TestMock_Query(t *testing.T) {
 				t:   t,
 			}
 			m.AddItem(tt.item.Body, tt.item.Error, tt.item.IsCount)
-			if gotSc := m.Query(""); !reflect.DeepEqual(gotSc, tt.wantSc) {
+			if gotSc := m.Query(config.PrestConf.PGDatabase, ""); !reflect.DeepEqual(gotSc, tt.wantSc) {
 				t.Errorf("Mock.Query() = %v, want %v", gotSc, tt.wantSc)
 			}
 		})
@@ -453,7 +455,7 @@ func TestMock_GetTransaction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := New(t)
-			gotTx, err := m.GetTransaction()
+			gotTx, err := m.GetTransaction(dbname)
 			errMactches := (err != nil) != tt.wantErr
 			if errMactches {
 				t.Errorf("Mock.GetTransaction() error = %v, wantErr %v", err, tt.wantErr)
@@ -521,7 +523,7 @@ func TestMockEmptyMethods(t *testing.T) {
 	}
 
 	// GetTransaction
-	_, err = mock.GetTransaction()
+	_, err = mock.GetTransaction(dbname)
 	if err != nil {
 		t.Errorf("expected empty return, got: %s", err)
 	}
@@ -596,9 +598,6 @@ func TestMockEmptyMethods(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected empty return, got: %s", err)
 	}
-
-	// SetDatabase
-	mock.SetDatabase("prest")
 
 	// SelectSQL
 	s := mock.SelectSQL("select 1", "prest", "public", "test1")

--- a/adapters/postgres/connection.go
+++ b/adapters/postgres/connection.go
@@ -11,8 +11,8 @@ func GetURI(DBName string) string {
 }
 
 // Get get postgres connection
-func Get() (*sqlx.DB, error) {
-	return connection.Get()
+func Get(database string) (*sqlx.DB, error) {
+	return connection.Get(database)
 }
 
 // GetPool of connection
@@ -26,16 +26,7 @@ func AddDatabaseToPool(name string, DB *sqlx.DB) {
 }
 
 // MustGet get postgres connection
-func MustGet() *sqlx.DB {
-	return connection.MustGet()
+func MustGet(database string) *sqlx.DB {
+	return connection.MustGet(database)
 }
 
-// SetDatabase set current database in use
-func SetDatabase(name string) {
-	connection.SetDatabase(name)
-}
-
-// GetDatabase get current database in use
-func GetDatabase() string {
-	return connection.GetDatabase()
-}

--- a/adapters/postgres/connection.go
+++ b/adapters/postgres/connection.go
@@ -29,4 +29,3 @@ func AddDatabaseToPool(name string, DB *sqlx.DB) {
 func MustGet(database string) *sqlx.DB {
 	return connection.MustGet(database)
 }
-

--- a/adapters/postgres/internal/connection/conn.go
+++ b/adapters/postgres/internal/connection/conn.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	err          error
-	pool         *Pool
+	err  error
+	pool *Pool
 )
 
 // Pool struct

--- a/adapters/postgres/queries.go
+++ b/adapters/postgres/queries.go
@@ -69,7 +69,7 @@ func (adapter *Postgres) ParseScript(scriptPath string, templateData map[string]
 
 // WriteSQL perform INSERT's, UPDATE's, DELETE's operations
 func WriteSQL(sql string, values []interface{}) (sc adapters.Scanner) {
-	db, err := connection.Get()
+	db, err := connection.Get(config.PrestConf.PGDatabase)
 	if err != nil {
 		log.Println(err)
 		sc = &scanner.PrestScanner{Error: err}
@@ -117,7 +117,7 @@ func WriteSQL(sql string, values []interface{}) (sc adapters.Scanner) {
 func (adapter *Postgres) ExecuteScripts(method, sql string, values []interface{}) (sc adapters.Scanner) {
 	switch method {
 	case "GET":
-		sc = adapter.Query(sql, values...)
+		sc = adapter.Query(config.PrestConf.PGDatabase, sql, values...)
 	case "POST", "PUT", "PATCH", "DELETE":
 		sc = WriteSQL(sql, values)
 	default:

--- a/adapters/testdata/schema.sql
+++ b/adapters/testdata/schema.sql
@@ -26,7 +26,7 @@ INSERT INTO test (name) VALUES ('tester02');
 INSERT INTO test2 (name, number) VALUES ('tester02', 2);
 INSERT INTO test3 (name) VALUES ('prest');
 INSERT INTO test3 (name) VALUES ('prest tester');
-INSERT INTO test5 (name, celphone) VALUES ('prest tester', '444444');
+INSERT INTO test5 (name, celphone) VALUES ('prest tester', '444444'), ('prest tester', '444444');
 INSERT INTO test7 (name, surname) VALUES ('gopher', 'da silva');
 INSERT INTO test_readonly_access (name) VALUES ('test01');
 INSERT INTO test_write_and_delete_access (name) VALUES ('test01');

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -15,10 +15,10 @@ var authUpCmd = &cobra.Command{
 	Long:  "Create basic table to use on auth endpoint",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if config.PrestConf.Adapter == nil {
-			postgres.Load()
+			postgres.Load(config.PrestConf.PGDatabase)
 		}
 
-		db, err := postgres.Get()
+		db, err := postgres.Get(config.PrestConf.PGDatabase)
 		if err != nil {
 			fmt.Fprintf(os.Stdout, err.Error())
 			return err
@@ -38,10 +38,10 @@ var authDownCmd = &cobra.Command{
 	Long:  "Drop basic table used on auth endpoint",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if config.PrestConf.Adapter == nil {
-			postgres.Load()
+			postgres.Load(config.PrestConf.PGDatabase)
 		}
 
-		db, err := postgres.Get()
+		db, err := postgres.Get(config.PrestConf.PGDatabase)
 		if err != nil {
 			fmt.Fprintf(os.Stdout, err.Error())
 			return err

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -26,9 +26,9 @@ var migrateCmd = &cobra.Command{
 
 func checkTable(cmd *cobra.Command, args []string) error {
 	if config.PrestConf.Adapter == nil {
-		postgres.Load()
+		postgres.Load(config.PrestConf.PGDatabase)
 	}
-	sc := config.PrestConf.Adapter.ShowTable("public", "schema_migrations")
+	sc := config.PrestConf.Adapter.ShowTable(config.PrestConf.PGDatabase, "public", "schema_migrations")
 	if err := sc.Err(); err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func checkTable(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if index != nil {
-		db, err := postgres.Get()
+		db, err := postgres.Get(config.PrestConf.PGDatabase)
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ var RootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if config.PrestConf.Adapter == nil {
 			nlog.Warningln("adapter is not set. Using the default (postgres)")
-			postgres.Load()
+			postgres.Load(config.PrestConf.PGDatabase)
 		}
 		startServer()
 	},

--- a/cmd/test.http
+++ b/cmd/test.http
@@ -1,0 +1,1 @@
+GET http://localhost:3010/defaultdb/public/login_user?_page_size=10&_page=1&_renderer=json&_distinct=true

--- a/controllers/auth_test.go
+++ b/controllers/auth_test.go
@@ -12,7 +12,7 @@ import (
 
 func Test_basicPasswordCheck(t *testing.T) {
 	config.Load()
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 
 	_, err := basicPasswordCheck("test@postgres.rest", "123456")
 	if err != nil {

--- a/controllers/databases.go
+++ b/controllers/databases.go
@@ -45,7 +45,7 @@ func GetDatabases(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sqlDatabases = fmt.Sprint(sqlDatabases, " ", page)
-	sc := config.PrestConf.Adapter.Query(sqlDatabases, values...)
+	sc := config.PrestConf.Adapter.Query(config.PrestConf.PGDatabase, sqlDatabases, values...)
 	if sc.Err() != nil {
 		http.Error(w, sc.Err().Error(), http.StatusBadRequest)
 		return

--- a/controllers/databases_test.go
+++ b/controllers/databases_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetDatabases(t *testing.T) {
 	config.Load()
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 
 	var testCases = []struct {
 		description string

--- a/controllers/schemas.go
+++ b/controllers/schemas.go
@@ -45,7 +45,7 @@ func GetSchemas(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sqlSchemas = fmt.Sprint(sqlSchemas, order, " ", page)
-	sc := config.PrestConf.Adapter.Query(sqlSchemas, values...)
+	sc := config.PrestConf.Adapter.Query(config.PrestConf.PGDatabase, sqlSchemas, values...)
 	if sc.Err() != nil {
 		http.Error(w, sc.Err().Error(), http.StatusBadRequest)
 		return

--- a/controllers/schemas_test.go
+++ b/controllers/schemas_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetSchemas(t *testing.T) {
 	config.Load()
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 
 	var testCases = []struct {
 		description string

--- a/controllers/sql.go
+++ b/controllers/sql.go
@@ -10,7 +10,6 @@ import (
 
 // ExecuteScriptQuery is a function to execute and return result of script query
 func ExecuteScriptQuery(rq *http.Request, queriesPath string, script string) ([]byte, error) {
-	config.PrestConf.Adapter.SetDatabase(config.PrestConf.PGDatabase)
 	sqlPath, err := config.PrestConf.Adapter.GetScript(rq.Method, queriesPath, script)
 	if err != nil {
 		err = fmt.Errorf("could not get script %s/%s, %+v", queriesPath, script, err)

--- a/controllers/sql_test.go
+++ b/controllers/sql_test.go
@@ -106,7 +106,7 @@ func TestRenderWithXML(t *testing.T) {
 	}
 	os.Setenv("PREST_DEBUG", "true")
 	config.Load()
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 	n := middlewares.GetApp()
 	r := router.Get()
 

--- a/controllers/tables.go
+++ b/controllers/tables.go
@@ -196,7 +196,7 @@ func SelectFromTables(w http.ResponseWriter, r *http.Request) {
 		runQuery = config.PrestConf.Adapter.QueryCount
 	}
 
-	sc := runQuery(database ,sqlSelect, values...)
+	sc := runQuery(database, sqlSelect, values...)
 	if err = sc.Err(); err != nil {
 		errorMessage := sc.Err().Error()
 		if errorMessage == fmt.Sprintf(`pq: relation "%s.%s" does not exist`, schema, table) {

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -15,7 +15,7 @@ import (
 
 func init() {
 	config.Load()
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 }
 
 func TestGetTables(t *testing.T) {

--- a/docs/prest-as-web-framework/_index.en.md
+++ b/docs/prest-as-web-framework/_index.en.md
@@ -29,7 +29,7 @@ func main() {
 	config.Load()
 
 	// Load Postgres Adapter
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 
 	// Get pREST app
 	middlewares.GetApp()

--- a/docs/prest-as-web-framework/custom-middlewares/_index.en.md
+++ b/docs/prest-as-web-framework/custom-middlewares/_index.en.md
@@ -25,7 +25,7 @@ func main() {
 	config.Load()
 
 	// Load Postgres Adapter
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 
 	// Get pREST app
 	n := middlewares.GetApp()
@@ -76,7 +76,7 @@ import (
 func main() {
 	config.Load()
 	// Load Postgres Adapter
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 	// Reorder middlewares
 	middlewares.MiddlewareStack = []negroni.Handler{
 		negroni.Handler(negroni.NewRecovery()),

--- a/docs/prest-as-web-framework/custom-middlewares/disable-jwt.en.md
+++ b/docs/prest-as-web-framework/custom-middlewares/disable-jwt.en.md
@@ -46,7 +46,7 @@ func main() {
 	config.Load()
 
 	// pREST Postgres
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 
 	// pREST routes
 	r := router.Get()

--- a/middlewares/config_test.go
+++ b/middlewares/config_test.go
@@ -19,7 +19,7 @@ import (
 
 func init() {
 	config.Load()
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 }
 
 func TestInitApp(t *testing.T) {
@@ -91,7 +91,7 @@ func TestGetAppWithoutReorderedMiddleware(t *testing.T) {
 func TestMiddlewareAccessNoblockingCustomRoutes(t *testing.T) {
 	os.Setenv("PREST_DEBUG", "true")
 	config.Load()
-	postgres.Load()
+	postgres.Load(config.PrestConf.PGDatabase)
 	app = nil
 	r := router.Get()
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("custom route")) })


### PR DESCRIPTION
Addresses several issues which complain about the default database name being changed by a request. 

IMO the database name should not be a state in the adapter. There is either the default database from the config, or the database specified by the request. The adapter already has its own pool of database connection but should not be aware of a "current" database (REST is stateless).

So I have removed the `SetDatabase()` and `GetDatabase()` functions along with the state variable and adapted the code accordingly. Tests ran "so far so good" but it would help if someone could review the code and run their own test.

**Issues affected:**  

#578 querying a nonexistent db breaks requests 
#497 prest looses database context during concurrent calls

Signed-off-by: Louis Brauer <louis@openbooking.ch>
