### PR TITLE
Supress cmd usage message in migration-related errors

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -25,6 +25,7 @@ var migrateCmd = &cobra.Command{
 }
 
 func checkTable(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
 	if config.PrestConf.Adapter == nil {
 		postgres.Load()
 	}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -17,6 +18,11 @@ var (
 	path    string
 )
 
+var (
+	ErrPathNotSet = errors.New("Migrations path not set. \nPlease set it using --path flag or in your prest config file")
+	ErrURLNotSet  = errors.New("Database URL not set. \nPlease set it using --url flag or configure it on your prest config file")
+)
+
 // migrateCmd represents the migrate command
 var migrateCmd = &cobra.Command{
 	Use:   "migrate",
@@ -25,6 +31,12 @@ var migrateCmd = &cobra.Command{
 }
 
 func checkTable(cmd *cobra.Command, args []string) error {
+	if path == "" {
+		return ErrPathNotSet
+	}
+	if urlConn == "" {
+		return ErrURLNotSet
+	}
 	cmd.SilenceUsage = true
 	if config.PrestConf.Adapter == nil {
 		postgres.Load()


### PR DESCRIPTION
- solves #820 
now:
```bash
❯ ./prestd2 migrate up --path ./migrations
Error: pq: table "example" does not exist
pq: table "example" does not exist
```
This config extends to most of the migration subcommands (eccept `auth`, as `checkTable` is not used there)
```bash
❯ ./prestd2 migrate down --path ./migrations
Error: pq: index "example_idx" does not exist
pq: index "example_idx" does not exist
```

- adds `flag` and `urlConn` checks for meaningful error message:
now:
```bash
❯ ./prestd2 migrate up
Error: Migrations path not set. 
Please set it using --path flag or in your prest config file
Usage:
  prestd migrate up [flags]
  prestd migrate up [command]

Available Commands:
  auth        Create auth table

Flags:
  -h, --help   help for up

Global Flags:
      --path string   Migrations directory
      --url string    Database driver url (default "postgres://postgres:postgres@127.0.0.1:5432/prest?sslmode=disable&sslcert=&sslkey=&sslrootcert=")

Use "prestd migrate up [command] --help" for more information about a command.

Migrations path not set. 
Please set it using --path flag or in your prest config file
```

before:
```bash
❯ ./prestd migrate up
Error: stat : no such file or directory
Usage:
  prestd migrate up [flags]
  prestd migrate up [command]

Available Commands:
  auth        Create auth table

Flags:
  -h, --help   help for up

Global Flags:
      --path string   Migrations directory
      --url string    Database driver url (default "postgres://postgres:postgres@127.0.0.1:5432/prest?sslmode=disable&sslcert=&sslkey=&sslrootcert=")

Use "prestd migrate up [command] --help" for more information about a command.

stat : no such file or directory
```
