### PR TITLE
build: update go dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM registry.hub.docker.com/library/golang:1.19.5 as builder
+FROM registry.hub.docker.com/library/golang:1.22.2 as builder
 WORKDIR /workspace
 COPY . .
 ENV GOOS linux
 ENV CGO_ENABLED 1
 RUN go mod vendor && \
     go build -ldflags "-s -w" -o prestd cmd/prestd/main.go && \
-    apt-get update && apt-get install --no-install-recommends -yq netcat
+    apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -yq netcat-traditional && rm -rf /var/lib/apt/lists/*
 
 # Use golang image
 # needs go to compile the plugin system
-FROM registry.hub.docker.com/library/golang:1.19.5
+FROM registry.hub.docker.com/library/golang:1.22.2
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 ENV CGO_ENABLED 1
 COPY --from=builder /bin/nc /bin/nc
 COPY --from=builder /workspace/prestd /bin/prestd


### PR DESCRIPTION
This pr updates the go version used to build the docker image.

Currently, v1.19.x is which which is an eol release and already has several critical cves.

Please let me know if any question occur.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated to a newer version of the golang base image for improved performance and security.
	- Optimized package installation steps in the Docker setup to enhance security and reduce image size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->