### PR TITLE
Fixes chkInvalidIdentifier for table and column names

### DIFF
--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -156,9 +156,18 @@ func PrepareTx(tx *sql.Tx, SQL string) (stmt *sql.Stmt, err error) {
 // chkInvalidIdentifier return true if identifier is invalid
 func chkInvalidIdentifier(identifer ...string) bool {
 	for _, ival := range identifer {
-		if ival == "" || len(ival) > 63 || unicode.IsDigit([]rune(ival)[0]) {
+		if ival == "" || unicode.IsDigit([]rune(ival)[0]) {
 			return true
 		}
+
+		if ival_split := strings.Split(ival, "."); len(ival_split) == 2 && len(ival_split[len(ival_split) - 1]) > 63 {
+			return true
+		}
+
+		if contains_dot := strings.Contains(ival, "."); contains_dot == false && len(ival) > 63 {
+			return true
+		}
+		
 		count := 0
 		for _, v := range ival {
 			if !unicode.IsLetter(v) &&

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -160,11 +160,13 @@ func chkInvalidIdentifier(identifer ...string) bool {
 			return true
 		}
 
-		if ival_split := strings.Split(ival, "."); len(ival_split) == 2 && len(ival_split[len(ival_split) - 1]) > 63 {
+		ivalSplit := strings.Split(ival, ".")
+		if len(ivalSplit) == 2 && len(ivalSplit[len(ivalSplit) - 1]) > 63 {
 			return true
 		}
 
-		if contains_dot := strings.Contains(ival, "."); contains_dot == false && len(ival) > 63 {
+		containsDot := strings.Contains(ival, ".")
+		if containsDot == false && len(ival) > 63 {
 			return true
 		}
 		

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -165,8 +165,8 @@ func chkInvalidIdentifier(identifer ...string) bool {
 			return true
 		}
 
-		containsDot := strings.Contains(ival, ".")
-		if containsDot == false && len(ival) > 63 {
+		hasDot := strings.Contains(ival, ".")
+		if !hasDot && len(ival) > 63 {
 			return true
 		}
 		

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -165,8 +165,7 @@ func chkInvalidIdentifier(identifer ...string) bool {
 			return true
 		}
 
-		hasDot := strings.Contains(ival, ".")
-		if !hasDot && len(ival) > 63 {
+		if !strings.Contains(ival, ".") && len(ival) > 63 {
 			return true
 		}
 		

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -705,6 +705,7 @@ func TestChkInvaidIdentifier(t *testing.T) {
 		{`SUM("test")`, false},
 		{"_123456789_123456789_123456789_123456789_123456789_123456789_12345", true},
 		{"not_invalid_table.with_not_invalid_column", false},
+		{"not_long_enough_invalid_table_with_lots_of_chars.with_not_invalid_column", false},
 		{"the_most_invalid_table_ever_seen_on_life_and_on_earth_at_least_today.the_most_invalid_column_ever_seen_on_life_and_on_earth_at_least_today", true},
 	}
 

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -707,6 +707,8 @@ func TestChkInvaidIdentifier(t *testing.T) {
 		{"not_invalid_table.with_not_invalid_column", false},
 		{"not_long_enough_invalid_table_with_lots_of_chars.with_not_invalid_column", false},
 		{"the_most_invalid_table_ever_seen_on_life_and_on_earth_at_least_today.the_most_invalid_column_ever_seen_on_life_and_on_earth_at_least_today", true},
+		{`SUM("the_most_invalid_table_ever_seen_on_life_and_on_earth_at_least_today.the_most_invalid_column_ever_seen_on_life_and_on_earth_at_least_today")`, true},
+		{`SUM("not_long_enough_invalid_table_with_lots_of_chars.with_not_invalid_column")`, false},
 	}
 
 	for _, tc := range testCases {

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -704,6 +704,8 @@ func TestChkInvaidIdentifier(t *testing.T) {
 		{"SUM(test)", false},
 		{`SUM("test")`, false},
 		{"_123456789_123456789_123456789_123456789_123456789_123456789_12345", true},
+		{"not_invalid_table.with_not_invalid_column", false},
+		{"the_most_invalid_table_ever_seen_on_life_and_on_earth_at_least_today.the_most_invalid_column_ever_seen_on_life_and_on_earth_at_least_today", true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR solves issue #718, as the problem is caused by our `chkInvalidIdentifier` function. The bug is caused because of the evaluation method of the string.

We search for the length of the whole string, but when we are doing JOINs or other operations regarding other tables, we generally use `tablename.columnname`. On the bug identified on this issue, we are able to see a table and column name combination passing 63 characters, but if we consider just the column name, it would be fine, because it's only 34 characters long.

In the future, we must add a custom option for validating the length of the column as determined by `max_identifier_length `.