### PR TITLE
Adds new Exposure Middleware - creating the protection for /databases, /tables, and /schemas endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,14 @@ type AccessConf struct {
 	Tables      []TablesConf
 }
 
+// ExposeConf (expose data) information
+type ExposeConf struct {
+	Enabled         bool
+	DatabaseListing bool
+	SchemaListing   bool
+	TableListing    bool
+}
+
 // Prest basic config
 type Prest struct {
 	AuthEnabled          bool
@@ -78,6 +86,7 @@ type Prest struct {
 	MigrationsPath       string
 	QueriesPath          string
 	AccessConf           AccessConf
+	ExposeConf           ExposeConf
 	CORSAllowOrigin      []string
 	CORSAllowHeaders     []string
 	CORSAllowMethods     []string
@@ -147,6 +156,10 @@ func viperCfg() {
 	viper.SetDefault("cache.storagepath", "./")
 	viper.SetDefault("cache.sufixfile", ".cache.prestd.db")
 	viper.SetDefault("pluginpath", "./lib")
+	viper.SetDefault("expose.enabled", false)
+	viper.SetDefault("expose.tables", true)
+	viper.SetDefault("expose.schemas", true)
+	viper.SetDefault("expose.databases", true)
 
 	hDir, err := homedir.Dir()
 	if err != nil {
@@ -231,6 +244,10 @@ func Parse(cfg *Prest) (err error) {
 	cfg.Cache.Time = viper.GetInt("cache.time")
 	cfg.Cache.StoragePath = viper.GetString("cache.storagepath")
 	cfg.Cache.SufixFile = viper.GetString("cache.sufixfile")
+	cfg.ExposeConf.Enabled = viper.GetBool("expose.enabled")
+	cfg.ExposeConf.TableListing = viper.GetBool("expose.tables")
+	cfg.ExposeConf.SchemaListing = viper.GetBool("expose.schemas")
+	cfg.ExposeConf.DatabaseListing = viper.GetBool("expose.databases")
 	var cacheendpoints []CacheEndpoint
 	err = viper.UnmarshalKey("cache.endpoints", &cacheendpoints)
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -223,3 +223,23 @@ func Test_Auth(t *testing.T) {
 		require.Equal(t, metadata[i], v)
 	}
 }
+
+func Test_ExposeDataConfig(t *testing.T) {
+	os.Setenv("PREST_CONF", "../testdata/prest_expose.toml")
+
+	viperCfg()
+	cfg := &Prest{}
+	err := Parse(cfg)
+	require.NoError(t, err)
+	require.Equal(t, true, cfg.ExposeConf.Enabled)
+	require.Equal(t, false, cfg.ExposeConf.DatabaseListing)
+	require.Equal(t, false, cfg.ExposeConf.SchemaListing)
+	require.Equal(t, false, cfg.ExposeConf.TableListing)
+
+	metadata := []string{"first_name", "last_name", "last_login"}
+	require.Equal(t, len(metadata), len(cfg.AuthMetadata))
+
+	for i, v := range cfg.AuthMetadata {
+		require.Equal(t, metadata[i], v)
+	}
+}

--- a/docs/deployment/server-configuration.md
+++ b/docs/deployment/server-configuration.md
@@ -83,6 +83,12 @@ mode = "disable"
 sslcert = "./PATH"
 sslkey = "./PATH"
 sslrootcert = "./PATH"
+
+[expose]
+enabled = true
+databases = true
+schemas = true
+tables = true
 ```
 
 ## Authorization
@@ -144,6 +150,38 @@ password = "password"
 | password | Password **field** that will be consulted |
 
 > to validate all endpoints with generated jwt token must be activated jwt option
+
+## Expose Data
+
+The expose data setting enables you to configure if you want users to be able to reach listing endpoints, such as:
+
+ - /databases
+ - /{database}/schemas
+ - /{database}/{schema}/tables
+
+
+An example of a configuration file disabling all listings:
+
+```toml
+# previous toml content
+[expose]
+    enabled = true
+```
+
+If you want to disable just the database listing:
+
+```toml
+# previous toml content
+[expose]
+    databases = true
+```
+
+| Name | Description |
+| --- | --- |
+| enabled | Set this as `true` if you want to **disable** all listing endpoints available. |
+| databases | Set this as `true` if you want to **disable** *databases* listing endpoints only. |
+| schemas | Set this as `true` if you want to **disable** *schemas* listing endpoints only. |
+| tables | Set this as `true` if you want to **disable** *tables* listing endpoints only. |
 
 ## SSL
 

--- a/middlewares/config.go
+++ b/middlewares/config.go
@@ -42,6 +42,9 @@ func initApp() {
 		if config.PrestConf.Cache.Enabled {
 			MiddlewareStack = append(MiddlewareStack, CacheMiddleware())
 		}
+		if config.PrestConf.ExposeConf.Enabled {
+			MiddlewareStack = append(MiddlewareStack, ExposureMiddleware())
+		}
 	}
 	app = negroni.New(MiddlewareStack...)
 }

--- a/middlewares/config_test.go
+++ b/middlewares/config_test.go
@@ -279,3 +279,28 @@ func Test_CORS_Middleware(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, len(body))
 }
+
+func TestExposeTablesMiddleware(t *testing.T) {
+	MiddlewareStack = []negroni.Handler{}
+	app = nil
+	os.Setenv("PREST_DEBUG", "true")
+	os.Setenv("PREST_CONF", "../testdata/prest_expose.toml")
+	config.Load()
+	app = nil
+	r := mux.NewRouter()
+	r.HandleFunc("/tables", controllers.GetTables).Methods("GET")
+	r.HandleFunc("/databases", controllers.GetDatabases).Methods("GET")
+	r.HandleFunc("/schemas", controllers.GetSchemas).Methods("GET")
+	n := GetApp()
+	n.UseHandler(r)
+	server := httptest.NewServer(n)
+	defer server.Close()
+	resp, _ := http.Get(server.URL + "/tables")
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	resp, _ = http.Get(server.URL + "/databases")
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	resp, _ = http.Get(server.URL + "/schemas")
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -159,3 +159,27 @@ func Cors(origin []string, headers []string) negroni.Handler {
 		next(w, r)
 	})
 }
+
+func ExposureMiddleware() negroni.Handler {
+	return negroni.HandlerFunc(func(rw http.ResponseWriter, rq *http.Request, next http.HandlerFunc) {
+		url := rq.URL.Path
+		exposeConf := config.PrestConf.ExposeConf
+
+		if strings.HasPrefix(url, "/databases") && !exposeConf.DatabaseListing {
+			http.Error(rw, "unauthorized listing", http.StatusUnauthorized)
+			return
+		}
+
+		if strings.HasPrefix(url, "/tables") && !exposeConf.TableListing {
+			http.Error(rw, "unauthorized listing", http.StatusUnauthorized)
+			return
+		}
+
+		if strings.HasPrefix(url, "/schemas") && !exposeConf.SchemaListing {
+			http.Error(rw, "unauthorized listing", http.StatusUnauthorized)
+			return
+		}
+
+		next(rw, rq)
+	})
+}

--- a/router/router.go
+++ b/router/router.go
@@ -51,6 +51,7 @@ func GetRouter() *mux.Router {
 	crudRoutes.HandleFunc("/{database}/{schema}/{table}", controllers.DeleteFromTable).Methods("DELETE")
 	crudRoutes.HandleFunc("/{database}/{schema}/{table}", controllers.UpdateTable).Methods("PUT", "PATCH")
 	router.PathPrefix("/").Handler(negroni.New(
+		middlewares.ExposureMiddleware(),
 		middlewares.AccessControl(),
 		middlewares.AuthMiddleware(),
 		middlewares.CacheMiddleware(),

--- a/testdata/prest_expose.toml
+++ b/testdata/prest_expose.toml
@@ -1,0 +1,11 @@
+[auth]
+table = "prest_users"
+username = "username"
+password = "password"
+metadata = ["first_name", "last_name", "last_login"]
+
+[expose]
+enabled = true
+tables = false
+databases = false
+schemas = false


### PR DESCRIPTION
In this PR we are setting some variables that enable users to disable certain endpoints for security reasons, enabling less infrastructure team/firewall necessity.

The settings will be put on `prest.toml` as shown below:

```toml
[sensitive]
disableall = false
databases = false
schemas = false
```

fixed: #741