### PR TITLE
Change port 6000 mentions to port 3000

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,7 +29,7 @@ func TestParse(t *testing.T) {
 	cfg := &Prest{}
 	err := Parse(cfg)
 	require.NoError(t, err)
-	require.Equal(t, 6000, cfg.HTTPPort)
+	require.Equal(t, 3000, cfg.HTTPPort)
 
 	var expected string
 	expected = os.Getenv("PREST_PG_DATABASE")

--- a/docs/deployment/server-configuration.md
+++ b/docs/deployment/server-configuration.md
@@ -54,8 +54,7 @@ migrations = "./migrations"
 # enabling debug mode will disable JWT authorization
 
 [http]
-port = 6000
-# Port 6000 is blocked on windows. You must change to 8080 or any unblocked port
+port = 3000
 
 [jwt]
 key = "secret"

--- a/testdata/prest.toml
+++ b/testdata/prest.toml
@@ -5,7 +5,7 @@ password = "password"
 metadata = ["first_name", "last_name", "last_login"]
 
 [http]
-port = 6000
+port = 3000
 
 [cache]
 enabled = true


### PR DESCRIPTION
As a way to enable a better user experience (due to a fact related on #727), I've set all ports over the code to 3000, maintaining the references from the previous commits and documentation.

fixes #727 