### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -37,7 +37,7 @@ func TestLoad(t *testing.T) {
 	// Only run the failing part when a specific env variable is set
 	if os.Getenv("BE_CRASHER") == "1" {
 		Load()
-		os.Setenv("PREST_PG_DATABASE", "prest-test")
+		t.Setenv("PREST_PG_DATABASE", "prest-test")
 		return
 	}
 	// Start the actual test in a different subprocess
@@ -1284,7 +1284,7 @@ func BenchmarkPrepare(b *testing.B) {
 }
 
 func TestDisableCache(t *testing.T) {
-	os.Setenv("PREST_PG_CACHE", "false")
+	t.Setenv("PREST_PG_CACHE", "false")
 	config.Load()
 	Load()
 	ClearStmt()
@@ -1296,7 +1296,6 @@ func TestDisableCache(t *testing.T) {
 	if ok {
 		t.Error("has query in cache")
 	}
-	os.Setenv("PREST_PG_CACHE", "true")
 }
 
 func TestParseBatchInsertRequest(t *testing.T) {

--- a/cache/buntdb_test.go
+++ b/cache/buntdb_test.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/prest/prest/adapters/postgres"
@@ -15,7 +14,7 @@ func init() {
 }
 
 func TestBuntGetDoesntExist(t *testing.T) {
-	os.Setenv("PREST_CACHE", "true")
+	t.Setenv("PREST_CACHE", "true")
 	config.Load()
 	w := httptest.NewRecorder()
 

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -10,12 +10,10 @@ import (
 func init() {
 	os.Setenv("PREST_CONF", "./testdata/prest.toml")
 	os.Setenv("PREST_CACHE_ENABLED", "true")
+	os.Setenv("PREST_PG_CACHE", "true")
 	config.Load()
 }
 func TestEndpointRulesEnable(t *testing.T) {
-	os.Setenv("PREST_CONF", "./testdata/prest.toml")
-	os.Setenv("PREST_CACHE_ENABLED", "true")
-	config.Load()
 	config.PrestConf.Cache.Endpoints = append(config.PrestConf.Cache.Endpoints, config.CacheEndpoint{
 		Time:     5,
 		Endpoint: "/prest/public/test",
@@ -38,9 +36,6 @@ func TestEndpointRulesNotExist(t *testing.T) {
 }
 
 func TestEndpointRulesDisable(t *testing.T) {
-	os.Setenv("PREST_CONF", "./testdata/prest.toml")
-	os.Setenv("PREST_CACHE_ENABLED", "true")
-	config.Load()
 	config.PrestConf.Cache.Endpoints = append(config.PrestConf.Cache.Endpoints, config.CacheEndpoint{
 		Endpoint: "/prest/public/test-disable",
 		Enabled:  false,

--- a/controllers/sql_test.go
+++ b/controllers/sql_test.go
@@ -4,7 +4,6 @@ package controllers
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -92,7 +91,7 @@ func TestRenderWithXML(t *testing.T) {
 	}{
 		{"Get schemas with COUNT clause with XML Render", "/schemas?_count=*&_renderer=xml", "GET", 200, "<objects><object><count>4</count></object></objects>"},
 	}
-	os.Setenv("PREST_DEBUG", "true")
+	t.Setenv("PREST_DEBUG", "true")
 	config.Load()
 	postgres.Load()
 	n := middlewares.GetApp()

--- a/middlewares/config_test.go
+++ b/middlewares/config_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -77,7 +76,7 @@ func TestGetAppWithoutReorderedMiddleware(t *testing.T) {
 }
 
 func Test_Middleware_DoesntBlock_CustomRoutes(t *testing.T) {
-	os.Setenv("PREST_DEBUG", "true")
+	t.Setenv("PREST_DEBUG", "true")
 	config.Load()
 	postgres.Load()
 	app = nil
@@ -90,7 +89,7 @@ func Test_Middleware_DoesntBlock_CustomRoutes(t *testing.T) {
 		AccessControl(),
 		negroni.Wrap(crudRoutes),
 	))
-	os.Setenv("PREST_CONF", "../testdata/prest.toml")
+	t.Setenv("PREST_CONF", "../testdata/prest.toml")
 	n := GetApp()
 	n.UseHandler(r)
 
@@ -121,7 +120,6 @@ func Test_Middleware_DoesntBlock_CustomRoutes(t *testing.T) {
 	require.Contains(t, string(body), "required authorization to table")
 
 	MiddlewareStack = []negroni.Handler{}
-	os.Setenv("PREST_CONF", "")
 }
 
 func customMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
@@ -136,7 +134,7 @@ func customMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerF
 }
 
 func TestDebug(t *testing.T) {
-	os.Setenv("PREST_DEBUG", "true")
+	t.Setenv("PREST_DEBUG", "true")
 	config.Load()
 	nd := appTest()
 	serverd := httptest.NewServer(nd)
@@ -148,8 +146,8 @@ func TestDebug(t *testing.T) {
 
 func TestEnableDefaultJWT(t *testing.T) {
 	app = nil
-	os.Setenv("PREST_JWT_DEFAULT", "false")
-	os.Setenv("PREST_DEBUG", "false")
+	t.Setenv("PREST_JWT_DEFAULT", "false")
+	t.Setenv("PREST_DEBUG", "false")
 	config.Load()
 	nd := appTest()
 	serverd := httptest.NewServer(nd)
@@ -162,8 +160,8 @@ func TestEnableDefaultJWT(t *testing.T) {
 func TestJWTIsRequired(t *testing.T) {
 	MiddlewareStack = []negroni.Handler{}
 	app = nil
-	os.Setenv("PREST_JWT_DEFAULT", "true")
-	os.Setenv("PREST_DEBUG", "false")
+	t.Setenv("PREST_JWT_DEFAULT", "true")
+	t.Setenv("PREST_DEBUG", "false")
 	config.Load()
 	nd := appTestWithJwt()
 	serverd := httptest.NewServer(nd)
@@ -178,10 +176,10 @@ func TestJWTSignatureOk(t *testing.T) {
 	app = nil
 	MiddlewareStack = nil
 	bearer := "Bearer eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQHNvbWV3aGVyZS5jb20iLCJpYXQiOjE1MTc1NjM2MTYsImlzcyI6InByaXZhdGUiLCJqdGkiOiJjZWZhNzRmZS04OTRjLWZmNjMtZDgxNi00NjIwYjhjZDkyZWUiLCJvcmciOiJwcml2YXRlIiwic3ViIjoiam9obi5kb2UifQ.zLWkEd4hP4XdCD_DlRy6mgPeKwEl1dcdtx5A_jHSfmc87EsrGgNSdi8eBTzCgSU0jgV6ssTgQwzY6x4egze2xA"
-	os.Setenv("PREST_JWT_DEFAULT", "true")
-	os.Setenv("PREST_DEBUG", "false")
-	os.Setenv("PREST_JWT_KEY", "s3cr3t")
-	os.Setenv("PREST_JWT_ALGO", "HS512")
+	t.Setenv("PREST_JWT_DEFAULT", "true")
+	t.Setenv("PREST_DEBUG", "false")
+	t.Setenv("PREST_JWT_KEY", "s3cr3t")
+	t.Setenv("PREST_JWT_ALGO", "HS512")
 	config.Load()
 	nd := appTestWithJwt()
 	serverd := httptest.NewServer(nd)
@@ -201,10 +199,10 @@ func TestJWTSignatureOk(t *testing.T) {
 func TestJWTSignatureKo(t *testing.T) {
 	app = nil
 	bearer := "Bearer: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImpvaG4uZG9lQHNvbWV3aGVyZS5jb20iLCJleHAiOjE1MjUzMzk2MTYsImlhdCI6MTUxNzU2MzYxNiwiaXNzIjoicHJpdmF0ZSIsImp0aSI6ImNlZmE3NGZlLTg5NGMtZmY2My1kODE2LTQ2MjBiOGNkOTJlZSIsIm9yZyI6InByaXZhdGUiLCJzdWIiOiJqb2huLmRvZSJ9.zGP1Xths2bK2r9FN0Gv1SzyoisO0dhRwvqrPvunGxUyU5TbkfdnTcQRJNYZzJfGILeQ9r3tbuakWm-NIoDlbbA"
-	os.Setenv("PREST_JWT_DEFAULT", "true")
-	os.Setenv("PREST_DEBUG", "false")
-	os.Setenv("PREST_JWT_KEY", "s3cr3t")
-	os.Setenv("PREST_JWT_ALGO", "HS256")
+	t.Setenv("PREST_JWT_DEFAULT", "true")
+	t.Setenv("PREST_DEBUG", "false")
+	t.Setenv("PREST_JWT_KEY", "s3cr3t")
+	t.Setenv("PREST_JWT_ALGO", "HS256")
 	config.Load()
 	nd := appTestWithJwt()
 	serverd := httptest.NewServer(nd)
@@ -251,9 +249,9 @@ func appTestWithJwt() *negroni.Negroni {
 
 func Test_CORS_Middleware(t *testing.T) {
 	MiddlewareStack = []negroni.Handler{}
-	os.Setenv("PREST_DEBUG", "true")
-	os.Setenv("PREST_CORS_ALLOWORIGIN", "*")
-	os.Setenv("PREST_CONF", "../testdata/prest.toml")
+	t.Setenv("PREST_DEBUG", "true")
+	t.Setenv("PREST_CORS_ALLOWORIGIN", "*")
+	t.Setenv("PREST_CONF", "../testdata/prest.toml")
 	config.Load()
 	app = nil
 	r := mux.NewRouter()
@@ -283,8 +281,8 @@ func Test_CORS_Middleware(t *testing.T) {
 func TestExposeTablesMiddleware(t *testing.T) {
 	MiddlewareStack = []negroni.Handler{}
 	app = nil
-	os.Setenv("PREST_DEBUG", "true")
-	os.Setenv("PREST_CONF", "../testdata/prest_expose.toml")
+	t.Setenv("PREST_DEBUG", "true")
+	t.Setenv("PREST_CONF", "../testdata/prest_expose.toml")
 	config.Load()
 	app = nil
 	r := mux.NewRouter()


### PR DESCRIPTION
This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```