### PR TITLE
[wip] split docker-compose files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19.5
 
       - name: Cache Go modules
         uses: actions/cache@v2

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 DOCKER_COMPOSE?=docker-compose
 
-PHONY: \
-	build_test_image \
-
+PHONY: build_test_image
 build_test_image:
 	$(DOCKER_COMPOSE) -f docker-compose.yml  run --rm postgres -d
 
+PHONY: test
 test:
 	$(DOCKER_COMPOSE) -f testdata/docker-compose.yml up --abort-on-container-exit --remove-orphans
+
+PHONY: build
+build:
+	go build -ldflags "-s -w" -o prestd cmd/prestd/main.go
+
+local:
+	$(DOCKER_COMPOSE) up

--- a/postgres.yml
+++ b/postgres.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_DB=prest
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "-U", "prest"]
+      interval: 30s
+      retries: 3

--- a/prest.yml
+++ b/prest.yml
@@ -1,0 +1,16 @@
+  prest:
+    build: .
+    restart: on-failure
+    links:
+      - "postgres:postgres"
+    environment:
+      - PREST_DEBUG=true # remove comment to disable DEBUG mode
+      - PREST_PG_HOST=postgres
+      - PREST_PG_CACHE=false
+      - PREST_JWT_DEFAULT=false # toggle to use jwt
+      - PREST_CACHE_ENABLED=false
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "3000:3000"

--- a/testdata/Dockerfile
+++ b/testdata/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.18
+FROM registry.hub.docker.com/library/golang:1.19.5
 WORKDIR /workspace
 RUN apt update && apt install -y postgresql-client
 


### PR DESCRIPTION
* this is to make local and CI testing equal and easier
* "depends" on #762
* this is to fix config's test files, as is now it breaks locally and works on CI: https://github.com/prest/prest/blob/main/config/config_test.go
