### PR TITLE
bump docker action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: curl -sfL https://git.io/goreleaser | sh -s -- check
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Login to Docker Registry
         if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
This updates the `docker/login-action`  to v3, hopefully solving https://github.com/prest/prest/actions/runs/6769305212/job/18395463386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub workflow to use the latest Docker login action for enhanced security and performance during container registry logins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->