### PR TITLE
Pass DOCKER_COMPOSE option to make...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+DOCKER_COMPOSE?=docker-compose
+
 PHONY: \
 	build_test_image \
 
 build_test_image:
-	docker-compose -f docker-compose.yml  run --rm postgres -d
+	$(DOCKER_COMPOSE) -f docker-compose.yml  run --rm postgres -d


### PR DESCRIPTION
The new docker cli added compose as a subcommand,
so you can run: docker compose ...

This allow users to set DOCKER_COMPOSE on their
environments to use the new version.

```bash
export DOCKER_COMPOSE="docker compose"
make
```
