### PR TITLE
Create a new image where plugins cannot be built at runtime

### DIFF
--- a/Dockerfile.noplugins
+++ b/Dockerfile.noplugins
@@ -1,0 +1,20 @@
+FROM registry.hub.docker.com/library/golang:1.22.2 as builder
+WORKDIR /workspace
+COPY . .
+ENV GOOS linux
+ENV CGO_ENABLED 1
+RUN go mod vendor && \
+    go build -ldflags "-s -w" -o prestd cmd/prestd/main.go && \
+    apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -yq netcat-traditional && rm -rf /var/lib/apt/lists/*
+
+# Use runtime image
+# Plugins not supported
+FROM registry.hub.docker.com/library/debian:bookworm
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /bin/nc /bin/nc
+COPY --from=builder /workspace/prestd /bin/prestd
+COPY --from=builder /workspace/etc/entrypoint.sh /app/entrypoint.sh
+COPY --from=builder /workspace/lib /app/lib
+COPY --from=builder /workspace/etc/plugin /app/plugin
+WORKDIR /app
+ENTRYPOINT ["sh", "/app/entrypoint.sh"]

--- a/scripts/docker-beta.sh
+++ b/scripts/docker-beta.sh
@@ -4,4 +4,6 @@
 # the beta tag in the github package (docker)
 git checkout . && \
     docker build . -t ghcr.io/prest/prest:beta && \
-    docker push ghcr.io/prest/prest:beta
+    docker push ghcr.io/prest/prest:beta && \
+    docker build . -f Dockerfile.noplugins -t ghcr.io/prest/prest:beta-noplugins && \
+    docker push ghcr.io/prest/prest:beta-noplugins

--- a/scripts/docker-gh-tag.sh
+++ b/scripts/docker-gh-tag.sh
@@ -2,9 +2,17 @@
 export DOCKER_TAG=${GITHUB_REF#refs/tags/}
 
 git checkout . && \
+    # Build the default image
     docker build . -t ghcr.io/prest/prest:latest && \
     docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:v1 && \
     docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:$DOCKER_TAG && \
     docker push ghcr.io/prest/prest:latest && \
     docker push ghcr.io/prest/prest:v1 && \
-    docker push ghcr.io/prest/prest:$DOCKER_TAG
+    docker push ghcr.io/prest/prest:$DOCKER_TAG && \
+    # Build the noplugins image
+    docker build . -f Dockerfile.noplugins -t ghcr.io/prest/prest:latest-noplugins && \
+    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:v1-noplugins && \
+    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:$DOCKER_TAG-noplugins && \
+    docker push ghcr.io/prest/prest:latest-noplugins && \
+    docker push ghcr.io/prest/prest:v1-noplugins && \
+    docker push ghcr.io/prest/prest:$DOCKER_TAG-noplugins

--- a/scripts/docker-gh-tag.sh
+++ b/scripts/docker-gh-tag.sh
@@ -5,14 +5,14 @@ git checkout . && \
     # Build the default image
     docker build . -t ghcr.io/prest/prest:latest && \
     docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:v1 && \
-    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:$DOCKER_TAG && \
+    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:"$DOCKER_TAG" && \
     docker push ghcr.io/prest/prest:latest && \
     docker push ghcr.io/prest/prest:v1 && \
-    docker push ghcr.io/prest/prest:$DOCKER_TAG && \
+    docker push ghcr.io/prest/prest:"$DOCKER_TAG" && \
     # Build the noplugins image
     docker build . -f Dockerfile.noplugins -t ghcr.io/prest/prest:latest-noplugins && \
     docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:v1-noplugins && \
-    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:$DOCKER_TAG-noplugins && \
+    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:"$DOCKER_TAG"-noplugins && \
     docker push ghcr.io/prest/prest:latest-noplugins && \
     docker push ghcr.io/prest/prest:v1-noplugins && \
-    docker push ghcr.io/prest/prest:$DOCKER_TAG-noplugins
+    docker push ghcr.io/prest/prest:"$DOCKER_TAG"-noplugins

--- a/scripts/docker-gh-tag.sh
+++ b/scripts/docker-gh-tag.sh
@@ -10,9 +10,9 @@ git checkout . && \
     docker push ghcr.io/prest/prest:v1 && \
     docker push ghcr.io/prest/prest:"$DOCKER_TAG" && \
     # Build the noplugins image
-    docker build . -f Dockerfile.noplugins -t ghcr.io/prest/prest:latest-noplugins && \
-    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:v1-noplugins && \
-    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:"$DOCKER_TAG"-noplugins && \
-    docker push ghcr.io/prest/prest:latest-noplugins && \
-    docker push ghcr.io/prest/prest:v1-noplugins && \
-    docker push ghcr.io/prest/prest:"$DOCKER_TAG"-noplugins
+    docker build . -f Dockerfile.noplugins -t ghcr.io/prest/prest:"latest-noplugins" && \
+    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:"v1-noplugins" && \
+    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:"$DOCKER_TAG-noplugins" && \
+    docker push ghcr.io/prest/prest:"latest-noplugins" && \
+    docker push ghcr.io/prest/prest:"v1-noplugins" && \
+    docker push ghcr.io/prest/prest:"$DOCKER_TAG-noplugins"

--- a/scripts/docker-hub-tag.sh
+++ b/scripts/docker-hub-tag.sh
@@ -2,12 +2,14 @@
 export DOCKER_TAG=${GITHUB_REF#refs/tags/}
 
 git checkout . && \
+    # Build the default image
     docker build . -t prest/prest:latest && \
     docker tag prest/prest:latest prest/prest:"$DOCKER_TAG" && \
     docker tag prest/prest:latest prest/prest:v1 && \
     docker push prest/prest:latest && \
     docker push prest/prest:v1 && \
     docker push prest/prest:"$DOCKER_TAG" && \
+    # Build the noplugins image
     docker build . -f Dockerfile.noplugins -t prest/prest:latest-noplugins && \
     docker tag prest/prest:latest prest/prest:"$DOCKER_TAG"-noplugins && \
     docker tag prest/prest:latest prest/prest:v1-noplugins && \

--- a/scripts/docker-hub-tag.sh
+++ b/scripts/docker-hub-tag.sh
@@ -10,9 +10,9 @@ git checkout . && \
     docker push prest/prest:v1 && \
     docker push prest/prest:"$DOCKER_TAG" && \
     # Build the noplugins image
-    docker build . -f Dockerfile.noplugins -t prest/prest:latest-noplugins && \
-    docker tag prest/prest:latest prest/prest:"$DOCKER_TAG"-noplugins && \
-    docker tag prest/prest:latest prest/prest:v1-noplugins && \
-    docker push prest/prest:latest-noplugins && \
-    docker push prest/prest:v1-noplugins && \
-    docker push prest/prest:"$DOCKER_TAG"-noplugins
+    docker build . -f Dockerfile.noplugins -t prest/prest:"latest-noplugins" && \
+    docker tag prest/prest:latest prest/prest:"$DOCKER_TAG-noplugins" && \
+    docker tag prest/prest:latest prest/prest:"v1-noplugins" && \
+    docker push prest/prest:"latest-noplugins" && \
+    docker push prest/prest:"v1-noplugins" && \
+    docker push prest/prest:"$DOCKER_TAG-noplugins"

--- a/scripts/docker-hub-tag.sh
+++ b/scripts/docker-hub-tag.sh
@@ -3,14 +3,14 @@ export DOCKER_TAG=${GITHUB_REF#refs/tags/}
 
 git checkout . && \
     docker build . -t prest/prest:latest && \
-    docker tag prest/prest:latest prest/prest:$DOCKER_TAG && \
+    docker tag prest/prest:latest prest/prest:"$DOCKER_TAG" && \
     docker tag prest/prest:latest prest/prest:v1 && \
     docker push prest/prest:latest && \
     docker push prest/prest:v1 && \
-    docker push prest/prest:$DOCKER_TAG && \
+    docker push prest/prest:"$DOCKER_TAG" && \
     docker build . -f Dockerfile.noplugins -t prest/prest:latest-noplugins && \
-    docker tag prest/prest:latest prest/prest:$DOCKER_TAG-noplugins && \
+    docker tag prest/prest:latest prest/prest:"$DOCKER_TAG"-noplugins && \
     docker tag prest/prest:latest prest/prest:v1-noplugins && \
     docker push prest/prest:latest-noplugins && \
     docker push prest/prest:v1-noplugins && \
-    docker push prest/prest:$DOCKER_TAG-noplugins
+    docker push prest/prest:"$DOCKER_TAG"-noplugins

--- a/scripts/docker-hub-tag.sh
+++ b/scripts/docker-hub-tag.sh
@@ -7,4 +7,10 @@ git checkout . && \
     docker tag prest/prest:latest prest/prest:v1 && \
     docker push prest/prest:latest && \
     docker push prest/prest:v1 && \
-    docker push prest/prest:$DOCKER_TAG
+    docker push prest/prest:$DOCKER_TAG && \
+    docker build . -f Dockerfile.noplugins -t prest/prest:latest-noplugins && \
+    docker tag prest/prest:latest prest/prest:$DOCKER_TAG-noplugins && \
+    docker tag prest/prest:latest prest/prest:v1-noplugins && \
+    docker push prest/prest:latest-noplugins && \
+    docker push prest/prest:v1-noplugins && \
+    docker push prest/prest:$DOCKER_TAG-noplugins


### PR DESCRIPTION
The current release image of prestd is using an image whose purpose is to compile go code. That image contains a lot of build dependencies that may contain security vulnerabilities.

This pull request fixes that issue by creating a new pRest image using a debian image as the runtime image. The version of the debian image is the same version used for the base of the golang:1.22.2 image. Users of that image will not be able to dynamically compile plugins at runtime (they will need to create a multi-stage build and copy the plugins in the prest-noplugins image).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Dockerfile configuration for building a container image without plugin support.
  - Added functionality to build and push Docker images tagged as `beta-noplugins`, `latest-noplugins`, and other `-noplugins` tags.

- **Chores**
  - Expanded existing scripts to support new Docker image tags for images without plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->