### PR TITLE
Add ECDSA/RSA-based JWT token support

### DIFF
--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -136,10 +136,10 @@ func JwtMiddleware(key string, algo string) negroni.Handler {
 		var err error
 		parsedKey, err = parsePEMKey([]byte(key))
 		if err != nil {
-			panic(fmt.Sprintf("Cannot parse public key: %s", err))
+			log.Fatalf("Cannot parse %#v key: %s", algo, err)
 		}
 	} else {
-		panic(fmt.Sprintf("Do not know how to parse key for algo %#v", algo))
+		log.Fatalf("Do not know how to parse key for %#v algorithm", algo)
 	}
 	jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
 		ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {

--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -105,6 +105,7 @@ func AccessControl() negroni.Handler {
 	})
 }
 
+// ErrNoPEMKey if jwt.key should contain PEM data, but no valid blocks were found
 var ErrNoPEMKey = errors.New("no RSA/EC/PUBLIC PEM data found")
 
 func parsePEMKey(data []byte) (key interface{}, err error) {


### PR DESCRIPTION
Implemented RSA and ECDSA type of JWT key (RS* and ES* algo) checking.
Login/generation part not included.

## Testing code

Tested using `certtool` from [GnuTLS](https://gnutls.org),  [jwt](https://github.com/golang-jwt/jwt/tree/main/cmd/jwt) and [onefile-websrv](https://github.com/korc/onefile-websrv).

###  Generation of keys
```
certtool -p --outfile rsa.key
# ECDSA keys are considerably smaller
certtool -p --outfile ecdsa.key --ecdsa
```

### Setting public keys in `prest.toml`
```
certtool --pubkey-info --load-privkey ecdsa.key
```
Copy-paste PEM data between and including BEGIN and END lines as multi-line string value for `jwt.key` using `"""` syntax in `prest.toml` like this:
```
[jwt]
algo = "ES256"
key = """
-----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiU5COUED4Jtml5qd6S48D1828jvn
NPO+ZSY6VA7tBXmaGCCFP0sIUDgYRhCu2qYj2jeq3dbpMlZvn7jDgpPzMQ==
-----END PUBLIC KEY-----
"""
```

### Generating tokens with `jwt`

```
token="$(jwt -sign + -key rsa.key -alg RS256)"
curl -H "Authorization: Bearer $token" localhost:3000/databases
```

### Generating JWT token on-fly with `onefile-websrv`

_Should go without saying that for real-world use, this server should be secured with additional configuration._

```
onefile-websrv -map "/rsa=jwt:{alg=RS256,exp=ts:+1h}file:rsa.key" -map "/ecdsa=jwt:{alg=ES256,exp=ts:+1h}file:ecdsa.key" -map "/hs=jwt:{alg=HS256,exp=ts:+1h}s3cr3t" -listen 127.0.0.1:3001
# for ECDSA keys
curl -H "Authorization: Bearer $(curl -s localhost:3001/ecdsa)" http://localhost:3000/databases
# for RSA kes
curl -H "Authorization: Bearer $(curl -s localhost:3001/rsa)" http://localhost:3000/databases
# for shared secrets
curl -H "Authorization: Bearer $(curl -s localhost:3001/hs)" http://localhost:3000/databases
```
