### PR TITLE
Fixes docker build tagging for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: |
+            prest/prest:latest
+            prest/prest:${{ github.event.release.tag_name }}
+            ghcr.io/prest/prest:latest
+            ghcr.io/prest/prest:${{ github.event.release.tag_name }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
We have a problem nowadays with our docker registry and tagging. With this in mind, I've created `release.yml` so we can deploy all of our releases.

In order to this PR to function, we need to set these env vars:

 - DOCKER_USERNAME
 - DOCKER_PASSWORD
 - GH_TOKEN