### PR TITLE
WIP: adds draft structure for copilot docs

### DIFF
--- a/docs/deployment/aws-copilot.en.md
+++ b/docs/deployment/aws-copilot.en.md
@@ -1,0 +1,20 @@
+---
+title: "Run pREST using AWS Copilot"
+date: 2021-12-17T17:00:00-03:00
+type: homepage
+menu: deployment
+weight: 3
+---
+
+This guide aims to help you deploy pREST using AWS Copilot, using all
+of Copilot's features.
+
+## What is AWS Copilot
+
+## Create your infrastructure
+
+### Create your environment
+
+### AWS Copilot Manifest
+
+### Call the API

--- a/docs/deployment/deployment-guides.en.md
+++ b/docs/deployment/deployment-guides.en.md
@@ -22,4 +22,5 @@ Choose from the full list of deployment guides:
 
 - [Deploy using Docker](/deployment/docker/)
 - [Deploy using Heroku](/deployment/heroku/)
+- [Deploy using AWS Copilot](/deployment/aws-copilot)
 - Deploy using Kubernetes **soon**, but read [here](https://github.com/prest/prest/tree/main/install-manifests/kubernetes)


### PR DESCRIPTION
# What

1. Creates documentation for deployment with AWS Copilot

fixed: #640

# Why

We're using this and I think it's good to give it back.

# Caveats

DRAFT for now.