### PR TITLE
router: skip init

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -11,18 +11,10 @@ import (
 	"github.com/urfave/negroni"
 )
 
-var router *mux.Router
-
-func initRouter() {
-	router = mux.NewRouter().StrictSlash(true)
-}
-
 // GetRouter reagister all routes
+// v2: this is not used anywhere, so we can make it private
 func GetRouter() *mux.Router {
-	if router == nil {
-		initRouter()
-	}
-
+	router := mux.NewRouter().StrictSlash(true)
 
 	if config.PrestConf.AuthEnabled {
 		// can be db specific in the future, there's bellow a proposal

--- a/router/routers_test.go
+++ b/router/routers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prest/prest/adapters/postgres"
 	"github.com/prest/prest/config"
 	"github.com/prest/prest/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -16,19 +17,9 @@ func init() {
 	postgres.Load()
 }
 
-func TestInitRouter(t *testing.T) {
-	initRouter()
-	if router == nil {
-		t.Errorf("Router should not be nil.")
-	}
-}
-
 func TestRoutes(t *testing.T) {
-	router = nil
 	r := Routes()
-	if r == nil {
-		t.Errorf("Should return a router.")
-	}
+	require.NotNil(t, r)
 }
 
 func TestDefaultRouters(t *testing.T) {
@@ -62,7 +53,6 @@ func TestDefaultRouters(t *testing.T) {
 
 func TestAuthRouterActive(t *testing.T) {
 	config.PrestConf.AuthEnabled = true
-	initRouter()
 	server := httptest.NewServer(GetRouter())
 	testutils.DoRequest(t, server.URL+"/auth", nil, "GET", http.StatusNotFound, "AuthEnable")
 	testutils.DoRequest(t, server.URL+"/auth", nil, "POST", http.StatusUnauthorized, "AuthEnable")


### PR DESCRIPTION
## "Problem"
We're using a init method when mux router is always used here and never received from anywhere else.

## Solution
Simplify the code to always create a new router on fn call