### PR TITLE
Extended test coverage for the Postgres package.

### DIFF
--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prest/prest/adapters"
 	"github.com/prest/prest/adapters/postgres/internal/connection"
 	"github.com/prest/prest/adapters/postgres/statements"
+	"github.com/prest/prest/adapters/scanner"
 	"github.com/prest/prest/config"
 )
 
@@ -1691,4 +1692,24 @@ ORDER BY
 		})
 	}
 
+}
+
+func Test_ShowTable(t *testing.T) {
+	pg := Postgres{}
+	sc := pg.ShowTable("testschema", "testtable")
+
+	scMock := newScannerMock(t)
+
+	if !reflect.DeepEqual(sc, scMock) {
+		t.Errorf("Should return a adpter Scanner with this structure: {[] <nil> true}; but got: %v", sc)
+	}
+}
+func newScannerMock(t *testing.T) (sc adapters.Scanner) {
+	t.Helper()
+	sc = &scanner.PrestScanner{
+		Buff:    bytes.NewBuffer([]byte("[]")),
+		Error:   nil,
+		IsQuery: true,
+	}
+	return
 }

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1507,3 +1507,188 @@ func Test_containsAsterisk(t *testing.T) {
 		})
 	}
 }
+
+func Test_Postgres_GeneratesFuncs(t *testing.T) {
+
+	// TEST FOR THESE FUNCTIONS:
+	// SelectSQL
+	// InsertSQL
+	// DeleteSQL
+	// UpdateSQL
+	// DatabaseWhere
+	// DatabaseOrderBy
+	// SchemaOrderBy
+	// TableClause --> THIS FUNCTION DONT NEED A TEST AT NOW...
+	// TableWhere
+	// TableOrderBy
+	// SchemaTablesClause --> THIS FUNCTION DONT NEED A TEST AT NOW...
+	// SchemaTablesWhere
+	// SchemaTablesOrderBy
+
+	//Postgres struct MOCK
+	// will be used just to invoke the functions
+	pg := Postgres{}
+
+	// all of this tests is for functions whats returns a string. We can use two string as args of tests. The string we will got by the function, and the expected string.
+	type args struct {
+		gotByFunc string
+		expect    string
+	}
+	testCases := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "test_SelectSQL",
+			args: args{
+				gotByFunc: pg.SelectSQL("select", "database", "schema", "table"),
+				expect:    `select "database"."schema"."table"`,
+			},
+		},
+		{
+			name: "test_InsertSQL",
+			args: args{
+				gotByFunc: pg.InsertSQL("database", "schema", "table", "names", "(name1, name2)"),
+				expect:    `INSERT INTO "database"."schema"."table"(names) VALUES(name1, name2)`,
+			},
+		},
+		{
+			name: "test_DeleteSQL",
+			args: args{
+				gotByFunc: pg.DeleteSQL("database", "schema", "table"),
+				expect:    `DELETE FROM "database"."schema"."table"`,
+			},
+		},
+		{
+			name: "test_UpdateSQL",
+			args: args{
+				gotByFunc: pg.UpdateSQL("database", "schema", "table", "syntax"),
+				expect:    `UPDATE "database"."schema"."table" SET syntax`,
+			},
+		},
+		{
+			name: "test_DatabaseWhere_Empty",
+			args: args{
+				gotByFunc: pg.DatabaseWhere(""),
+				expect:    statements.DatabasesWhere,
+			},
+		},
+		{
+			name: "test_DatabaseWhere_withRequest",
+			args: args{
+				gotByFunc: pg.DatabaseWhere("testrequestwhere"),
+				expect:    fmt.Sprintf(`%v AND testrequestwhere`, statements.DatabasesWhere),
+			},
+		},
+		{
+			name: "test_DatabaseOrderBy",
+			args: args{
+				gotByFunc: pg.DatabaseOrderBy("order", true),
+				expect:    "order",
+			},
+		},
+		{
+			name: "test_DatabaseOrderBy_Empty_hasCount",
+			args: args{
+				gotByFunc: pg.DatabaseOrderBy("", true),
+				expect:    "",
+			},
+		},
+		{
+			name: "test_DatabaseOrderBy_Empty_nocount",
+			args: args{
+				gotByFunc: pg.DatabaseOrderBy("", false),
+				expect: fmt.Sprintf(`
+ORDER BY
+	%s ASC`, statements.FieldDatabaseName),
+			},
+		},
+		{
+			name: "test_SchemaOrderBy",
+			args: args{
+				gotByFunc: pg.SchemaOrderBy("order", true),
+				expect:    "order",
+			},
+		},
+		{
+			name: "test_SchemaOrderBy_Empty_hasCount",
+			args: args{
+				gotByFunc: pg.SchemaOrderBy("", true),
+				expect:    "",
+			},
+		},
+		{
+			name: "test_SchemaOrderBy_Empty_nocount",
+			args: args{
+				gotByFunc: pg.SchemaOrderBy("", false),
+				expect: fmt.Sprintf(`
+ORDER BY
+	%s ASC`, statements.FieldSchemaName),
+			},
+		},
+		{
+			name: "test_TableWhere",
+			args: args{
+				gotByFunc: pg.TableWhere("requestWhere"),
+				expect:    fmt.Sprintf(`%v AND requestWhere`, statements.TablesWhere),
+			},
+		},
+		{
+			name: "test_TableWhere_Empty",
+			args: args{
+				gotByFunc: pg.TableWhere(""),
+				expect:    statements.TablesWhere,
+			},
+		},
+		{
+			name: "test_TableOrderBy",
+			args: args{
+				gotByFunc: pg.TableOrderBy("order"),
+				expect:    "order",
+			},
+		},
+		{
+			name: "test_TableOrderBy_Empty",
+			args: args{
+				gotByFunc: pg.TableOrderBy(""),
+				expect:    statements.TablesOrderBy,
+			},
+		},
+		{
+			name: "test_SchemaTablesWhere",
+			args: args{
+				gotByFunc: pg.SchemaTablesWhere("requestWhere"),
+				expect:    fmt.Sprintf("%v AND requestWhere", statements.SchemaTablesWhere),
+			},
+		},
+		{
+			name: "test_SchemaTablesWhere_Empty",
+			args: args{
+				gotByFunc: pg.SchemaTablesWhere(""),
+				expect:    statements.SchemaTablesWhere,
+			},
+		},
+		{
+			name: "test_SchemaTablesOrderBy",
+			args: args{
+				gotByFunc: pg.SchemaTablesOrderBy("order"),
+				expect:    "order",
+			},
+		},
+		{
+			name: "test_SchemaTablesOrderBy_Empty",
+			args: args{
+				gotByFunc: pg.SchemaTablesOrderBy(""),
+				expect:    statements.SchemaTablesOrderBy,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.args.gotByFunc != tc.args.expect {
+				t.Errorf("Got: %v, Want: %v", tc.args.gotByFunc, tc.args.expect)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION


At first, I noticed that several functions had similar execution, receiving some parameters and returning a string. These functions I'm calling by Generators. Generators are the functions that the Postgres struct uses to generate strings for SQL commands.

Although they were simple, until then, there was no implementation and I identified a problem with this: in addition to the test coverage, the absence of tests in these units could result in false positives in other tests in the future, in case of modifications and implementations. In other words, it would take us much longer to identify where the problem is coming from.

I also implemented tests for the **Show table** function. As it returns a Scan interface and uses the Query function for that, I performed a test comparing the resulting interface with a Mock of it.

**Tested Functions:**

- SelectSQL
- InsertSQL
- DeleteSQL
- UpdateSQL
- DatabaseWhere
- DatabaseOrderBy
- SchemaOrderBy
- table where
- TableOrderBy
- SchemaTablesWhere
- SchemaTablesOrderBy
- Test_ShowTable