### PR TITLE
Adds Exposure Setting for sensitive endpoints on TOML

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,7 @@ type AccessConf struct {
 	Tables      []TablesConf
 }
 
-// ExposeConf (expose data) informations
+// ExposeConf (expose data) information
 type ExposeConf struct {
 	Enabled         bool
 	DatabaseListing bool

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,14 @@ type AccessConf struct {
 	Tables      []TablesConf
 }
 
+// ExposeConf (expose data) informations
+type ExposeConf struct {
+	Enabled         bool
+	DatabaseListing bool
+	SchemaListing   bool
+	TableListing    bool
+}
+
 // Prest basic config
 type Prest struct {
 	AuthEnabled          bool
@@ -91,6 +99,7 @@ type Prest struct {
 	HTTPSKey             string
 	Cache                Cache
 	PluginPath           string
+	ExposeConf           ExposeConf
 }
 
 var (
@@ -142,6 +151,10 @@ func viperCfg() {
 	viper.SetDefault("https.mode", false)
 	viper.SetDefault("https.cert", "/etc/certs/cert.crt")
 	viper.SetDefault("https.key", "/etc/certs/cert.key")
+	viper.SetDefault("expose.enabled", false)
+	viper.SetDefault("expose.tables", true)
+	viper.SetDefault("expose.schemas", true)
+	viper.SetDefault("expose.databases", true)
 	viper.SetDefault("cache.enabled", false)
 	viper.SetDefault("cache.time", 10)
 	viper.SetDefault("cache.storagepath", "./")
@@ -231,6 +244,10 @@ func Parse(cfg *Prest) (err error) {
 	cfg.Cache.Time = viper.GetInt("cache.time")
 	cfg.Cache.StoragePath = viper.GetString("cache.storagepath")
 	cfg.Cache.SufixFile = viper.GetString("cache.sufixfile")
+	cfg.ExposeConf.Enabled = viper.GetBool("expose.enabled")
+	cfg.ExposeConf.TableListing = viper.GetBool("expose.tables")
+	cfg.ExposeConf.SchemaListing = viper.GetBool("expose.schemas")
+	cfg.ExposeConf.DatabaseListing = viper.GetBool("expose.databases")
 	var cacheendpoints []CacheEndpoint
 	err = viper.UnmarshalKey("cache.endpoints", &cacheendpoints)
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -223,3 +223,23 @@ func Test_Auth(t *testing.T) {
 		require.Equal(t, metadata[i], v)
 	}
 }
+
+func Test_ExposeDataConfig(t *testing.T) {
+	os.Setenv("PREST_CONF", "../testdata/prest_expose.toml")
+
+	viperCfg()
+	cfg := &Prest{}
+	err := Parse(cfg)
+	require.NoError(t, err)
+	require.Equal(t, true, cfg.ExposeConf.Enabled)
+	require.Equal(t, true, cfg.ExposeConf.DatabaseListing)
+	require.Equal(t, true, cfg.ExposeConf.SchemaListing)
+	require.Equal(t, true, cfg.ExposeConf.TableListing)
+
+	metadata := []string{"first_name", "last_name", "last_login"}
+	require.Equal(t, len(metadata), len(cfg.AuthMetadata))
+
+	for i, v := range cfg.AuthMetadata {
+		require.Equal(t, metadata[i], v)
+	}
+}

--- a/controllers/sql.go
+++ b/controllers/sql.go
@@ -20,23 +20,19 @@ func ExecuteScriptQuery(rq *http.Request, queriesPath string, script string) ([]
 		err = fmt.Errorf("could not get script %s/%s, %v", queriesPath, script, err)
 		return nil, err
 	}
-
 	templateData := make(map[string]interface{})
 	extractHeaders(rq, templateData)
 	extractQueryParameters(rq, templateData)
-
 	sql, values, err := config.PrestConf.Adapter.ParseScript(sqlPath, templateData)
 	if err != nil {
 		err = fmt.Errorf("could not parse script %s/%s, %v", queriesPath, script, err)
 		return nil, err
 	}
-
 	sc := config.PrestConf.Adapter.ExecuteScriptsCtx(rq.Context(), rq.Method, sql, values)
 	if sc.Err() != nil {
 		err = fmt.Errorf("could not execute sql %v, %s", sc.Err(), sql)
 		return nil, err
 	}
-
 	return sc.Bytes(), nil
 }
 

--- a/controllers/sql_test.go
+++ b/controllers/sql_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestExecuteScriptQuery(t *testing.T) {
+	config.Load()
+	config.PrestConf.Adapter = &postgres.Postgres{}
 	r := mux.NewRouter()
 	r.HandleFunc("/testing/script-get/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp, err := ExecuteScriptQuery(r, "fulltable", "get_all")

--- a/controllers/tables_expose_test.go
+++ b/controllers/tables_expose_test.go
@@ -1,0 +1,55 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/prest/prest/adapters/postgres"
+	"github.com/prest/prest/config"
+	"github.com/prest/prest/middlewares"
+	"github.com/prest/prest/testutils"
+)
+
+func init() {
+	fmt.Println("AQUI COMECA")
+	os.Setenv("PREST_DEBUG", "true")
+	os.Setenv("PREST_CONF", "../testdata/prest_expose.toml")
+	os.Setenv("PREST_JWT_DEFAULT", "false")
+	config.Load()
+	postgres.Load()
+	config.PrestConf.Adapter = &postgres.Postgres{}
+}
+
+func TestGetTablesWithEnabledExposeMiddleware(t *testing.T) {
+	config.Load()
+	postgres.Load()
+	config.PrestConf.Adapter = &postgres.Postgres{}
+	config.PrestConf.ExposeConf.Enabled = true
+	config.PrestConf.ExposeConf.TableListing = true
+	router := mux.NewRouter()
+	router.HandleFunc("/{database}/{schema}/tables", GetTables).Methods("GET")
+	n := middlewares.GetApp()
+	n.UseHandler(router)
+	server := httptest.NewServer(n)
+	defer server.Close()
+	// n := middlewares.GetApp()
+	// router := mux.NewRouter()
+	// router.HandleFunc("/{database}/{schema}/tables", GetTables).Methods("GET").Name("tables")
+	// n.UseHandler(router)
+	// server := httptest.NewServer(n)
+	// defer server.Close()
+
+	// url, _ := router.Get("tables").URL("database", "prest-test", "schema", "public")
+
+	// if err != nil {
+	// 	fmt.Println(err)
+	// }
+
+	// fmt.Printf("url: %v", url)
+
+	testutils.DoRequest(t, server.URL+"/prest-test/public/tables", nil, "GET", 401, "GetTables")
+	// fmt.Println("AQUI TERMINA")
+}

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prest/prest/adapters/postgres"
 	"github.com/prest/prest/config"
 	pctx "github.com/prest/prest/context"
-	"github.com/prest/prest/middlewares"
 	"github.com/prest/prest/testutils"
 )
 
@@ -88,22 +87,6 @@ func TestGetTablesByDatabaseAndSchema(t *testing.T) {
 		t.Log(tc.description)
 		testutils.DoRequest(t, server.URL+tc.url, nil, tc.method, tc.status, "GetTablesByDatabaseAndSchema")
 	}
-}
-
-func TestGetTablesWithEnabledExposeMiddleware(t *testing.T) {
-	config.Load()
-	postgres.Load()
-	config.PrestConf.Adapter = &postgres.Postgres{}
-	config.PrestConf.ExposeConf.Enabled = true
-	config.PrestConf.ExposeConf.TableListing = true
-	router := mux.NewRouter()
-	router.HandleFunc("/{database}/{schema}/tables", GetTables).Methods("GET")
-	n := middlewares.GetApp()
-	n.UseHandler(router)
-	server := httptest.NewServer(n)
-	defer server.Close()
-
-	testutils.DoRequest(t, server.URL+"/random/public/tables", nil, "GET", 401, "GetDatabases")
 }
 
 func TestSelectFromTables(t *testing.T) {

--- a/docs/deployment/server-configuration.md
+++ b/docs/deployment/server-configuration.md
@@ -83,6 +83,12 @@ mode = "disable"
 sslcert = "./PATH"
 sslkey = "./PATH"
 sslrootcert = "./PATH"
+
+[expose]
+enabled = true
+databases = true
+schemas = true
+tables = true
 ```
 
 ## Authorization
@@ -144,6 +150,40 @@ password = "password"
 | password | Password **field** that will be consulted |
 
 > to validate all endpoints with generated jwt token must be activated jwt option
+
+## Expose Data
+
+The expose data setting enables you to configure if you want users to be able to reach listing endpoints, such as:
+
+ - /databases
+ - /{database}/schemas
+ - /{database}/{schema}/tables
+
+
+An example of a configuration file disabling all listings:
+
+```toml
+# previous toml content
+
+[expose]
+    enabled = true
+```
+
+If you want to disable just the database listing:
+
+```toml
+# previous toml content
+
+[expose]
+    databases = true
+```
+
+| Name | Description |
+| --- | --- |
+| enabled | Set this as `true` if you want to **disable** all listing endpoints available. |
+| databases | Set this as `true` if you want to **disable** *databases* listing endpoints only. |
+| schemas | Set this as `true` if you want to **disable** *schemas* listing endpoints only. |
+| tables | Set this as `true` if you want to **disable** *tables* listing endpoints only. |
 
 ## SSL
 

--- a/middlewares/config.go
+++ b/middlewares/config.go
@@ -42,6 +42,9 @@ func initApp() {
 		if config.PrestConf.Cache.Enabled {
 			MiddlewareStack = append(MiddlewareStack, CacheMiddleware())
 		}
+		if config.PrestConf.ExposeConf.Enabled {
+			MiddlewareStack = append(MiddlewareStack, ExposureMiddleware())
+		}
 	}
 	app = negroni.New(MiddlewareStack...)
 }

--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -105,6 +105,34 @@ func AccessControl() negroni.Handler {
 	})
 }
 
+func ExposureMiddleware() negroni.Handler {
+	return negroni.HandlerFunc(func(rw http.ResponseWriter, rq *http.Request, next http.HandlerFunc) {
+		fmt.Println()
+		url := rq.URL.String()
+		exposeConf := config.PrestConf.ExposeConf
+
+		if strings.Contains(url, "/databases") && !exposeConf.DatabaseListing {
+			err := fmt.Errorf("unauthorized listing")
+			http.Error(rw, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		if strings.Contains(url, "/tables") && !exposeConf.TableListing {
+			err := fmt.Errorf("unauthorized listing")
+			http.Error(rw, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		if strings.Contains(url, "/schemas") && !exposeConf.SchemaListing {
+			err := fmt.Errorf("unauthorized listing")
+			http.Error(rw, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		next(rw, rq)
+	})
+}
+
 // JwtMiddleware check if actual request have JWT
 func JwtMiddleware(key string, algo string) negroni.Handler {
 	return negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {

--- a/router/router.go
+++ b/router/router.go
@@ -51,6 +51,7 @@ func GetRouter() *mux.Router {
 	crudRoutes.HandleFunc("/{database}/{schema}/{table}", controllers.DeleteFromTable).Methods("DELETE")
 	crudRoutes.HandleFunc("/{database}/{schema}/{table}", controllers.UpdateTable).Methods("PUT", "PATCH")
 	router.PathPrefix("/").Handler(negroni.New(
+		middlewares.ExposureMiddleware(),
 		middlewares.AccessControl(),
 		middlewares.AuthMiddleware(),
 		middlewares.CacheMiddleware(),

--- a/testdata/prest_expose.toml
+++ b/testdata/prest_expose.toml
@@ -1,85 +1,8 @@
-[auth]
-table = "prest_users"
-username = "username"
-password = "password"
-metadata = ["first_name", "last_name", "last_login"]
+[jwt]
+default = false
 
 [http]
 port = 3000
-
-[cache]
-enabled = true
-
-    [[cache.endpoints]]
-    endpoint = "/prest/public/test"
-    time = 5
-
-[access]
-restrict = true  # can access only the tables listed below
-
-    [[access.tables]]
-    name = "Reply"
-    permissions = ["read", "write", "delete"]
-    fields = ["id", "name"]
-
-    [[access.tables]]
-    name = "test"
-    permissions = ["read", "write", "delete"]
-    fields = ["id", "name"]
-
-    [[access.tables]]
-    name = "testarray"
-    permissions = ["read", "write", "delete"]
-    fields = ["id", "data"]
-
-    [[access.tables]]
-    name = "test2"
-    permissions = ["read", "write", "delete"]
-    fields = ["id", "name"]
-
-    [[access.tables]]
-    name = "test3"
-    permissions = ["read", "write", "delete"]
-    fields = ["id", "name"]
-
-    [[access.tables]]
-    name = "test4"
-    permissions = ["read", "write", "delete"]
-    fields = ["id", "name"]
-
-    [[access.tables]]
-    name = "test5"
-    permissions = ["read", "write", "delete"]
-    fields = ["*"]
-
-    [[access.tables]]
-    name = "test_readonly_access"
-    permissions = ["read"]
-    fields = ["id", "name"]
-
-    [[access.tables]]
-    name = "test_write_and_delete_access"
-    permissions = ["write", "delete"]
-
-    [[access.tables]]
-    name = "test_list_only_id"
-    permissions = ["read"]
-    fields = ["id"]
-
-    [[access.tables]]
-    name = "test6"
-    permissions = ["read", "write", "delete"]
-    fields = ["nuveo", "name"]
-
-    [[access.tables]]
-    name = "view_test"
-    permissions = ["read"]
-    fields = ["player"]
-
-    [[access.tables]]
-    name = "test_group_by_table"
-    permissions = ["read"]
-    fields = ["id", "name", "age", "salary"]
 
 [expose]
 enabled = true

--- a/testdata/prest_expose.toml
+++ b/testdata/prest_expose.toml
@@ -80,3 +80,9 @@ restrict = true  # can access only the tables listed below
     name = "test_group_by_table"
     permissions = ["read"]
     fields = ["id", "name", "age", "salary"]
+
+[expose]
+enabled = true
+databases = true
+schemas = true
+tables = true


### PR DESCRIPTION
In this PR we are setting some variables that enable users to disable certain endpoints for security reasons, enabling less infrastructure team/firewall necessity.

The settings will be put on `prest.toml` as shown below:

```toml
[sensitive]
disableall = false
databases = false
schemas = false
```

fixed: #741