### PR TITLE
remove cache/test file reference

### DIFF
--- a/scripts/docker-hub-tag.sh
+++ b/scripts/docker-hub-tag.sh
@@ -7,6 +7,4 @@ git checkout . && \
     docker tag prest/prest:latest prest/prest:v1 && \
     docker push prest/prest:latest && \
     docker push prest/prest:v1 && \
-    docker push prest/prest:$DOCKER_TAG && \
-    git checkout . && \
-    rm cache/test
+    docker push prest/prest:$DOCKER_TAG

--- a/scripts/releaser-tag.sh
+++ b/scripts/releaser-tag.sh
@@ -2,5 +2,4 @@
 export DOCKER_TAG=${GITHUB_REF#refs/tags/}
 
 git checkout . && \
-    rm -rf cache/test && \
     curl -sL https://git.io/goreleaser | bash


### PR DESCRIPTION
# what
remove reference to the `cache/test` file

# why
since we split the build action file into `build` and `test` actions, this file does not exist anymore in the build action.

https://github.com/prest/prest/actions/runs/4151811751/jobs/7182349449
