### PR TITLE
Change JSON_AGG to JSONB_AGG, enabling better performance on the DBMS

### DIFF
--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -609,7 +609,7 @@ func (adapter *Postgres) QueryCtx(ctx context.Context, SQL string, params ...int
 		log.Errorln(err)
 		return &scanner.PrestScanner{Error: err}
 	}
-	SQL = fmt.Sprintf("SELECT json_agg(s) FROM (%s) s", SQL)
+	SQL = fmt.Sprintf("SELECT jsonb_agg(s) FROM (%s) s", SQL)
 	log.Debugln("generated SQL:", SQL, " parameters: ", params)
 	p, err := Prepare(db, SQL)
 	if err != nil {
@@ -634,7 +634,7 @@ func (adapter *Postgres) Query(SQL string, params ...interface{}) (sc adapters.S
 		log.Println(err)
 		return &scanner.PrestScanner{Error: err}
 	}
-	SQL = fmt.Sprintf("SELECT json_agg(s) FROM (%s) s", SQL)
+	SQL = fmt.Sprintf("SELECT jsonb_agg(s) FROM (%s) s", SQL)
 	log.Debugln("generated SQL:", SQL, " parameters: ", params)
 	p, err := Prepare(db, SQL)
 	if err != nil {

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1279,7 +1279,7 @@ func TestDisableCache(t *testing.T) {
 	if err := sc.Err(); err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-	_, ok := stmts.PrepareMap[`SELECT json_agg(s) FROM (SELECT * FROM "Reply") s`]
+	_, ok := stmts.PrepareMap[`SELECT jsonb_agg(s) FROM (SELECT * FROM "Reply") s`]
 	if ok {
 		t.Error("has query in cache")
 	}

--- a/controllers/schemas_test.go
+++ b/controllers/schemas_test.go
@@ -22,15 +22,15 @@ func TestGetSchemas(t *testing.T) {
 		status      int
 		body        string
 	}{
-		{"Get schemas without custom where clause", "/schemas", "GET", http.StatusOK, "[{\"schema_name\":\"information_schema\"}, \n {\"schema_name\":\"pg_catalog\"}, \n {\"schema_name\":\"pg_toast\"}, \n {\"schema_name\":\"public\"}]"},
-		{"Get schemas with custom where clause", "/schemas?schema_name=$eq.public", "GET", http.StatusOK, "[{\"schema_name\":\"public\"}]"},
-		{"Get schemas with custom order clause", "/schemas?schema_name=$eq.public&_order=schema_name", "GET", http.StatusOK, "[{\"schema_name\":\"public\"}]"},
+		{"Get schemas without custom where clause", "/schemas", "GET", http.StatusOK, "[{\"schema_name\": \"information_schema\"}, {\"schema_name\": \"pg_catalog\"}, {\"schema_name\": \"pg_toast\"}, {\"schema_name\": \"public\"}]"},
+		{"Get schemas with custom where clause", "/schemas?schema_name=$eq.public", "GET", http.StatusOK, "[{\"schema_name\": \"public\"}]"},
+		{"Get schemas with custom order clause", "/schemas?schema_name=$eq.public&_order=schema_name", "GET", http.StatusOK, "[{\"schema_name\": \"public\"}]"},
 		{"Get schemas with custom order invalid clause", "/schemas?schema_name=$eq.public&_order=$eq.schema_name", "GET", http.StatusBadRequest, "invalid identifier\n"},
-		{"Get schemas with custom where clause and pagination", "/schemas?schema_name=$eq.public&_page=1&_page_size=20", "GET", http.StatusOK, "[{\"schema_name\":\"public\"}]"},
+		{"Get schemas with custom where clause and pagination", "/schemas?schema_name=$eq.public&_page=1&_page_size=20", "GET", http.StatusOK, "[{\"schema_name\": \"public\"}]"},
 		{"Get schemas with COUNT clause", "/schemas?_count=*", "GET", http.StatusOK, "[{\"count\":4}]"},
 		{"Get schemas with custom where invalid clause", "/schemas?0schema_name=$eq.public", "GET", http.StatusBadRequest, "0schema_name: invalid identifier\n"},
 		{"Get schemas with noexistent column", "/schemas?schematame=$eq.test", "GET", http.StatusBadRequest, "pq: column \"schematame\" does not exist\n"},
-		{"Get schemas with distinct clause", "/schemas?schema_name=$eq.public&_distinct=true", "GET", http.StatusOK, "[{\"schema_name\":\"public\"}]"},
+		{"Get schemas with distinct clause", "/schemas?schema_name=$eq.public&_distinct=true", "GET", http.StatusOK, "[{\"schema_name\": \"public\"}]"},
 	}
 
 	router := mux.NewRouter()

--- a/controllers/schemas_test.go
+++ b/controllers/schemas_test.go
@@ -27,7 +27,7 @@ func TestGetSchemas(t *testing.T) {
 		{"Get schemas with custom order clause", "/schemas?schema_name=$eq.public&_order=schema_name", "GET", http.StatusOK, "[{\"schema_name\": \"public\"}]"},
 		{"Get schemas with custom order invalid clause", "/schemas?schema_name=$eq.public&_order=$eq.schema_name", "GET", http.StatusBadRequest, "invalid identifier\n"},
 		{"Get schemas with custom where clause and pagination", "/schemas?schema_name=$eq.public&_page=1&_page_size=20", "GET", http.StatusOK, "[{\"schema_name\": \"public\"}]"},
-		{"Get schemas with COUNT clause", "/schemas?_count=*", "GET", http.StatusOK, "[{\"count\":4}]"},
+		{"Get schemas with COUNT clause", "/schemas?_count=*", "GET", http.StatusOK, "[{\"count\": 4}]"},
 		{"Get schemas with custom where invalid clause", "/schemas?0schema_name=$eq.public", "GET", http.StatusBadRequest, "0schema_name: invalid identifier\n"},
 		{"Get schemas with noexistent column", "/schemas?schematame=$eq.test", "GET", http.StatusBadRequest, "pq: column \"schematame\" does not exist\n"},
 		{"Get schemas with distinct clause", "/schemas?schema_name=$eq.public&_distinct=true", "GET", http.StatusOK, "[{\"schema_name\": \"public\"}]"},

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -103,7 +103,7 @@ func TestSelectFromTables(t *testing.T) {
 		status      int
 		body        string
 	}{
-		{"execute select in a table with array", "/prest-test/public/testarray", "GET", http.StatusOK, "[{\"id\": 100, \"data\":[\"Gohan\",\"Goten\"]}]"},
+		{"execute select in a table with array", "/prest-test/public/testarray", "GET", http.StatusOK, "[{\"id\": 100, \"data\": [\"Gohan\", \"Goten\"]}]"},
 		{"execute select in a table without custom where clause", "/prest-test/public/test", "GET", http.StatusOK, ""},
 		{"execute select in a table case sentive", "/prest-test/public/Reply", "GET", http.StatusOK, "[{\"id\": 1, \"name\": \"prest tester\"}, {\"id\": 2, \"name\": \"prest-test-insert\"}, {\"id\": 3, \"name\": \"prest-test-insert-ctx\"}, {\"id\": 4, \"name\": \"3prest-test-batch-insert\"}, {\"id\": 5, \"name\": \"3batch-prest-test-insert\"}, {\"id\": 6, \"name\": \"3prest-test-batch-insert-ctx\"}, {\"id\": 7, \"name\": \"3batch-prest-test-insert-ctx\"}, {\"id\": 8, \"name\": \"copy-ctx\"}, {\"id\": 9, \"name\": \"copy-ctx\"}, {\"id\": 10, \"name\": \"copy\"}, {\"id\": 11, \"name\": \"copy\"}]"},
 		{"execute select in a table with count all fields *", "/prest-test/public/test?_count=*", "GET", http.StatusOK, ""},
@@ -123,7 +123,7 @@ func TestSelectFromTables(t *testing.T) {
 		{"execute select in a view with count all fields *", "/prest-test/public/view_test?_count=*", "GET", http.StatusOK, ""},
 		{"execute select in a view with count function", "/prest-test/public/view_test?_count=player", "GET", http.StatusOK, ""},
 		{"execute select in a view with count function check return list", "/prest-test/public/view_test?_count=player", "GET", http.StatusOK, "[{\"count\": 1}]"},
-		{"execute select in a view with count function check return object (_count_first)", "/prest-test/public/view_test?_count=player&_count_first=true", "GET", http.StatusOK, "{\"count\": 1}"},
+		{"execute select in a view with count function check return object (_count_first)", "/prest-test/public/view_test?_count=player&_count_first=true", "GET", http.StatusOK, "{\"count\":1}"},
 		{"execute select in a view with order function", "/prest-test/public/view_test?_order=-player", "GET", http.StatusOK, ""},
 		{"execute select in a view with custom where clause", "/prest-test/public/view_test?player=$eq.gopher", "GET", http.StatusOK, ""},
 		{"execute select in a view with custom join clause", "/prest-test/public/view_test?_join=inner:test2:test2.name:eq:view_test.player", "GET", http.StatusOK, ""},

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -103,9 +103,9 @@ func TestSelectFromTables(t *testing.T) {
 		status      int
 		body        string
 	}{
-		{"execute select in a table with array", "/prest-test/public/testarray", "GET", http.StatusOK, "[{\"id\": 100,\"data\":[\"Gohan\",\"Goten\"]}]"},
+		{"execute select in a table with array", "/prest-test/public/testarray", "GET", http.StatusOK, "[{\"id\": 100, \"data\":[\"Gohan\",\"Goten\"]}]"},
 		{"execute select in a table without custom where clause", "/prest-test/public/test", "GET", http.StatusOK, ""},
-		{"execute select in a table case sentive", "/prest-test/public/Reply", "GET", http.StatusOK, "[{\"id\": 1,\"name\": \"prest tester\"}, {\"id\": 2,\"name\": \"prest-test-insert\"}, {\"id\": 3,\"name\": \"prest-test-insert-ctx\"}, {\"id\": 4,\"name\": \"3prest-test-batch-insert\"}, {\"id\": 5,\"name\": \"3batch-prest-test-insert\"}, {\"id\": 6,\"name\": \"3prest-test-batch-insert-ctx\"}, {\"id\": 7,\"name\": \"3batch-prest-test-insert-ctx\"}, {\"id\": 8,\"name\": \"copy-ctx\"}, {\"id\": 9,\"name\": \"copy-ctx\"}, {\"id\": 10,\"name\": \"copy\"}, {\"id\": 11,\"name\": \"copy\"}]"},
+		{"execute select in a table case sentive", "/prest-test/public/Reply", "GET", http.StatusOK, "[{\"id\": 1, \"name\": \"prest tester\"}, {\"id\": 2, \"name\": \"prest-test-insert\"}, {\"id\": 3, \"name\": \"prest-test-insert-ctx\"}, {\"id\": 4, \"name\": \"3prest-test-batch-insert\"}, {\"id\": 5, \"name\": \"3batch-prest-test-insert\"}, {\"id\": 6, \"name\": \"3prest-test-batch-insert-ctx\"}, {\"id\": 7, \"name\": \"3batch-prest-test-insert-ctx\"}, {\"id\": 8, \"name\": \"copy-ctx\"}, {\"id\": 9, \"name\": \"copy-ctx\"}, {\"id\": 10, \"name\": \"copy\"}, {\"id\": 11, \"name\": \"copy\"}]"},
 		{"execute select in a table with count all fields *", "/prest-test/public/test?_count=*", "GET", http.StatusOK, ""},
 		{"execute select in a table with count function", "/prest-test/public/test?_count=name", "GET", http.StatusOK, ""},
 		{"execute select in a table with custom where clause", "/prest-test/public/test?name=$eq.test", "GET", http.StatusOK, ""},
@@ -117,7 +117,7 @@ func TestSelectFromTables(t *testing.T) {
 		{"execute select in a table with select * and distinct", "/prest-test/public/test5?_select=*&_distinct=true", "GET", http.StatusOK, ""},
 
 		{"execute select in a table with group by clause", "/prest-test/public/test_group_by_table?_select=age,sum:salary&_groupby=age", "GET", http.StatusOK, ""},
-		{"execute select in a table with group by and having clause", "/prest-test/public/test_group_by_table?_select=age,sum:salary&_groupby=age->>having:sum:salary:$gt:3000", "GET", http.StatusOK, "[{\"age\": 19,\"sum\": 7997}]"},
+		{"execute select in a table with group by and having clause", "/prest-test/public/test_group_by_table?_select=age,sum:salary&_groupby=age->>having:sum:salary:$gt:3000", "GET", http.StatusOK, "[{\"age\": 19, \"sum\": 7997}]"},
 
 		{"execute select in a view without custom where clause", "/prest-test/public/view_test", "GET", http.StatusOK, ""},
 		{"execute select in a view with count all fields *", "/prest-test/public/view_test?_count=*", "GET", http.StatusOK, ""},

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -103,9 +103,9 @@ func TestSelectFromTables(t *testing.T) {
 		status      int
 		body        string
 	}{
-		{"execute select in a table with array", "/prest-test/public/testarray", "GET", http.StatusOK, "[{\"id\":100,\"data\":[\"Gohan\",\"Goten\"]}]"},
+		{"execute select in a table with array", "/prest-test/public/testarray", "GET", http.StatusOK, "[{\"id\": 100,\"data\":[\"Gohan\",\"Goten\"]}]"},
 		{"execute select in a table without custom where clause", "/prest-test/public/test", "GET", http.StatusOK, ""},
-		{"execute select in a table case sentive", "/prest-test/public/Reply", "GET", http.StatusOK, "[{\"id\":1,\"name\":\"prest tester\"}, \n {\"id\":2,\"name\":\"prest-test-insert\"}, \n {\"id\":3,\"name\":\"prest-test-insert-ctx\"}, \n {\"id\":4,\"name\":\"3prest-test-batch-insert\"}, \n {\"id\":5,\"name\":\"3batch-prest-test-insert\"}, \n {\"id\":6,\"name\":\"3prest-test-batch-insert-ctx\"}, \n {\"id\":7,\"name\":\"3batch-prest-test-insert-ctx\"}, \n {\"id\":8,\"name\":\"copy-ctx\"}, \n {\"id\":9,\"name\":\"copy-ctx\"}, \n {\"id\":10,\"name\":\"copy\"}, \n {\"id\":11,\"name\":\"copy\"}]"},
+		{"execute select in a table case sentive", "/prest-test/public/Reply", "GET", http.StatusOK, "[{\"id\": 1 ,\"name\": \"prest tester\"}, {\"id\": 2 ,\"name\": \"prest-test-insert\"}, {\"id\": 3 ,\"name\": \"prest-test-insert-ctx\"}, {\"id\": 4 ,\"name\": \"3prest-test-batch-insert\"}, {\"id\": 5 ,\"name\": \"3batch-prest-test-insert\"}, {\"id\": 6 ,\"name\": \"3prest-test-batch-insert-ctx\"}, {\"id\": 7 ,\"name\": \"3batch-prest-test-insert-ctx\"}, {\"id\": 8 ,\"name\": \"copy-ctx\"}, {\"id\": 9 ,\"name\": \"copy-ctx\"}, {\"id\": 10 ,\"name\": \"copy\"}, {\"id\": 11 ,\"name\": \"copy\"}]"},
 		{"execute select in a table with count all fields *", "/prest-test/public/test?_count=*", "GET", http.StatusOK, ""},
 		{"execute select in a table with count function", "/prest-test/public/test?_count=name", "GET", http.StatusOK, ""},
 		{"execute select in a table with custom where clause", "/prest-test/public/test?name=$eq.test", "GET", http.StatusOK, ""},

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -105,7 +105,7 @@ func TestSelectFromTables(t *testing.T) {
 	}{
 		{"execute select in a table with array", "/prest-test/public/testarray", "GET", http.StatusOK, "[{\"id\": 100,\"data\":[\"Gohan\",\"Goten\"]}]"},
 		{"execute select in a table without custom where clause", "/prest-test/public/test", "GET", http.StatusOK, ""},
-		{"execute select in a table case sentive", "/prest-test/public/Reply", "GET", http.StatusOK, "[{\"id\": 1 ,\"name\": \"prest tester\"}, {\"id\": 2 ,\"name\": \"prest-test-insert\"}, {\"id\": 3 ,\"name\": \"prest-test-insert-ctx\"}, {\"id\": 4 ,\"name\": \"3prest-test-batch-insert\"}, {\"id\": 5 ,\"name\": \"3batch-prest-test-insert\"}, {\"id\": 6 ,\"name\": \"3prest-test-batch-insert-ctx\"}, {\"id\": 7 ,\"name\": \"3batch-prest-test-insert-ctx\"}, {\"id\": 8 ,\"name\": \"copy-ctx\"}, {\"id\": 9 ,\"name\": \"copy-ctx\"}, {\"id\": 10 ,\"name\": \"copy\"}, {\"id\": 11 ,\"name\": \"copy\"}]"},
+		{"execute select in a table case sentive", "/prest-test/public/Reply", "GET", http.StatusOK, "[{\"id\": 1,\"name\": \"prest tester\"}, {\"id\": 2,\"name\": \"prest-test-insert\"}, {\"id\": 3,\"name\": \"prest-test-insert-ctx\"}, {\"id\": 4,\"name\": \"3prest-test-batch-insert\"}, {\"id\": 5,\"name\": \"3batch-prest-test-insert\"}, {\"id\": 6,\"name\": \"3prest-test-batch-insert-ctx\"}, {\"id\": 7,\"name\": \"3batch-prest-test-insert-ctx\"}, {\"id\": 8,\"name\": \"copy-ctx\"}, {\"id\": 9,\"name\": \"copy-ctx\"}, {\"id\": 10,\"name\": \"copy\"}, {\"id\": 11,\"name\": \"copy\"}]"},
 		{"execute select in a table with count all fields *", "/prest-test/public/test?_count=*", "GET", http.StatusOK, ""},
 		{"execute select in a table with count function", "/prest-test/public/test?_count=name", "GET", http.StatusOK, ""},
 		{"execute select in a table with custom where clause", "/prest-test/public/test?name=$eq.test", "GET", http.StatusOK, ""},
@@ -117,13 +117,13 @@ func TestSelectFromTables(t *testing.T) {
 		{"execute select in a table with select * and distinct", "/prest-test/public/test5?_select=*&_distinct=true", "GET", http.StatusOK, ""},
 
 		{"execute select in a table with group by clause", "/prest-test/public/test_group_by_table?_select=age,sum:salary&_groupby=age", "GET", http.StatusOK, ""},
-		{"execute select in a table with group by and having clause", "/prest-test/public/test_group_by_table?_select=age,sum:salary&_groupby=age->>having:sum:salary:$gt:3000", "GET", http.StatusOK, "[{\"age\":19,\"sum\":7997}]"},
+		{"execute select in a table with group by and having clause", "/prest-test/public/test_group_by_table?_select=age,sum:salary&_groupby=age->>having:sum:salary:$gt:3000", "GET", http.StatusOK, "[{\"age\": 19,\"sum\": 7997}]"},
 
 		{"execute select in a view without custom where clause", "/prest-test/public/view_test", "GET", http.StatusOK, ""},
 		{"execute select in a view with count all fields *", "/prest-test/public/view_test?_count=*", "GET", http.StatusOK, ""},
 		{"execute select in a view with count function", "/prest-test/public/view_test?_count=player", "GET", http.StatusOK, ""},
-		{"execute select in a view with count function check return list", "/prest-test/public/view_test?_count=player", "GET", http.StatusOK, "[{\"count\":1}]"},
-		{"execute select in a view with count function check return object (_count_first)", "/prest-test/public/view_test?_count=player&_count_first=true", "GET", http.StatusOK, "{\"count\":1}"},
+		{"execute select in a view with count function check return list", "/prest-test/public/view_test?_count=player", "GET", http.StatusOK, "[{\"count\": 1}]"},
+		{"execute select in a view with count function check return object (_count_first)", "/prest-test/public/view_test?_count=player&_count_first=true", "GET", http.StatusOK, "{\"count\": 1}"},
 		{"execute select in a view with order function", "/prest-test/public/view_test?_order=-player", "GET", http.StatusOK, ""},
 		{"execute select in a view with custom where clause", "/prest-test/public/view_test?player=$eq.gopher", "GET", http.StatusOK, ""},
 		{"execute select in a view with custom join clause", "/prest-test/public/view_test?_join=inner:test2:test2.name:eq:view_test.player", "GET", http.StatusOK, ""},

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -50,7 +50,7 @@ func DoRequest(t *testing.T, url string, r interface{}, method string, expectedS
 
 	if len(expectedBody) > 0 {
 		assert.True(t, containsStringInSlice(expectedBody, string(body)),
-			fmt.Sprintf("expected %q, got: %q", expectedBody, string(body)))
+			fmt.Sprintf("expected %q, got: %q", expectedBody[0], string(body)))
 	}
 }
 


### PR DESCRIPTION
This change enables us to perform better on our aggregation and API response time, without changing the whole serializing code. 

If this PR gets merged, we can work on the future on a new serializer.

fixed: #730 