### PR TITLE
ci(test): run test suite via docker-compose-test.yml and document usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,86 +4,29 @@ run-name: test code
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    environment: build
-    container: golang:latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: /__w/prest/prest
-    env:
-      PREST_PG_HOST: postgres
-      PREST_PG_DATABASE: prest-test
-      PREST_PG_USER: postgres
-      PREST_PG_PASS: postgres
-      PREST_PG_PORT: 5432
-      PREST_SSL_MODE: disable
-      PREST_CONF: /__w/prest/prest/testdata/prest.toml
-      PREST_MIGRATIONS: /__w/prest/prest/testdata/migrations
-      PREST_QUERIES_LOCATION: /__w/prest/prest/testdata/queries
-      BE_CRASHER: 1
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
-    services:
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: prest-test
-          POSTGRES_PORT: 5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install PostgreSQL client
-        run: |
-          apt-get update
-          apt-get install -y postgresql-client
+      - name: Run tests via docker compose
+        run: docker compose -f docker-compose-test.yml up --abort-on-container-exit --exit-code-from tests
 
-      - name: Setup Databases
-        env:
-          PGPASSWORD: postgres
-        run: |
-          for db in $PREST_PG_DATABASE secondary-db; do
-            psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -c "DROP DATABASE IF EXISTS \"$db\";"
-            psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -c "CREATE DATABASE \"$db\";"
-            psql -h $PREST_PG_HOST -p $PREST_PG_PORT -U $PREST_PG_USER -d $db -f ./testdata/schema.sql
-          done
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ^1.23
-      - run: go version
-
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: pREST Test
-        run: |
-          env go run ./cmd/prestd/main.go migrate up
-          env go test -v -race -covermode=atomic -coverprofile=./coverage.out ./...
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose-test.yml down -v --remove-orphans
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
-          file: ./coverage.out
+          files: ./coverage.out

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_COMPOSE?=docker-compose -f docker-compose.yml
 
-PHONY: build_test_image
+.PHONY: build_test_image
 build_test_image:
 	$(DOCKER_COMPOSE) run --rm postgres -d
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 DOCKER_COMPOSE?=docker-compose -f docker-compose.yml
 
-PHONY: build_test_image 
+PHONY: build_test_image
 build_test_image:
 	$(DOCKER_COMPOSE) run --rm postgres -d
 
 PHONY: test
 test:
-	$(DOCKER_COMPOSE) -f testdata/docker-compose.yml up --abort-on-container-exit --remove-orphans
+	docker compose -f docker-compose-test.yml up --abort-on-container-exit --exit-code-from tests
+	docker compose -f docker-compose-test.yml down -v --remove-orphans
 
 PHONY: dc-up
 dc-up:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PHONY: build_test_image
 build_test_image:
 	$(DOCKER_COMPOSE) run --rm postgres -d
 
-PHONY: test
+.PHONY: test
 test:
 	docker compose -f docker-compose-test.yml up --abort-on-container-exit --exit-code-from tests
 	docker compose -f docker-compose-test.yml down -v --remove-orphans

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pRESTd
+
 [![Tests](https://github.com/prest/prest/actions/workflows/test.yml/badge.svg)](https://github.com/prest/prest/actions/workflows/test.yml)
 [![GoDoc](https://godoc.org/github.com/prest/prest?status.png)](https://godoc.org/github.com/prest/prest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/prest/prest)](https://goreportcard.com/report/github.com/prest/prest)
@@ -45,4 +46,21 @@ Deploy to Heroku and instantly get a realtime RESTFul API backed by Heroku Postg
 
 ## Documentation
 
-Visit https://docs.prestd.com/
+Visit <https://docs.prestd.com/>
+
+## Testing
+
+Run the test suite inside Docker (no local Postgres required):
+
+```bash
+make test
+```
+
+Or directly with Docker Compose:
+
+```bash
+docker compose -f docker-compose-test.yml up --abort-on-container-exit --exit-code-from tests
+docker compose -f docker-compose-test.yml down -v --remove-orphans
+```
+
+The `tests` service runs `./testdata/runtest.sh`, provisioning databases and executing Go tests [[memory:8772187]].

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ docker compose -f docker-compose-test.yml up --abort-on-container-exit --exit-co
 docker compose -f docker-compose-test.yml down -v --remove-orphans
 ```
 
-The `tests` service runs `./testdata/runtest.sh`, provisioning databases and executing Go tests [[memory:8772187]].
+The `tests` service runs `./testdata/runtest.sh`, provisioning databases and executing Go tests.

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,40 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  tests:
+    image: golang:1.23-bookworm
+    working_dir: /workspace
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - PREST_CONF=/workspace/testdata/prest.toml
+      - PREST_MIGRATIONS=/workspace/testdata/migrations
+      - PREST_QUERIES_LOCATION=/workspace/testdata/queries
+      - PREST_PG_HOST=postgres
+      - PREST_PG_PORT=5432
+      - PREST_PG_USER=postgres
+      - PREST_PG_PASS=postgres
+      - PREST_PG_DATABASE=prest-test
+      - PGPASSWORD=postgres
+      - GOTOOLCHAIN=auto
+      - GOPROXY=https://proxy.golang.org,direct
+      - BE_CRASHER=1
+    volumes:
+      - ./:/workspace
+    command: >-
+      bash -lc "apt-get update && apt-get install -y --no-install-recommends postgresql-client git ca-certificates && bash -x ./testdata/runtest.sh"


### PR DESCRIPTION
simplify the life of maintaining CI and how to run local tests with the same configuration

- Add tmpfs to Postgres in docker-compose-test.yml for ephemeral storage and clean teardown
- Update Makefile `test` target to run docker compose with `--exit-code-from tests` and `down -v`
- Add “Testing” section to README with `make test` and compose commands; fix docs URL formatting
- Refactor GitHub Actions workflow to use docker-compose-test.yml, propagate test exit code, and teardown
- Remove containerized Go runner/PSQL bootstrap from workflow; simplify steps
- Minor YAML quoting consistency in workflow
- Aligns test flow across local and CI; no local Postgres required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None
- Tests
  - Unified test execution into a single Docker Compose flow with explicit up/down lifecycle and exit-code handling.
  - Tests now wait for the database to be healthy before running and perform automatic cleanup.
  - Makefile test target updated to invoke the Docker Compose-based flow.
- Documentation
  - Added badges and a Testing section describing the Makefile and Docker Compose test commands.
- Chores
  - Streamlined CI to a minimal permissions-based workflow and updated coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->