### PR TITLE
fix(postgres): improve `_returning` param handling for SQL injection safety

### DIFF
--- a/adapters/postgres/queries.go
+++ b/adapters/postgres/queries.go
@@ -65,6 +65,7 @@ func (adapter *Postgres) ParseScript(scriptPath string, templateData map[string]
 	}
 
 	sqlQuery = buff.String()
+	values = funcs.Args
 	return
 }
 

--- a/template/funcregistry.go
+++ b/template/funcregistry.go
@@ -3,6 +3,7 @@ package template
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -11,6 +12,8 @@ import (
 // FuncRegistry registry func for templates
 type FuncRegistry struct {
 	TemplateData map[string]interface{}
+	Args         []interface{}
+	next         int
 }
 
 // RegistryAllFuncs for template
@@ -22,6 +25,10 @@ func (fr *FuncRegistry) RegistryAllFuncs() (funcs template.FuncMap) {
 		"unEscape":       fr.unEscape,
 		"split":          fr.split,
 		"limitOffset":    fr.limitOffset,
+		// secure SQL helpers
+		"sqlVal":         fr.sqlVal,
+		"sqlList":        fr.sqlList,
+		"ident":          fr.ident,
 	}
 	return
 }
@@ -82,4 +89,43 @@ func (fr *FuncRegistry) limitOffset(pageNumber, pageSize string) (value string) 
 		value = ""
 	}
 	return
+}
+
+// sqlVal returns a positional placeholder for a single value and stores it in Args
+func (fr *FuncRegistry) sqlVal(key string) string {
+	v := fr.TemplateData[key]
+	fr.Args = append(fr.Args, v)
+	fr.next++
+	return fmt.Sprintf("$%d", fr.next)
+}
+
+// sqlList returns a parenthesized, comma-separated list of placeholders for a slice value
+func (fr *FuncRegistry) sqlList(key string) string {
+	if s, ok := fr.TemplateData[key].([]string); ok {
+		ph := make([]string, len(s))
+		for i := range s {
+			fr.Args = append(fr.Args, s[i])
+			fr.next++
+			ph[i] = fmt.Sprintf("$%d", fr.next)
+		}
+		return fmt.Sprintf("(%s)", strings.Join(ph, ","))
+	}
+	fr.Args = append(fr.Args, fr.TemplateData[key])
+	fr.next++
+	return fmt.Sprintf("($%d)", fr.next)
+}
+
+var identRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$`)
+
+// ident validates and safely quotes an identifier (optionally dotted path)
+func (fr *FuncRegistry) ident(key string) (string, error) {
+	s, _ := fr.TemplateData[key].(string)
+	if !identRe.MatchString(s) {
+		return "", fmt.Errorf("invalid identifier: %s", s)
+	}
+	parts := strings.Split(s, ".")
+	for i := range parts {
+		parts[i] = `"` + parts[i] + `"`
+	}
+	return strings.Join(parts, "."), nil
 }


### PR DESCRIPTION
- Refactored `ReturningByRequest` to properly quote identifiers in the `_returning` query param, preventing SQL injection.
- Now supports dot notation _(e.g., `schema.table.column`)_ by quoting each part.
- Returns error if invalid identifier is detected.
- Adds test coverage for new behavior.

Refs [#GHSA-p46v-f2x8-qp98](https://github.com/advisories/GHSA-p46v-f2x8-qp98)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Parameterized SQL templating: templates now emit placeholders and provide bound argument lists.
  - RETURNING clause builder supports “*” and automatically quotes identifiers, including dotted paths.

- Bug Fixes
  - Safer GROUP BY … HAVING handling with proper escaping of string values.
  - Validation of JOIN types to prevent invalid joins, with clear errors.
  - Query parsing now returns collected parameter values alongside the SQL text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->