### PR TITLE
CORS documentation improvement

### DIFF
--- a/docs/configurations/_index.en.md
+++ b/docs/configurations/_index.en.md
@@ -166,3 +166,9 @@ While serving multiple databases over the same API with pREST is doable, it's by
 [pg]
     single = false
 ```
+
+## CORS support
+
+**Cross-Origin Resource Sharing**
+
+Read the specific topic where we talk about CROS [here](/cors-support/).

--- a/docs/cors-support/_index.en.md
+++ b/docs/cors-support/_index.en.md
@@ -5,11 +5,16 @@ weight: 14
 menu: main
 ---
 
-In the prest.toml you can configurate the CORS allowed origin:
+[Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) is an HTTP-header based mechanism that allows a server to indicate any origins (domain, scheme, or port) other than its own from which a browser should permit loading resources. CORS also relies on a mechanism by which browsers make a "preflight" request to the server hosting the cross-origin resource, in order to check that the server will permit the actual request. In that preflight, the browser sends headers that indicate the HTTP method and headers that will be used in the actual request.
+
+There are two settings to be made for releasing CROS (Cross-Origin Resource Sharing) in pREST, **source** and **method**.
+
+In the `prest.toml` you can configurate the CORS allowed origin.
 
 Example:
 
-```
+```toml
 [cors]
 alloworigin = ["https://prestd.com", "http://foo.com"]
+allowheaders = ["GET", "DELETE", "POST", "PUT", "PATCH", "OPTIONS"]
 ```

--- a/docs/cors-support/_index.en.md
+++ b/docs/cors-support/_index.en.md
@@ -9,7 +9,7 @@ menu: main
 
 There are two settings to be made for releasing CROS (Cross-Origin Resource Sharing) in pREST, **source** and **method**.
 
-In the `prest.toml` you can configurate the CORS allowed origin.
+In the `prest.toml` you can configure the CORS allowed origin.
 
 Example:
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/prest/prest
 go 1.15
 
 require (
-	github.com/auth0/go-jwt-middleware v1.0.2-0.20211104132826-8ea1f08a4fdf
+	github.com/auth0/go-jwt-middleware v1.0.1
 	github.com/clbanning/mxj v1.8.4
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
 	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/auth0/go-jwt-middleware v1.0.1 h1:/fsQ4vRr4zod1wKReUH+0A3ySRjGiT9G34kypO/EKwI=
 github.com/auth0/go-jwt-middleware v1.0.1/go.mod h1:YSeUX3z6+TF2H+7padiEqNJ73Zy9vXW72U//IgN0BIM=
-github.com/auth0/go-jwt-middleware v1.0.2-0.20211104132826-8ea1f08a4fdf h1:xNkl0vGZS5bNaw7pO4cBNbpB3xd3h9c6sOXxLr8noKA=
-github.com/auth0/go-jwt-middleware v1.0.2-0.20211104132826-8ea1f08a4fdf/go.mod h1:E8L/IcU1q3QsM58EBxS/NQD+boGYOXu3ny+x8v3IphM=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
fixed: #621

by default the color configuration in pREST is an empty list.

To configure CORS support you must describe the domains and the methods