### PR TITLE
fix config v2 link and docs

### DIFF
--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-//Adapter interface
+// Adapter interface
 type Adapter interface {
 	// GetTransaction attempts to get a transaction from the db connection
 	GetTransaction() (tx *sql.Tx, err error)

--- a/config/config.go
+++ b/config/config.go
@@ -400,7 +400,7 @@ func parseSSLV1Data(cfg *Prest) {
 	log.Warningln(`
 You are using v1 of prestd configs, please migrate to v2.
 
-v1 will be deprecated by dec 31st 2023.
+v1 will be deprecated by Dec 31st 2023.
 
 View more at https://docs.prestd.com/get-started/configuring-prest`)
 	cfg.PGSSLMode = cfg.SSLMode

--- a/config/config.go
+++ b/config/config.go
@@ -393,16 +393,16 @@ You are using v2 of prestd configs, please note that v1 postgres SSL environment
 
 When using v2 the following environment variables will be ignored: PREST_SSL_MODE, PREST_SSL_CERT, PREST_SSL_KEY, PREST_SSL_ROOTCERT
 
-View more at https://docs.prestd.com/deployment/configuring-prest`)
+View more at https://docs.prestd.com/get-started/configuring-prest`)
 }
 
 func parseSSLV1Data(cfg *Prest) {
 	log.Warningln(`
 You are using v1 of prestd configs, please migrate to v2.
 
-v1 will be deprecated soon.
+v1 will be deprecated by dec 31st 2023.
 
-View more at https://docs.prestd.com/deployment/configuring-prest`)
+View more at https://docs.prestd.com/get-started/configuring-prest`)
 	cfg.PGSSLMode = cfg.SSLMode
 	cfg.PGSSLKey = cfg.SSLKey
 	cfg.PGSSLCert = cfg.SSLCert


### PR DESCRIPTION
fix #844


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated deprecation warning for v1 configurations to specify the deprecation date as December 31st, 2023.
  - Modified the documentation URL in the deprecation warning to direct users to the updated configuration guide.

- **Style**
  - Improved comment formatting for the `Adapter` interface for better code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->