### PR TITLE
Fix: the noplugins images were incorrectly tagged (v1 and $DOCKER_TAG)

### DIFF
--- a/scripts/docker-gh-tag.sh
+++ b/scripts/docker-gh-tag.sh
@@ -11,8 +11,8 @@ git checkout . && \
     docker push ghcr.io/prest/prest:"$DOCKER_TAG" && \
     # Build the noplugins image
     docker build . -f Dockerfile.noplugins -t ghcr.io/prest/prest:"latest-noplugins" && \
-    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:"v1-noplugins" && \
-    docker tag ghcr.io/prest/prest:latest ghcr.io/prest/prest:"$DOCKER_TAG-noplugins" && \
+    docker tag ghcr.io/prest/prest:"latest-noplugins" ghcr.io/prest/prest:"v1-noplugins" && \
+    docker tag ghcr.io/prest/prest:"latest-noplugins" ghcr.io/prest/prest:"$DOCKER_TAG-noplugins" && \
     docker push ghcr.io/prest/prest:"latest-noplugins" && \
     docker push ghcr.io/prest/prest:"v1-noplugins" && \
     docker push ghcr.io/prest/prest:"$DOCKER_TAG-noplugins"

--- a/scripts/docker-hub-tag.sh
+++ b/scripts/docker-hub-tag.sh
@@ -11,8 +11,8 @@ git checkout . && \
     docker push prest/prest:"$DOCKER_TAG" && \
     # Build the noplugins image
     docker build . -f Dockerfile.noplugins -t prest/prest:"latest-noplugins" && \
-    docker tag prest/prest:latest prest/prest:"$DOCKER_TAG-noplugins" && \
-    docker tag prest/prest:latest prest/prest:"v1-noplugins" && \
+    docker tag prest/prest:"latest-noplugins" prest/prest:"$DOCKER_TAG-noplugins" && \
+    docker tag prest/prest:"latest-noplugins" prest/prest:"v1-noplugins" && \
     docker push prest/prest:"latest-noplugins" && \
     docker push prest/prest:"v1-noplugins" && \
     docker push prest/prest:"$DOCKER_TAG-noplugins"


### PR DESCRIPTION
There was a small error in the tag and push script added in pull request #883. The images tagged v1-noplugins and 1.5.3-noplugins are in fact the same image as v1 and 1.5.3, because the source tag used to create these tags was the wrong one.

This new pull request fixes the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker image tagging scripts for consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->