### PR TITLE
try to create the cache storagepath if not exists

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -104,6 +104,8 @@ type Prest struct {
 	PluginMiddlewareList []PluginMiddleware
 }
 
+const defaultCacheDir = "./"
+
 var (
 	// PrestConf config variable
 	PrestConf      *Prest
@@ -117,8 +119,14 @@ func Load() {
 	PrestConf = &Prest{}
 	Parse(PrestConf)
 	if _, err := os.Stat(PrestConf.QueriesPath); os.IsNotExist(err) {
-		if err = os.MkdirAll(PrestConf.QueriesPath, 0700); os.IsNotExist(err) {
-			log.Errorf("Queries directory %s was not created\n", PrestConf.QueriesPath)
+		if err = os.MkdirAll(PrestConf.QueriesPath, 0700); err != nil {
+			log.Errorf("Queries directory %s was not created, err: %v\n", PrestConf.QueriesPath, err)
+		}
+	}
+	if _, err := os.Stat(PrestConf.Cache.StoragePath); os.IsNotExist(err) {
+		if err = os.MkdirAll(PrestConf.Cache.StoragePath, 0700); err != nil {
+			log.Errorf("Cache directory %s was not created, falling back to default './', err: %v\n", PrestConf.Cache.StoragePath, err)
+			PrestConf.Cache.StoragePath = defaultCacheDir
 		}
 	}
 }


### PR DESCRIPTION
fix #858 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved directory creation logic to ensure cache storage is available, with fallback to a default directory if necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->