### PR TITLE
Multi-database support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,9 +58,11 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -c "DROP DATABASE IF EXISTS \"$PREST_PG_DATABASE\";"
-          psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -c "CREATE DATABASE \"$PREST_PG_DATABASE\";"
-          psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -d $PREST_PG_DATABASE -f ./testdata/schema.sql
+          for db in $PREST_PG_DATABASE secondary-db; do
+            psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -c "DROP DATABASE IF EXISTS \"$db\";"
+            psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -c "CREATE DATABASE \"$db\";"
+            psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -d $db -f ./testdata/schema.sql
+          done
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           apt-get update
           apt-get install -y postgresql-client
 
-      - name: Setup Database
+      - name: Setup Databases
         env:
           PGPASSWORD: postgres
         run: |

--- a/adapters/postgres/connection.go
+++ b/adapters/postgres/connection.go
@@ -21,8 +21,8 @@ func GetPool() *connection.Pool {
 }
 
 // AddDatabaseToPool add connection to pool
-func AddDatabaseToPool(name string, DB *sqlx.DB) {
-	connection.AddDatabaseToPool(name, DB)
+func AddDatabaseToPool(name string) (*sqlx.DB, error) {
+	return connection.AddDatabaseToPool(name)
 }
 
 // MustGet get postgres connection

--- a/adapters/postgres/internal/connection/conn.go
+++ b/adapters/postgres/internal/connection/conn.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	err          error
 	pool         *Pool
 	currDatabase string
 )
@@ -55,13 +54,15 @@ func GetURI(DBName string) string {
 	return dbURI
 }
 
-// Get get postgres connection
+// Get get Postgres connection adding it to the pool if needed
 func Get() (*sqlx.DB, error) {
 	DB := getDatabaseFromPool(GetDatabase())
+	// Connection is already in the pool
 	if DB != nil {
 		return DB, nil
 	}
 
+	// Connection is not in the pool, add it
 	DB, err := AddDatabaseToPool(GetDatabase())
 
 	return DB, err
@@ -99,7 +100,7 @@ func getDatabaseFromPool(name string) *sqlx.DB {
 	return DB
 }
 
-// AddDatabaseToPool add connection to pool
+// AddDatabaseToPool create and add connection to the pool
 func AddDatabaseToPool(name string) (*sqlx.DB, error) {
 	DB, err := sqlx.Connect("postgres", GetURI(name))
 	if err != nil {

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -1695,7 +1695,11 @@ func (adapter *Postgres) GetDatabase() string {
 func getDBFromCtx(ctx context.Context) (db *sqlx.DB, err error) {
 	dbName, ok := ctx.Value(pctx.DBNameKey).(string)
 	if ok {
-		return connection.GetFromPool(dbName)
+		DB, err := connection.GetFromPool(dbName)
+		if err == nil {
+			return DB, err
+		}
+		return connection.AddDatabaseToPool(dbName)
 	}
 	return connection.Get()
 }

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -1690,8 +1690,9 @@ func (adapter *Postgres) GetDatabase() string {
 	return connection.GetDatabase()
 }
 
-// getDBFromCtx tries to get the db from context if not present it will
-// fallback to the current setted db
+// getDBFromCtx tries to get the DB from context adding it to the pool if not
+// present, unless DB name is unset in the context - it will then fallback to
+// the current DB has been set via `SetDatabase(...)`
 func getDBFromCtx(ctx context.Context) (db *sqlx.DB, err error) {
 	dbName, ok := ctx.Value(pctx.DBNameKey).(string)
 	if ok {

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/structy/log"
 )
 
+// Should be in sync with databases under test (see `testdata/runtest.sh` and
+// Github `test` workflow)
 var databases = []string{"prest-test", "secondary-db"}
 
 func init() {

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/structy/log"
 )
 
-var databases = []string {"prest-test", "secondary-db"}
+var databases = []string{"prest-test", "secondary-db"}
 
 func init() {
 	config.Load()

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -503,7 +503,7 @@ func TestInsert(t *testing.T) {
 	}{
 		{"Insert data into a table with one field", `INSERT INTO "prest-test"."public"."test4"("name") VALUES($1)`, []interface{}{"prest-test-insert"}},
 		{"Insert data into a table with more than one field", `INSERT INTO "prest-test"."public"."test5"("name", "celphone") VALUES($1, $2)`, []interface{}{"prest-test-insert", "88888888"}},
-		{"Insert data into a table with more than one field and with quotes case sensitive", `INSERT INTO "prest-test"."public"."Reply"("name") VALUES($1)`, []interface{}{"prest-test-insert"}},
+		{"Insert data into a table with more than one field and with quotes case sensitive", `INSERT INTO "prest-test"."public"."TestCase"("name") VALUES($1)`, []interface{}{"prest-test-insert"}},
 	}
 
 	for _, tc := range testCases {
@@ -526,7 +526,7 @@ func TestInsertCtx(t *testing.T) {
 	}{
 		{"Insert data into a table with one field", `INSERT INTO "%s"."public"."test4"("name") VALUES($1)`, []interface{}{"prest-test-insert-ctx"}},
 		{"Insert data into a table with more than one field", `INSERT INTO "%s"."public"."test5"("name", "celphone") VALUES($1, $2)`, []interface{}{"prest-test-insert-ctx", "88888888"}},
-		{"Insert data into a table with more than one field and with quotes case sensitive", `INSERT INTO "%s"."public"."Reply"("name") VALUES($1)`, []interface{}{"prest-test-insert-ctx"}},
+		{"Insert data into a table with more than one field and with quotes case sensitive", `INSERT INTO "%s"."public"."TestCase"("name") VALUES($1)`, []interface{}{"prest-test-insert-ctx"}},
 	}
 
 	for _, db := range databases {
@@ -1223,22 +1223,22 @@ func TestNormalizeGroupFunction(t *testing.T) {
 }
 
 func TestCacheQuery(t *testing.T) {
-	sc := config.PrestConf.Adapter.Query(`SELECT * FROM "Reply"`)
+	sc := config.PrestConf.Adapter.Query(`SELECT * FROM "TestCase"`)
 	if err := sc.Err(); err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-	sc = config.PrestConf.Adapter.Query(`SELECT * FROM "Reply"`)
+	sc = config.PrestConf.Adapter.Query(`SELECT * FROM "TestCase"`)
 	if err := sc.Err(); err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
 }
 
 func TestCacheQueryCount(t *testing.T) {
-	sc := config.PrestConf.Adapter.QueryCount(`SELECT COUNT(*) FROM "Reply"`)
+	sc := config.PrestConf.Adapter.QueryCount(`SELECT COUNT(*) FROM "TestCase"`)
 	if err := sc.Err(); err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-	sc = config.PrestConf.Adapter.QueryCount(`SELECT COUNT(*) FROM "Reply"`)
+	sc = config.PrestConf.Adapter.QueryCount(`SELECT COUNT(*) FROM "TestCase"`)
 	if err := sc.Err(); err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
@@ -1249,11 +1249,11 @@ func TestCacheQueryCountCtx(t *testing.T) {
 		ctx := context.WithValue(context.Background(), pctx.DBNameKey, db)
 
 		t.Log(fmt.Sprintf("(DB: %s) Cached query count", db))
-		sc := config.PrestConf.Adapter.QueryCountCtx(ctx, `SELECT COUNT(*) FROM "Reply"`)
+		sc := config.PrestConf.Adapter.QueryCountCtx(ctx, `SELECT COUNT(*) FROM "TestCase"`)
 		if err := sc.Err(); err != nil {
 			t.Errorf("expected no errors, but got %v", err)
 		}
-		sc = config.PrestConf.Adapter.QueryCountCtx(ctx, `SELECT COUNT(*) FROM "Reply"`)
+		sc = config.PrestConf.Adapter.QueryCountCtx(ctx, `SELECT COUNT(*) FROM "TestCase"`)
 		if err := sc.Err(); err != nil {
 			t.Errorf("expected no errors, but got %v", err)
 		}
@@ -1296,7 +1296,7 @@ func TestCacheDelete(t *testing.T) {
 func BenchmarkPrepare(b *testing.B) {
 	db := connection.MustGet()
 	for index := 0; index < b.N; index++ {
-		_, err := Prepare(db, `SELECT * FROM "Reply"`)
+		_, err := Prepare(db, `SELECT * FROM "TestCase"`)
 		if err != nil {
 			b.Fail()
 		}
@@ -1308,11 +1308,11 @@ func TestDisableCache(t *testing.T) {
 	config.Load()
 	Load()
 	ClearStmt()
-	sc := config.PrestConf.Adapter.Query(`SELECT * FROM "Reply"`)
+	sc := config.PrestConf.Adapter.Query(`SELECT * FROM "TestCase"`)
 	if err := sc.Err(); err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-	_, ok := stmts.PrepareMap[`SELECT jsonb_agg(s) FROM (SELECT * FROM "Reply") s`]
+	_, ok := stmts.PrepareMap[`SELECT jsonb_agg(s) FROM (SELECT * FROM "TestCase") s`]
 	if ok {
 		t.Error("has query in cache")
 	}
@@ -1387,7 +1387,7 @@ func TestBatchInsertValues(t *testing.T) {
 			[]interface{}{"2prest-test-batch-insert", "88888888", "2batch-prest-test-insert", "98888888"},
 		}, {
 			"Insert data into a table with more than one field and with quotes case sensitive",
-			`INSERT INTO "prest-test"."public"."Reply"("name") VALUES($1),($2)`,
+			`INSERT INTO "prest-test"."public"."TestCase"("name") VALUES($1),($2)`,
 			[]interface{}{"3prest-test-batch-insert", "3batch-prest-test-insert"},
 		},
 	}
@@ -1421,7 +1421,7 @@ func TestBatchInsertValuesCtx(t *testing.T) {
 			[]interface{}{"2prest-test-batch-insert", "88888888", "2batch-prest-test-insert", "98888888"},
 		}, {
 			"Insert data into a table with more than one field and with quotes case sensitive",
-			`INSERT INTO "%s"."public"."Reply"("name") VALUES($1),($2)`,
+			`INSERT INTO "%s"."public"."TestCase"("name") VALUES($1),($2)`,
 			[]interface{}{"3prest-test-batch-insert-ctx", "3batch-prest-test-insert-ctx"},
 		},
 	}
@@ -1463,7 +1463,7 @@ func TestPostgres_BatchInsertCopyCtx(t *testing.T) {
 			"batch copy",
 			args{
 				"public",
-				"Reply",
+				"TestCase",
 				[]string{`"name"`},
 				[]interface{}{"copy-ctx"},
 			},
@@ -1473,7 +1473,7 @@ func TestPostgres_BatchInsertCopyCtx(t *testing.T) {
 			"batch copy without quotes",
 			args{
 				"public",
-				"Reply",
+				"TestCase",
 				[]string{"name"},
 				[]interface{}{"copy-ctx"},
 			},
@@ -1483,7 +1483,7 @@ func TestPostgres_BatchInsertCopyCtx(t *testing.T) {
 			"batch copy with err",
 			args{
 				"public",
-				"Reply",
+				"TestCase",
 				[]string{"na"},
 				[]interface{}{"copy-ctx"},
 			},
@@ -1527,7 +1527,7 @@ func TestPostgres_BatchInsertCopy(t *testing.T) {
 			args{
 				"prest-test",
 				"public",
-				"Reply",
+				"TestCase",
 				[]string{`"name"`},
 				[]interface{}{"copy"},
 			},
@@ -1538,7 +1538,7 @@ func TestPostgres_BatchInsertCopy(t *testing.T) {
 			args{
 				"prest-test",
 				"public",
-				"Reply",
+				"TestCase",
 				[]string{"name"},
 				[]interface{}{"copy"},
 			},
@@ -1549,7 +1549,7 @@ func TestPostgres_BatchInsertCopy(t *testing.T) {
 			args{
 				"prest-test",
 				"public",
-				"Reply",
+				"TestCase",
 				[]string{"na"},
 				[]interface{}{"copy"},
 			},

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -3,8 +3,8 @@ package controllers
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -18,7 +18,7 @@ import (
 	"github.com/prest/prest/testutils"
 )
 
-var databases = []string {"prest-test", "secondary-db"}
+var databases = []string{"prest-test", "secondary-db"}
 
 func Init() {
 	config.Load()

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/prest/prest/testutils"
 )
 
+// Should be in sync with databases under test (see `testdata/runtest.sh` and
+// Github `test` workflow)
 var databases = []string{"prest-test", "secondary-db"}
 
 func Init() {
@@ -80,8 +82,13 @@ func TestGetTablesByDatabaseAndSchema(t *testing.T) {
 		{"Get tables by databases with noexistent column", "/%s/public?t.taababa=$eq.test", "GET", http.StatusBadRequest},
 		{"Get tables by databases with not configured database", "/random/public?t.taababa=$eq.test", "GET", http.StatusBadRequest},
 	}
+
+	// Re-initialize pREST instance under test, mostly to revert `config` changes below
 	defer Init()
+
 	for _, db := range databases {
+		// Testing against multiple databases needs `SingleDB = false` in the
+		// config
 		config.PrestConf.SingleDB = false
 		router := mux.NewRouter()
 		router.HandleFunc("/{database}/{schema}", setHTTPTimeoutMiddleware(GetTablesByDatabaseAndSchema)).

--- a/controllers/tables_test.go
+++ b/controllers/tables_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"encoding/json"
 	"io"
 	"log"
@@ -17,7 +18,9 @@ import (
 	"github.com/prest/prest/testutils"
 )
 
-func init() {
+var databases = []string {"prest-test", "secondary-db"}
+
+func Init() {
 	config.Load()
 	postgres.Load()
 	if config.PrestConf.PGDatabase != "prest-test" {
@@ -65,27 +68,30 @@ func TestGetTablesByDatabaseAndSchema(t *testing.T) {
 		method      string
 		status      int
 	}{
-		{"Get tables by database and schema without custom where clause", "/prest-test/public", "GET", http.StatusOK},
-		{"Get tables by database and schema with custom where clause", "/prest-test/public?t.tablename=$eq.test", "GET", http.StatusOK},
-		{"Get tables by database and schema with order clause", "/prest-test/public?t.tablename=$eq.test&_order=t.tablename", "GET", http.StatusOK},
-		{"Get tables by database and schema with custom where clause and pagination", "/prest-test/public?t.tablename=$eq.test&_page=1&_page_size=20", "GET", http.StatusOK},
-		{"Get tables by database and schema with distinct clause", "/prest-test/public?_distinct=true", "GET", http.StatusOK},
+		{"Get tables by database and schema without custom where clause", "/%s/public", "GET", http.StatusOK},
+		{"Get tables by database and schema with custom where clause", "/%s/public?t.tablename=$eq.test", "GET", http.StatusOK},
+		{"Get tables by database and schema with order clause", "/%s/public?t.tablename=$eq.test&_order=t.tablename", "GET", http.StatusOK},
+		{"Get tables by database and schema with custom where clause and pagination", "/%s/public?t.tablename=$eq.test&_page=1&_page_size=20", "GET", http.StatusOK},
+		{"Get tables by database and schema with distinct clause", "/%s/public?_distinct=true", "GET", http.StatusOK},
 		// errors
-		{"Get tables by database and schema with custom where invalid clause", "/prest-test/public?0t.tablename=$eq.test", "GET", http.StatusBadRequest},
-		{"Get tables by databases and schema with custom where and pagination invalid", "/prest-test/public?t.tablename=$eq.test&_page=A&_page_size=20", "GET", http.StatusBadRequest},
-		{"Get tables by databases and schema with ORDER BY and column invalid", "/prest-test/public?_order=0t.tablename", "GET", http.StatusBadRequest},
-		{"Get tables by databases with noexistent column", "/prest-test/public?t.taababa=$eq.test", "GET", http.StatusBadRequest},
+		{"Get tables by database and schema with custom where invalid clause", "/%s/public?0t.tablename=$eq.test", "GET", http.StatusBadRequest},
+		{"Get tables by databases and schema with custom where and pagination invalid", "/%s/public?t.tablename=$eq.test&_page=A&_page_size=20", "GET", http.StatusBadRequest},
+		{"Get tables by databases and schema with ORDER BY and column invalid", "/%s/public?_order=0t.tablename", "GET", http.StatusBadRequest},
+		{"Get tables by databases with noexistent column", "/%s/public?t.taababa=$eq.test", "GET", http.StatusBadRequest},
 		{"Get tables by databases with not configured database", "/random/public?t.taababa=$eq.test", "GET", http.StatusBadRequest},
 	}
-
-	router := mux.NewRouter()
-	router.HandleFunc("/{database}/{schema}", setHTTPTimeoutMiddleware(GetTablesByDatabaseAndSchema)).
-		Methods("GET")
-	server := httptest.NewServer(router)
-	defer server.Close()
-	for _, tc := range testCases {
-		t.Log(tc.description)
-		testutils.DoRequest(t, server.URL+tc.url, nil, tc.method, tc.status, "GetTablesByDatabaseAndSchema")
+	defer Init()
+	for _, db := range databases {
+		config.PrestConf.SingleDB = false
+		router := mux.NewRouter()
+		router.HandleFunc("/{database}/{schema}", setHTTPTimeoutMiddleware(GetTablesByDatabaseAndSchema)).
+			Methods("GET")
+		server := httptest.NewServer(router)
+		defer server.Close()
+		for _, tc := range testCases {
+			t.Log(fmt.Sprintf("(DB: %s) %s", db, tc.description))
+			testutils.DoRequest(t, fmt.Sprintf(server.URL+tc.url, db), nil, tc.method, tc.status, "GetTablesByDatabaseAndSchema")
+		}
 	}
 }
 
@@ -95,6 +101,7 @@ func TestSelectFromTables(t *testing.T) {
 		Methods("GET")
 	server := httptest.NewServer(router)
 	defer server.Close()
+	defer Init()
 
 	var testCases = []struct {
 		description string
@@ -103,63 +110,66 @@ func TestSelectFromTables(t *testing.T) {
 		status      int
 		body        string
 	}{
-		{"execute select in a table with array", "/prest-test/public/testarray", "GET", http.StatusOK, "[{\"id\": 100, \"data\": [\"Gohan\", \"Goten\"]}]"},
-		{"execute select in a table without custom where clause", "/prest-test/public/test", "GET", http.StatusOK, ""},
-		{"execute select in a table case sentive", "/prest-test/public/Reply", "GET", http.StatusOK, "[{\"id\": 1, \"name\": \"prest tester\"}, {\"id\": 2, \"name\": \"prest-test-insert\"}, {\"id\": 3, \"name\": \"prest-test-insert-ctx\"}, {\"id\": 4, \"name\": \"3prest-test-batch-insert\"}, {\"id\": 5, \"name\": \"3batch-prest-test-insert\"}, {\"id\": 6, \"name\": \"3prest-test-batch-insert-ctx\"}, {\"id\": 7, \"name\": \"3batch-prest-test-insert-ctx\"}, {\"id\": 8, \"name\": \"copy-ctx\"}, {\"id\": 9, \"name\": \"copy-ctx\"}, {\"id\": 10, \"name\": \"copy\"}, {\"id\": 11, \"name\": \"copy\"}]"},
-		{"execute select in a table with count all fields *", "/prest-test/public/test?_count=*", "GET", http.StatusOK, ""},
-		{"execute select in a table with count function", "/prest-test/public/test?_count=name", "GET", http.StatusOK, ""},
-		{"execute select in a table with custom where clause", "/prest-test/public/test?name=$eq.test", "GET", http.StatusOK, ""},
-		{"execute select in a table with custom join clause", "/prest-test/public/test?_join=inner:test8:test8.nameforjoin:$eq:test.name", "GET", http.StatusOK, ""},
-		{"execute select in a table with order clause empty", "/prest-test/public/test?_order=", "GET", http.StatusOK, ""},
-		{"execute select in a table with custom where clause and pagination", "/prest-test/public/test?name=$eq.test&_page=1&_page_size=20", "GET", http.StatusOK, ""},
-		{"execute select in a table with select fields", "/prest-test/public/test5?_select=celphone,name", "GET", http.StatusOK, ""},
-		{"execute select in a table with select *", "/prest-test/public/test5?_select=*", "GET", http.StatusOK, ""},
-		{"execute select in a table with select * and distinct", "/prest-test/public/test5?_select=*&_distinct=true", "GET", http.StatusOK, ""},
+		{"execute select in a table with array", "/%s/public/testarray", "GET", http.StatusOK, "[{\"id\": 100, \"data\": [\"Gohan\", \"Goten\"]}]"},
+		{"execute select in a table without custom where clause", "/%s/public/test", "GET", http.StatusOK, ""},
+		{"execute select in a table case sentive", "/%s/public/Reply", "GET", http.StatusOK, "[{\"id\": 1, \"name\": \"prest tester\"}]"},
+		{"execute select in a table with count all fields *", "/%s/public/test?_count=*", "GET", http.StatusOK, ""},
+		{"execute select in a table with count function", "/%s/public/test?_count=name", "GET", http.StatusOK, ""},
+		{"execute select in a table with custom where clause", "/%s/public/test?name=$eq.test", "GET", http.StatusOK, ""},
+		{"execute select in a table with custom join clause", "/%s/public/test?_join=inner:test8:test8.nameforjoin:$eq:test.name", "GET", http.StatusOK, ""},
+		{"execute select in a table with order clause empty", "/%s/public/test?_order=", "GET", http.StatusOK, ""},
+		{"execute select in a table with custom where clause and pagination", "/%s/public/test?name=$eq.test&_page=1&_page_size=20", "GET", http.StatusOK, ""},
+		{"execute select in a table with select fields", "/%s/public/test5?_select=celphone,name", "GET", http.StatusOK, ""},
+		{"execute select in a table with select *", "/%s/public/test5?_select=*", "GET", http.StatusOK, ""},
+		{"execute select in a table with select * and distinct", "/%s/public/test5?_select=*&_distinct=true", "GET", http.StatusOK, ""},
 
-		{"execute select in a table with group by clause", "/prest-test/public/test_group_by_table?_select=age,sum:salary&_groupby=age", "GET", http.StatusOK, ""},
-		{"execute select in a table with group by and having clause", "/prest-test/public/test_group_by_table?_select=age,sum:salary&_groupby=age->>having:sum:salary:$gt:3000", "GET", http.StatusOK, "[{\"age\": 19, \"sum\": 7997}]"},
+		{"execute select in a table with group by clause", "/%s/public/test_group_by_table?_select=age,sum:salary&_groupby=age", "GET", http.StatusOK, ""},
+		{"execute select in a table with group by and having clause", "/%s/public/test_group_by_table?_select=age,sum:salary&_groupby=age->>having:sum:salary:$gt:3000", "GET", http.StatusOK, "[{\"age\": 19, \"sum\": 7997}]"},
 
-		{"execute select in a view without custom where clause", "/prest-test/public/view_test", "GET", http.StatusOK, ""},
-		{"execute select in a view with count all fields *", "/prest-test/public/view_test?_count=*", "GET", http.StatusOK, ""},
-		{"execute select in a view with count function", "/prest-test/public/view_test?_count=player", "GET", http.StatusOK, ""},
-		{"execute select in a view with count function check return list", "/prest-test/public/view_test?_count=player", "GET", http.StatusOK, "[{\"count\": 1}]"},
-		{"execute select in a view with count function check return object (_count_first)", "/prest-test/public/view_test?_count=player&_count_first=true", "GET", http.StatusOK, "{\"count\":1}"},
-		{"execute select in a view with order function", "/prest-test/public/view_test?_order=-player", "GET", http.StatusOK, ""},
-		{"execute select in a view with custom where clause", "/prest-test/public/view_test?player=$eq.gopher", "GET", http.StatusOK, ""},
-		{"execute select in a view with custom join clause", "/prest-test/public/view_test?_join=inner:test2:test2.name:eq:view_test.player", "GET", http.StatusOK, ""},
-		{"execute select in a view with custom where clause and pagination", "/prest-test/public/view_test?player=$eq.gopher&_page=1&_page_size=20", "GET", http.StatusOK, ""},
-		{"execute select in a view with select fields", "/prest-test/public/view_test?_select=player", "GET", http.StatusOK, ""},
+		{"execute select in a view without custom where clause", "/%s/public/view_test", "GET", http.StatusOK, ""},
+		{"execute select in a view with count all fields *", "/%s/public/view_test?_count=*", "GET", http.StatusOK, ""},
+		{"execute select in a view with count function", "/%s/public/view_test?_count=player", "GET", http.StatusOK, ""},
+		{"execute select in a view with count function check return list", "/%s/public/view_test?_count=player", "GET", http.StatusOK, "[{\"count\": 1}]"},
+		{"execute select in a view with count function check return object (_count_first)", "/%s/public/view_test?_count=player&_count_first=true", "GET", http.StatusOK, "{\"count\":1}"},
+		{"execute select in a view with order function", "/%s/public/view_test?_order=-player", "GET", http.StatusOK, ""},
+		{"execute select in a view with custom where clause", "/%s/public/view_test?player=$eq.gopher", "GET", http.StatusOK, ""},
+		{"execute select in a view with custom join clause", "/%s/public/view_test?_join=inner:test2:test2.name:eq:view_test.player", "GET", http.StatusOK, ""},
+		{"execute select in a view with custom where clause and pagination", "/%s/public/view_test?player=$eq.gopher&_page=1&_page_size=20", "GET", http.StatusOK, ""},
+		{"execute select in a view with select fields", "/%s/public/view_test?_select=player", "GET", http.StatusOK, ""},
 
-		{"execute select in a table with invalid join clause", "/prest-test/public/test?_join=inner:test2:test2.name", "GET", http.StatusBadRequest, ""},
-		{"execute select in a table with invalid where clause", "/prest-test/public/test?0name=$eq.test", "GET", http.StatusBadRequest, ""},
-		{"execute select in a table with order clause and column invalid", "/prest-test/public/test?_order=0name", "GET", http.StatusBadRequest, ""},
-		{"execute select in a table with invalid pagination clause", "/prest-test/public/test?name=$eq.test&_page=A", "GET", http.StatusBadRequest, ""},
-		{"execute select in a table with invalid where clause", "/prest-test/public/test?0name=$eq.test", "GET", http.StatusBadRequest, ""},
-		{"execute select in a table with invalid count clause", "/prest-test/public/test?_count=0name", "GET", http.StatusBadRequest, ""},
-		{"execute select in a table with invalid order clause", "/prest-test/public/test?_order=0name", "GET", http.StatusBadRequest, ""},
-		{"execute select in a table with invalid fields using group by clause", "/prest-test/public/test_group_by_table?_select=pa,sum:pum&_groupby=pa", "GET", http.StatusBadRequest, ""},
-		{"execute select in a table with invalid fields using group by and having clause", "/prest-test/public/test_group_by_table?_select=pa,sum:pum&_groupby=pa->>having:sum:pmu:$eq:150", "GET", http.StatusBadRequest, ""},
+		{"execute select in a table with invalid join clause", "/%s/public/test?_join=inner:test2:test2.name", "GET", http.StatusBadRequest, ""},
+		{"execute select in a table with invalid where clause", "/%s/public/test?0name=$eq.test", "GET", http.StatusBadRequest, ""},
+		{"execute select in a table with order clause and column invalid", "/%s/public/test?_order=0name", "GET", http.StatusBadRequest, ""},
+		{"execute select in a table with invalid pagination clause", "/%s/public/test?name=$eq.test&_page=A", "GET", http.StatusBadRequest, ""},
+		{"execute select in a table with invalid where clause", "/%s/public/test?0name=$eq.test", "GET", http.StatusBadRequest, ""},
+		{"execute select in a table with invalid count clause", "/%s/public/test?_count=0name", "GET", http.StatusBadRequest, ""},
+		{"execute select in a table with invalid order clause", "/%s/public/test?_order=0name", "GET", http.StatusBadRequest, ""},
+		{"execute select in a table with invalid fields using group by clause", "/%s/public/test_group_by_table?_select=pa,sum:pum&_groupby=pa", "GET", http.StatusBadRequest, ""},
+		{"execute select in a table with invalid fields using group by and having clause", "/%s/public/test_group_by_table?_select=pa,sum:pum&_groupby=pa->>having:sum:pmu:$eq:150", "GET", http.StatusBadRequest, ""},
 
-		{"execute select in a view with an other column", "/prest-test/public/view_test?_select=celphone", "GET", http.StatusBadRequest, ""},
-		{"execute select in a view with where and column invalid", "/prest-test/public/view_test?0celphone=$eq.888888", "GET", http.StatusBadRequest, ""},
-		{"execute select in a view with custom join clause invalid", "/prest-test/public/view_test?_join=inner:test2.name:eq:view_test.player", "GET", http.StatusBadRequest, ""},
-		{"execute select in a view with custom where clause and pagination invalid", "/prest-test/public/view_test?player=$eq.gopher&_page=A&_page_size=20", "GET", http.StatusBadRequest, ""},
-		{"execute select in a view with order by and column invalid", "/prest-test/public/view_test?_order=0celphone", "GET", http.StatusBadRequest, ""},
-		{"execute select in a view with count column invalid", "/prest-test/public/view_test?_count=0celphone", "GET", http.StatusBadRequest, ""},
+		{"execute select in a view with an other column", "/%s/public/view_test?_select=celphone", "GET", http.StatusBadRequest, ""},
+		{"execute select in a view with where and column invalid", "/%s/public/view_test?0celphone=$eq.888888", "GET", http.StatusBadRequest, ""},
+		{"execute select in a view with custom join clause invalid", "/%s/public/view_test?_join=inner:test2.name:eq:view_test.player", "GET", http.StatusBadRequest, ""},
+		{"execute select in a view with custom where clause and pagination invalid", "/%s/public/view_test?player=$eq.gopher&_page=A&_page_size=20", "GET", http.StatusBadRequest, ""},
+		{"execute select in a view with order by and column invalid", "/%s/public/view_test?_order=0celphone", "GET", http.StatusBadRequest, ""},
+		{"execute select in a view with count column invalid", "/%s/public/view_test?_count=0celphone", "GET", http.StatusBadRequest, ""},
 
 		{"execute select in a db that does not exist", "/invalid/public/view_test?_count=0celphone", "GET", http.StatusBadRequest, ""},
 	}
+	for _, db := range databases {
+		config.PrestConf.SingleDB = false
 
-	for _, tc := range testCases {
-		t.Log(tc.description)
-		//config.PrestConf = &config.Prest{}
-		//config.Load()
+		for _, tc := range testCases {
+			t.Log(fmt.Sprintf("(DB: %s) %s", db, tc.description))
+			//config.PrestConf = &config.Prest{}
+			//config.Load()
 
-		if tc.body != "" {
-			testutils.DoRequest(t, server.URL+tc.url, nil, tc.method, tc.status, "SelectFromTables", tc.body)
-			continue
+			if tc.body != "" {
+				testutils.DoRequest(t, fmt.Sprintf(server.URL+tc.url, db), nil, tc.method, tc.status, "SelectFromTables", tc.body)
+				continue
+			}
+			testutils.DoRequest(t, fmt.Sprintf(server.URL+tc.url, db), nil, tc.method, tc.status, "SelectFromTables")
 		}
-		testutils.DoRequest(t, server.URL+tc.url, nil, tc.method, tc.status, "SelectFromTables")
 	}
 }
 

--- a/testdata/runtest.sh
+++ b/testdata/runtest.sh
@@ -1,5 +1,6 @@
 DATABASES="$PREST_PG_DATABASE secondary-db"
 
+// Create databases for tests
 for db in $DATABASES; do
     echo "\n\n.:: POSTGRES: DROP/CREATE DATABASE $db"
     psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -c "DROP DATABASE IF EXISTS \"$db\";"

--- a/testdata/schema.sql
+++ b/testdata/schema.sql
@@ -1,6 +1,7 @@
 -- CREATE TABLES
 CREATE TABLE test(id serial, name text);
 CREATE TABLE "Reply"(id serial, name text);
+CREATE TABLE "TestCase"(id serial, name text);
 CREATE TABLE test2(name text, number integer);
 CREATE TABLE test3(id serial, name text UNIQUE);
 CREATE TABLE test4(id serial primary key, name text UNIQUE);
@@ -22,6 +23,7 @@ CREATE TABLE prest_users(id serial, username text, password text);
 -- Inserts
 INSERT INTO test (name) VALUES ('prest tester');
 INSERT INTO "Reply" (name) VALUES ('prest tester');
+INSERT INTO "TestCase" (name) VALUES ('prest tester');
 INSERT INTO test (name) VALUES ('tester02');
 INSERT INTO test2 (name, number) VALUES ('tester02', 2);
 INSERT INTO test3 (name) VALUES ('prest');


### PR DESCRIPTION
My use case targets pREST over multiple databases and initial attempt implementing it has been showing non-default databases (i.e. those in addition to `PREST_PG_DATABASE`) result in `not found in pool` error attempting to call database-aware endpoints (e.g. `/{DATABASE}/{SCHEMA}/{TABLE}`)

The PR is an (rather naive) attempt to make pREST work for the scenario:
- `adapters.postgres.AddDatabaseToPool(...)` now creates DB connection and adds it to the pool (previously, creating connection has been done only in `adapters.postgres.Get(...)`)
- `adapters.postgres.getDBFromCtx(...)` is extended to add DB connection to the pool if not found there, unless there is no DB name in the context - it will then return one set as current (via `adapters.SetDatabase(...)`)

Please note `/tables` and `/schemas` endpoints will still report entities from current database only - I didn't alter corresponding code to iterate over multiple databases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for handling multiple databases dynamically in test cases.
	- Added a new "TestCase" table to the database schema for enhanced testing capabilities.
- **Bug Fixes**
	- Updated test cases to align with the new database schema, ensuring accuracy and reliability of tests.
- **Refactor**
	- Refactored test cases to utilize context for dynamic database name handling, improving test flexibility and coverage.
- **Tests**
	- Enhanced testing infrastructure to support multiple databases, allowing for more comprehensive testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->