### PR TITLE
Suppress error messages when the image cannot be used to build plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN go mod vendor && \
 FROM registry.hub.docker.com/library/golang:1.22.2
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 ENV CGO_ENABLED 1
+ENV PREST_BUILD_PLUGINS 1
 COPY --from=builder /bin/nc /bin/nc
 COPY --from=builder /workspace/prestd /bin/prestd
 COPY --from=builder /workspace/etc/entrypoint.sh /app/entrypoint.sh

--- a/Dockerfile.noplugins
+++ b/Dockerfile.noplugins
@@ -11,6 +11,7 @@ RUN go mod vendor && \
 # Plugins not supported
 FROM registry.hub.docker.com/library/debian:bookworm
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+ENV PREST_BUILD_PLUGINS 0
 COPY --from=builder /bin/nc /bin/nc
 COPY --from=builder /workspace/prestd /bin/prestd
 COPY --from=builder /workspace/etc/entrypoint.sh /app/entrypoint.sh

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -30,9 +30,14 @@ do
 done
 
 # prestd/plugin build
-echo "[prestd] Plugin/build: starting..."
-./plugin/go-build.sh
-echo "[prestd] Plugin/build: ending"
+if [ "$PREST_BUILD_PLUGINS" -eq 1 ];
+then
+    echo "[prestd] Plugin/build: starting..."
+    ./plugin/go-build.sh
+    echo "[prestd] Plugin/build: ending"
+else
+    echo "[prestd] Skipping plugin/build"
+fi
 
 sleep 5;
 echo "[prestd] Ready hosting $PREST_PG_HOST to port $PREST_PG_PORT !"


### PR DESCRIPTION
This change follow pull request #883. The new image created by the new Dockerfile is working correctly, but there's an error message displayed in the logs when the container is starting:
```
[prestd] Plugin/build: starting...
[prestd] Go build simple plugins in only file!
go build: hello plugin...
./plugin/go-build.sh: line 8: go: command not found <-- Here
[prestd] Go build complex plugins in folder (with main.go file)!
[prestd] Plugin/build: ending
```

The change add a new environment variable to determine if we should build the plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to control plugin building via the `PREST_BUILD_PLUGINS` environment variable.

- **Enhancements**
  - Dockerfile now includes the `PREST_BUILD_PLUGINS` environment variable for better plugin management.
  - `Dockerfile.noplugins` now explicitly disables plugin support and uses a Debian Bookworm base image.

- **Improvements**
  - Enhanced the entrypoint script to conditionally execute plugin building based on the `PREST_BUILD_PLUGINS` variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->