### PR TITLE
Update _health - add default timeout and extend to allow multiple checkers

### DIFF
--- a/controllers/healthcheck.go
+++ b/controllers/healthcheck.go
@@ -12,6 +12,10 @@ import (
 
 type CheckList []func(context.Context) error
 
+var DefaultCheckList = CheckList{
+	CheckDBHealth,
+}
+
 func CheckDBHealth(ctx context.Context) error {
 	conn, err := postgres.Get()
 	if err != nil {

--- a/controllers/healthcheck_test.go
+++ b/controllers/healthcheck_test.go
@@ -9,12 +9,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/prest/prest/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckDBHealth(t *testing.T) {
-	if err := CheckDBHealth(context.Background()); err != nil {
-		t.Errorf("expected no error running the test query, got %s", err)
-	}
+	require.Nil(t, CheckDBHealth(context.Background()))
 }
 
 func healthyDB(context.Context) error   { return nil }

--- a/controllers/healthcheck_test.go
+++ b/controllers/healthcheck_test.go
@@ -30,7 +30,8 @@ func TestHealthStatus(t *testing.T) {
 		{unhealthyDB, "unhealthy database", http.StatusServiceUnavailable},
 	} {
 		router := mux.NewRouter()
-		router.HandleFunc("/_health", WrappedHealthCheck(tc.checkDBHealth)).Methods("GET")
+		checks := CheckList{tc.checkDBHealth}
+		router.HandleFunc("/_health", WrappedHealthCheck(checks)).Methods("GET")
 		server := httptest.NewServer(router)
 		defer server.Close()
 		testutils.DoRequest(t, server.URL+"/_health", nil, "GET", tc.expected, "")

--- a/controllers/healthcheck_test.go
+++ b/controllers/healthcheck_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -11,17 +12,17 @@ import (
 )
 
 func TestCheckDBHealth(t *testing.T) {
-	if err := CheckDBHealth(); err != nil {
+	if err := CheckDBHealth(context.Background()); err != nil {
 		t.Errorf("expected no error running the test query, got %s", err)
 	}
 }
 
-func healthyDB() error   { return nil }
-func unhealthyDB() error { return errors.New("could not connect to the database") }
+func healthyDB(context.Context) error   { return nil }
+func unhealthyDB(context.Context) error { return errors.New("could not connect to the database") }
 
 func TestHealthStatus(t *testing.T) {
 	for _, tc := range []struct {
-		checkDBHealth func() error
+		checkDBHealth func(context.Context) error
 		desc          string
 		expected      int
 	}{

--- a/router/router.go
+++ b/router/router.go
@@ -38,7 +38,7 @@ func GetRouter() *mux.Router {
 	router.HandleFunc("/{database}/{schema}", controllers.GetTablesByDatabaseAndSchema).Methods("GET")
 	router.HandleFunc("/show/{database}/{schema}/{table}", controllers.ShowTable).Methods("GET")
 	crudRoutes := mux.NewRouter().PathPrefix("/").Subrouter().StrictSlash(true)
-	router.HandleFunc("/_health", controllers.WrappedHealthCheck(controllers.CheckDBHealth)).Methods("GET")
+	router.HandleFunc("/_health", controllers.WrappedHealthCheck(controllers.DefaultCheckList)).Methods("GET")
 	crudRoutes.HandleFunc("/{database}/{schema}/{table}", controllers.SelectFromTables).Methods("GET")
 	crudRoutes.HandleFunc("/{database}/{schema}/{table}", controllers.InsertInTables).Methods("POST")
 	crudRoutes.HandleFunc("/batch/{database}/{schema}/{table}", controllers.BatchInsertInTables).Methods("POST")


### PR DESCRIPTION
This extends the current `_health` endpoint to allow multiple checks for the future and also limits the checks for the configured endpoint timeout (defaults to 60 seconds).