### PR TITLE
Adds new support for JSONB Objects and Lists

### DIFF
--- a/adapters/postgres/errors.go
+++ b/adapters/postgres/errors.go
@@ -11,5 +11,6 @@ var (
 	ErrInvalidOperator         = errors.New("invalid operator")
 	ErrInvalidGroupFn          = errors.New("invalid group function")
 	// ErrBodyEmpty err throw when body is empty
-	ErrBodyEmpty = errors.New("body is empty")
+	ErrBodyEmpty               = errors.New("body is empty")
+	ErrEmptyOrInvalidSlice     = errors.New("empty or invalid slice")
 )

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -305,8 +305,13 @@ func (adapter *Postgres) ReturningByRequest(r *http.Request) (returningSyntax st
 	return
 }
 
-func sliceToJSONList(ifaceSlice interface{}) (returnValue string) {
+func sliceToJSONList(ifaceSlice interface{}) (returnValue string, err error) {
     v := reflect.ValueOf(ifaceSlice)
+
+	if v.Kind() == 0 {
+		return "[]", ErrEmptyOrInvalidSlice
+	}
+
 	value := make([]string, 0)
 	
     for i := 0; i < v.Len(); i++ {
@@ -356,7 +361,11 @@ func (adapter *Postgres) SetByRequest(r *http.Request, initialPlaceholderID int)
 				}
 				values = append(values, string(jsonData))
 			case reflect.Slice:
-				values = append(values, sliceToJSONList(value))
+				value, err = sliceToJSONList(value)
+				if err != nil {
+					log.Errorln(err)
+				}
+				values = append(values, value)
 			default:
 				values = append(values, value)
 		}

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -336,7 +336,6 @@ func (adapter *Postgres) SetByRequest(r *http.Request, initialPlaceholderID int)
 		err = ErrBodyEmpty
 		return
 	}
-
 	fields := make([]string, 0)
 	for key, value := range body {
 		if chkInvalidIdentifier(key) {
@@ -351,11 +350,13 @@ func (adapter *Postgres) SetByRequest(r *http.Request, initialPlaceholderID int)
 			case reflect.Interface:
 				values = append(values, formatters.FormatArray(value))
 			case reflect.Map:
-				value, err = json.Marshal(value)
-				if err != nil {
-					fmt.Println(err.Error())
+				b := new(bytes.Buffer)
+				enc := json.NewEncoder(b)
+
+				if err := enc.Encode(value); err != nil {
+					log.Fatal(err)
 				}
-				values = append(values, fmt.Sprint(value))
+				values = append(values, fmt.Sprint(b))
 			case reflect.Slice:
 				values = append(values, sliceToJSONList(value))
 			default:

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -316,11 +316,11 @@ func sliceToJSONList(ifaceSlice interface{}) (returnValue string) {
 				newVal := fmt.Sprint(val)
 				value = append(value, newVal)
 			default:
-				newVal := fmt.Sprintf(`'%s'`, val)
+				newVal := fmt.Sprintf(`"%s"`, val)
 				value = append(value, newVal)
 		}
     }
-	returnValue = fmt.Sprintf(`"[%v]"`, strings.Join(value, ", "))
+	returnValue = fmt.Sprintf(`[%v]`, strings.Join(value, ", "))
 	return
 }
 

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -350,13 +350,11 @@ func (adapter *Postgres) SetByRequest(r *http.Request, initialPlaceholderID int)
 			case reflect.Interface:
 				values = append(values, formatters.FormatArray(value))
 			case reflect.Map:
-				b := new(bytes.Buffer)
-				enc := json.NewEncoder(b)
-
-				if err := enc.Encode(value); err != nil {
-					log.Fatal(err)
+				jsonData, err := json.Marshal(value)
+				if err != nil {
+					log.Errorln(err)
 				}
-				values = append(values, fmt.Sprint(b))
+				values = append(values, string(jsonData))
 			case reflect.Slice:
 				values = append(values, sliceToJSONList(value))
 			default:

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -1978,3 +1978,31 @@ func newScannerMock(t *testing.T) (sc adapters.Scanner) {
 	}
 	return
 }
+
+func TestSliceToJSONList(t *testing.T) {
+	var i interface{}
+	var testCases = []struct {
+		description    string
+		body           interface{}
+		expectedValue  string
+		err            error
+	}{
+		{"String slice", []string{"one","two","three"}, `["one", "two", "three"]`, nil},
+		{"Integer slice", []int{1,2,3}, `[1, 2, 3]`, nil},
+		{"Interface error", i, `[]`, ErrEmptyOrInvalidSlice},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+
+		value, err := sliceToJSONList(tc.body)
+
+		if !strings.Contains(tc.expectedValue, value) {
+			t.Errorf("expected %s in %s", value, tc.expectedValue)
+		}
+
+		if err != tc.err {
+			t.Errorf("expected %s in %s", err, tc.err)
+		}
+	}
+}

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -114,6 +114,12 @@ func TestSetByRequest(t *testing.T) {
 	mc["dbname"] = "prest"
 	ma := make(map[string]interface{})
 	ma["c.name"] = "prest"
+	mjl := make(map[string]interface{})
+	mjl["prest"] = []string{"prest", "is", "awesome"}
+	mjo := make(map[string]interface{})
+	mjo["prest"] = "is marvelous"
+	mjoJson, _ := json.Marshal(mjo)
+	mjoStr := string(mjoJson)
 
 	var testCases = []struct {
 		description    string
@@ -124,6 +130,8 @@ func TestSetByRequest(t *testing.T) {
 	}{
 		{"set by request more than one field", mc, []string{`"dbname"=$`, `"test"=$`, ", "}, []string{"prest", "prest"}, nil},
 		{"set by request one field", m, []string{`"name"=$`}, []string{"prest"}, nil},
+		{"set by request one JSONB List field", mjl, []string{`"prest"=$`}, []string{`["prest", "is", "awesome"]`}, nil},
+		{"set by request one JSONB Object field", mjo, []string{`"prest"=$`}, []string{mjoStr}, nil},
 		{"set by request alias", ma, []string{`"c".`, `"name"=$`}, []string{"prest"}, nil},
 		{"set by request empty body", nil, nil, nil, ErrBodyEmpty},
 	}


### PR DESCRIPTION
As reported on issue #692, there was a bug in our software when we were trying to update JSONB objects on the database. This PR intends to solve this bug, creating a switch-case structure to check what type of object we are receiving and what it should return. 