### PR TITLE
feat: Allow for an OR clause

### DIFF
--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -354,7 +354,8 @@ func (adapter *Postgres) whereKeyAndValue(rawKey, v string, pid *int) (key strin
 				err = errors.Wrapf(ErrInvalidIdentifier, "%s", keyInfo[0])
 				return
 			}
-			*pid++
+			err = errors.Errorf("unknown type suffix: %s", keyInfo[1])
+			return
 		}
 		return
 	}

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -234,8 +234,7 @@ func (adapter *Postgres) WhereByRequest(r *http.Request, initialPlaceholderID in
 				if v == "" {
 					continue
 				}
-				// split only on explicit "||" separator to avoid mutating operator values
-				parts := strings.Split(v, "||")
+				parts := splitTopLevelOrGroup(v)
 				for _, part := range parts {
 					part = strings.TrimSpace(part)
 					if part == "" {
@@ -281,19 +280,133 @@ func (adapter *Postgres) WhereByRequest(r *http.Request, initialPlaceholderID in
 	return
 }
 
+func splitTopLevelOrGroup(v string) []string {
+	parts := make([]string, 0)
+	var current strings.Builder
+
+	inSingleQuote := false
+	inDoubleQuote := false
+
+	flush := func() {
+		part := strings.TrimSpace(current.String())
+		if part != "" {
+			parts = append(parts, part)
+		}
+		current.Reset()
+	}
+
+	for i := 0; i < len(v); {
+		ch := v[i]
+
+		if inSingleQuote {
+			current.WriteByte(ch)
+			if ch == '\'' {
+				if i+1 < len(v) && v[i+1] == '\'' {
+					current.WriteByte(v[i+1])
+					i += 2
+					continue
+				}
+				inSingleQuote = false
+			}
+			i++
+			continue
+		}
+
+		if inDoubleQuote {
+			current.WriteByte(ch)
+			if ch == '"' {
+				if i+1 < len(v) && v[i+1] == '"' {
+					current.WriteByte(v[i+1])
+					i += 2
+					continue
+				}
+				inDoubleQuote = false
+			}
+			i++
+			continue
+		}
+
+		if isTopLevelLegacySeparator(v, i) {
+			flush()
+			i += 2
+			continue
+		}
+
+		if ch == '\'' {
+			inSingleQuote = true
+			current.WriteByte(ch)
+			i++
+			continue
+		}
+
+		if ch == '"' {
+			inDoubleQuote = true
+			current.WriteByte(ch)
+			i++
+			continue
+		}
+
+		if isTopLevelOrSeparator(v, i) {
+			flush()
+			i += 2
+			for i < len(v) && isWhitespace(v[i]) {
+				i++
+			}
+			continue
+		}
+
+		current.WriteByte(ch)
+		i++
+	}
+
+	flush()
+	return parts
+}
+
+func isTopLevelOrSeparator(v string, i int) bool {
+	if i+1 >= len(v) {
+		return false
+	}
+
+	if !strings.EqualFold(v[i:i+2], "OR") {
+		return false
+	}
+
+	if i > 0 && !isWhitespace(v[i-1]) {
+		return false
+	}
+
+	if i+2 >= len(v) || !isWhitespace(v[i+2]) {
+		return false
+	}
+
+	return true
+}
+
+func isTopLevelLegacySeparator(v string, i int) bool {
+	return i+1 < len(v) && v[i] == '|' && v[i+1] == '|'
+}
+
+func isWhitespace(b byte) bool {
+	return unicode.IsSpace(rune(b))
+}
+
 func (adapter *Postgres) whereKeyAndValue(rawKey, v string, pid *int) (key string, values []interface{}, err error) {
 	var value, op string
-	if v != "" {
-		op = removeOperatorRegex.FindString(v)
-		op = strings.Replace(op, ".", "", -1)
-		if op == "" {
-			op = "$eq"
-		}
-		value = removeOperatorRegex.ReplaceAllString(v, "")
-		op, err = GetQueryOperator(op)
-		if err != nil {
-			return
-		}
+	if v == "" {
+		err = ErrInvalidOperator
+		return
+	}
+
+	op = removeOperatorRegex.FindString(v)
+	op = strings.Replace(op, ".", "", -1)
+	if op == "" {
+		op = "$eq"
+	}
+	value = removeOperatorRegex.ReplaceAllString(v, "")
+	op, err = GetQueryOperator(op)
+	if err != nil {
+		return
 	}
 
 	keyInfo := strings.Split(rawKey, ":")

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -234,9 +234,7 @@ func (adapter *Postgres) WhereByRequest(r *http.Request, initialPlaceholderID in
 				if v == "" {
 					continue
 				}
-				// support both "||" and " OR " as separators without splitting operator values
-				v = strings.ReplaceAll(v, " OR ", "||")
-				v = strings.ReplaceAll(v, " or ", "||")
+				// split only on explicit "||" separator to avoid mutating operator values
 				parts := strings.Split(v, "||")
 				for _, part := range parts {
 					part = strings.TrimSpace(part)
@@ -312,8 +310,28 @@ func (adapter *Postgres) whereKeyAndValue(rawKey, v string, pid *int) (key strin
 			jsonField[0] = fmt.Sprintf(`"%s"`, strings.Join(fields, `"."`))
 			// escape single quotes in json attribute key
 			safeAttr := strings.ReplaceAll(jsonField[1], "'", "''")
-			key = fmt.Sprintf(`%s->>'%s' %s $%d`, jsonField[0], safeAttr, op, *pid)
-			values = append(values, value)
+			jsonLeft := fmt.Sprintf(`%s->>'%s'`, jsonField[0], safeAttr)
+			switch op {
+			case "IN", "NOT IN":
+				v := strings.Split(value, ",")
+				keyParams := make([]string, len(v))
+				for i := 0; i < len(v); i++ {
+					values = append(values, v[i])
+					keyParams[i] = fmt.Sprintf(`$%d`, *pid+i)
+				}
+				*pid += len(v)
+				key = fmt.Sprintf(`%s %s (%s)`, jsonLeft, op, strings.Join(keyParams, ","))
+			case "ANY", "SOME", "ALL":
+				key = fmt.Sprintf(`%s = %s ($%d)`, jsonLeft, op, *pid)
+				values = append(values, formatters.FormatArray(strings.Split(value, ",")))
+				*pid++
+			case "IS NULL", "IS NOT NULL", "IS TRUE", "IS NOT TRUE", "IS FALSE", "IS NOT FALSE":
+				key = fmt.Sprintf(`%s %s`, jsonLeft, op)
+			default: // "=", "!=", ">", ">=", "<", "<="
+				key = fmt.Sprintf(`%s %s $%d`, jsonLeft, op, *pid)
+				values = append(values, value)
+				*pid++
+			}
 		case "tsquery":
 			tsQueryField := strings.Split(keyInfo[0], "$")
 			if !ident.IsValid(tsQueryField[0]) {
@@ -336,8 +354,8 @@ func (adapter *Postgres) whereKeyAndValue(rawKey, v string, pid *int) (key strin
 				err = errors.Wrapf(ErrInvalidIdentifier, "%s", keyInfo[0])
 				return
 			}
+			*pid++
 		}
-		*pid++
 		return
 	}
 

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -208,8 +208,8 @@ func chkInvalidIdentifier(identifier ...string) bool {
 // WhereByRequest create interface for queries + where
 func (adapter *Postgres) WhereByRequest(r *http.Request, initialPlaceholderID int) (whereSyntax string, values []interface{}, err error) {
 	whereKey := []string{}
-	whereValues := []string{}
-	var value, op string
+	whereValues := []interface{}{}
+	orClauses := []string{}
 
 	pid := initialPlaceholderID
 	for key, val := range r.URL.Query() {
@@ -217,94 +217,58 @@ func (adapter *Postgres) WhereByRequest(r *http.Request, initialPlaceholderID in
 			// keep the original key untouched to avoid invalid identifier errors
 			rawKey := key
 			for _, v := range val {
-				if v != "" {
-					op = removeOperatorRegex.FindString(v)
-					op = strings.Replace(op, ".", "", -1)
-					if op == "" {
-						op = "$eq"
+				var k string
+				var vls []interface{}
+				k, vls, err = adapter.whereKeyAndValue(rawKey, v, &pid)
+				if err != nil {
+					return
+				}
+				if k != "" {
+					whereKey = append(whereKey, k)
+					whereValues = append(whereValues, vls...)
+				}
+			}
+		} else if key == "_or" {
+			for _, v := range val {
+				v = strings.TrimSpace(v)
+				if v == "" {
+					continue
+				}
+				// support both "||" and " OR " as separators without splitting operator values
+				v = strings.ReplaceAll(v, " OR ", "||")
+				v = strings.ReplaceAll(v, " or ", "||")
+				parts := strings.Split(v, "||")
+				for _, part := range parts {
+					part = strings.TrimSpace(part)
+					if part == "" {
+						continue
 					}
-					value = removeOperatorRegex.ReplaceAllString(v, "")
-					op, err = GetQueryOperator(op)
+					// part is expected to be field=condition
+					// we look for the first "="
+					pos := strings.Index(part, "=")
+					if pos <= 0 {
+						continue
+					}
+					field := part[:pos]
+					condition := part[pos+1:]
+
+					var k string
+					var vls []interface{}
+					k, vls, err = adapter.whereKeyAndValue(field, condition, &pid)
 					if err != nil {
 						return
 					}
-				}
-
-				keyInfo := strings.Split(rawKey, ":")
-
-				if len(keyInfo) > 1 {
-					switch keyInfo[1] {
-					case "jsonb":
-						jsonField := strings.Split(keyInfo[0], "->>")
-						if len(jsonField) != 2 || !ident.IsValid(jsonField[0]) || !ident.IsValid(jsonField[1]) {
-							err = errors.Wrapf(ErrInvalidIdentifier, "%v", jsonField)
-							return
-						}
-						fields := strings.Split(jsonField[0], ".")
-						jsonField[0] = fmt.Sprintf(`"%s"`, strings.Join(fields, `"."`))
-						// escape single quotes in json attribute key
-						safeAttr := strings.ReplaceAll(jsonField[1], "'", "''")
-						whereKey = append(whereKey, fmt.Sprintf(`%s->>'%s' %s $%d`, jsonField[0], safeAttr, op, pid))
-						values = append(values, value)
-					case "tsquery":
-						tsQueryField := strings.Split(keyInfo[0], "$")
-						if !ident.IsValid(tsQueryField[0]) {
-							err = errors.Wrapf(ErrInvalidIdentifier, "%s", tsQueryField[0])
-							return
-						}
-						safeVal := strings.ReplaceAll(value, "'", "''")
-						tsQuery := fmt.Sprintf(`%s @@ to_tsquery('%s')`, tsQueryField[0], safeVal)
-						if len(tsQueryField) == 2 {
-							if !ident.IsValid(tsQueryField[1]) {
-								err = errors.Wrapf(ErrInvalidIdentifier, "%s", tsQueryField[1])
-								return
-							}
-							safeCfg := strings.ReplaceAll(tsQueryField[1], "'", "''")
-							tsQuery = fmt.Sprintf(`%s @@ to_tsquery('%s', '%s')`, tsQueryField[0], safeCfg, safeVal)
-						}
-						whereKey = append(whereKey, tsQuery)
-					default:
-						if !ident.IsValid(keyInfo[0]) {
-							err = errors.Wrapf(ErrInvalidIdentifier, "%s", keyInfo[0])
-							return
-						}
+					if k != "" {
+						orClauses = append(orClauses, k)
+						whereValues = append(whereValues, vls...)
 					}
-					pid++
-					continue
-				}
-
-				if !ident.IsValid(rawKey) {
-					err = errors.Wrapf(ErrInvalidIdentifier, "%s", rawKey)
-					return
-				}
-
-				// always quote the field for SQL usage without mutating the original key
-				fields := strings.Split(rawKey, ".")
-				quotedKey := fmt.Sprintf(`"%s"`, strings.Join(fields, `"."`))
-
-				switch op {
-				case "IN", "NOT IN":
-					v := strings.Split(value, ",")
-					keyParams := make([]string, len(v))
-					for i := 0; i < len(v); i++ {
-						whereValues = append(whereValues, v[i])
-						keyParams[i] = fmt.Sprintf(`$%d`, pid+i)
-					}
-					pid += len(v)
-					whereKey = append(whereKey, fmt.Sprintf(`%s %s (%s)`, quotedKey, op, strings.Join(keyParams, ",")))
-				case "ANY", "SOME", "ALL":
-					whereKey = append(whereKey, fmt.Sprintf(`%s = %s ($%d)`, quotedKey, op, pid))
-					whereValues = append(whereValues, formatters.FormatArray(strings.Split(value, ",")))
-					pid++
-				case "IS NULL", "IS NOT NULL", "IS TRUE", "IS NOT TRUE", "IS FALSE", "IS NOT FALSE":
-					whereKey = append(whereKey, fmt.Sprintf(`%s %s`, quotedKey, op))
-				default: // "=", "!=", ">", ">=", "<", "<="
-					whereKey = append(whereKey, fmt.Sprintf(`%s %s $%d`, quotedKey, op, pid))
-					whereValues = append(whereValues, value)
-					pid++
 				}
 			}
 		}
+	}
+
+	if len(orClauses) > 0 {
+		whereKey = append(whereKey, fmt.Sprintf("(%s)", strings.Join(orClauses, " OR ")))
 	}
 
 	for i := 0; i < len(whereKey); i++ {
@@ -315,8 +279,97 @@ func (adapter *Postgres) WhereByRequest(r *http.Request, initialPlaceholderID in
 		}
 	}
 
-	for i := 0; i < len(whereValues); i++ {
-		values = append(values, whereValues[i])
+	values = append(values, whereValues...)
+	return
+}
+
+func (adapter *Postgres) whereKeyAndValue(rawKey, v string, pid *int) (key string, values []interface{}, err error) {
+	var value, op string
+	if v != "" {
+		op = removeOperatorRegex.FindString(v)
+		op = strings.Replace(op, ".", "", -1)
+		if op == "" {
+			op = "$eq"
+		}
+		value = removeOperatorRegex.ReplaceAllString(v, "")
+		op, err = GetQueryOperator(op)
+		if err != nil {
+			return
+		}
+	}
+
+	keyInfo := strings.Split(rawKey, ":")
+
+	if len(keyInfo) > 1 {
+		switch keyInfo[1] {
+		case "jsonb":
+			jsonField := strings.Split(keyInfo[0], "->>")
+			if len(jsonField) != 2 || !ident.IsValid(jsonField[0]) || !ident.IsValid(jsonField[1]) {
+				err = errors.Wrapf(ErrInvalidIdentifier, "%v", jsonField)
+				return
+			}
+			fields := strings.Split(jsonField[0], ".")
+			jsonField[0] = fmt.Sprintf(`"%s"`, strings.Join(fields, `"."`))
+			// escape single quotes in json attribute key
+			safeAttr := strings.ReplaceAll(jsonField[1], "'", "''")
+			key = fmt.Sprintf(`%s->>'%s' %s $%d`, jsonField[0], safeAttr, op, *pid)
+			values = append(values, value)
+		case "tsquery":
+			tsQueryField := strings.Split(keyInfo[0], "$")
+			if !ident.IsValid(tsQueryField[0]) {
+				err = errors.Wrapf(ErrInvalidIdentifier, "%s", tsQueryField[0])
+				return
+			}
+			safeVal := strings.ReplaceAll(value, "'", "''")
+			tsQuery := fmt.Sprintf(`%s @@ to_tsquery('%s')`, tsQueryField[0], safeVal)
+			if len(tsQueryField) == 2 {
+				if !ident.IsValid(tsQueryField[1]) {
+					err = errors.Wrapf(ErrInvalidIdentifier, "%s", tsQueryField[1])
+					return
+				}
+				safeCfg := strings.ReplaceAll(tsQueryField[1], "'", "''")
+				tsQuery = fmt.Sprintf(`%s @@ to_tsquery('%s', '%s')`, tsQueryField[0], safeCfg, safeVal)
+			}
+			key = tsQuery
+		default:
+			if !ident.IsValid(keyInfo[0]) {
+				err = errors.Wrapf(ErrInvalidIdentifier, "%s", keyInfo[0])
+				return
+			}
+		}
+		*pid++
+		return
+	}
+
+	if !ident.IsValid(rawKey) {
+		err = errors.Wrapf(ErrInvalidIdentifier, "%s", rawKey)
+		return
+	}
+
+	// always quote the field for SQL usage without mutating the original key
+	fields := strings.Split(rawKey, ".")
+	quotedKey := fmt.Sprintf(`"%s"`, strings.Join(fields, `"."`))
+
+	switch op {
+	case "IN", "NOT IN":
+		v := strings.Split(value, ",")
+		keyParams := make([]string, len(v))
+		for i := 0; i < len(v); i++ {
+			values = append(values, v[i])
+			keyParams[i] = fmt.Sprintf(`$%d`, *pid+i)
+		}
+		*pid += len(v)
+		key = fmt.Sprintf(`%s %s (%s)`, quotedKey, op, strings.Join(keyParams, ","))
+	case "ANY", "SOME", "ALL":
+		key = fmt.Sprintf(`%s = %s ($%d)`, quotedKey, op, *pid)
+		values = append(values, formatters.FormatArray(strings.Split(value, ",")))
+		*pid++
+	case "IS NULL", "IS NOT NULL", "IS TRUE", "IS NOT TRUE", "IS FALSE", "IS NOT FALSE":
+		key = fmt.Sprintf(`%s %s`, quotedKey, op)
+	default: // "=", "!=", ">", ">=", "<", "<="
+		key = fmt.Sprintf(`%s %s $%d`, quotedKey, op, *pid)
+		values = append(values, value)
+		*pid++
 	}
 	return
 }

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -178,13 +178,13 @@ func TestWhereByRequest(t *testing.T) {
 	config.Load()
 	Load()
 	var testCases = []struct {
-		description     string
-		url             string
-		expectedSQL     []string
-		expectedValues  []string
-		expectNoWhere   bool
-		expectNoValues  bool
-		err             error
+		description    string
+		url            string
+		expectedSQL    []string
+		expectedValues []string
+		expectNoWhere  bool
+		expectNoValues bool
+		err            error
 	}{
 		{"Where by request without paginate", "/databases?dbname=$eq.prest&test=$eq.cool", []string{`"dbname" = $`, `"test" = $`, " AND "}, []string{"prest", "cool"}, false, false, nil},
 		{"Where by request with alias", "/databases?dbname=$eq.prest&c.test=$eq.cool", []string{`"dbname" = $`, `"c".`, `"test" = $`, " AND "}, []string{"prest", "cool"}, false, false, nil},
@@ -203,9 +203,11 @@ func TestWhereByRequest(t *testing.T) {
 		{"Where by request with ltree match ltxtquery", "/prest-test/public/test5?path='$ltreematchtxt.Top*'", []string{`"path" @ $`}, []string{`'Top*'`}, false, false, nil},
 		{"Where by request with _or", "/prest-test/public/test5?_or=name=$eq.prest||phoneNumber=$eq.123", []string{`("name" = $`, ` OR "phoneNumber" = $`, `)`}, []string{"prest", "123"}, false, false, nil},
 		{"Where by request with _or and AND", "/prest-test/public/test5?_or=name=$eq.prest||phoneNumber=$eq.123&age=$gt.18", []string{`("name" = $`, ` OR "phoneNumber" = $`, `)`, `"age" > $`, ` AND `}, []string{"prest", "123", "18"}, false, false, nil},
-		{"Where by request with _or using explicit separator", "/prest-test/public/test5?_or=name=$ilike.%25val%25||phoneNumber=$eq.123", []string{`("name" ILIKE $`, ` OR "phoneNumber" = $`, `)`}, []string{"%val%", "123"}, false, false, nil},
+		{"Where by request with _or using explicit OR separator", "/prest-test/public/test5?_or=name=$ilike.%25val%25 OR phoneNumber=$eq.123", []string{`("name" ILIKE $`, ` OR "phoneNumber" = $`, `)`}, []string{"%val%", "123"}, false, false, nil},
+		{"Where by request with _or preserving quoted OR value", `/prest-test/public/test5?_or=title=$eq."foo OR bar" OR phoneNumber=$eq.123`, []string{`("title" = $`, ` OR "phoneNumber" = $`, `)`}, []string{`"foo OR bar"`, "123"}, false, false, nil},
 		{"Where by request with _or using $in", "/prest-test/public/test5?_or=name=$in.foo,bar||phoneNumber=$eq.123", []string{`("name" IN (`, ` OR "phoneNumber" = $`, `)`}, []string{"foo", "bar", "123"}, false, false, nil},
 		{"Where by request with empty _or", "/prest-test/public/test5?_or=", nil, nil, true, true, nil},
+		{"Where by request with empty _or rhs", "/prest-test/public/test5?_or=name=", nil, nil, true, true, ErrInvalidOperator},
 		{"Where by request with malformed _or", "/prest-test/public/test5?_or=namevalue", nil, nil, true, true, nil},
 	}
 
@@ -219,8 +221,8 @@ func TestWhereByRequest(t *testing.T) {
 		where, values, err := config.PrestConf.Adapter.WhereByRequest(req, 1)
 		t.Log("where:", where)
 		t.Log("values:", values)
-		if err != nil {
-			t.Errorf("expected no errors in where by request, got %v", err)
+		if err != tc.err {
+			t.Errorf("expected errors %v in where by request, got %v", tc.err, err)
 		}
 
 		if tc.expectNoWhere {

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -178,27 +178,35 @@ func TestWhereByRequest(t *testing.T) {
 	config.Load()
 	Load()
 	var testCases = []struct {
-		description    string
-		url            string
-		expectedSQL    []string
-		expectedValues []string
-		err            error
+		description     string
+		url             string
+		expectedSQL     []string
+		expectedValues  []string
+		expectNoWhere   bool
+		expectNoValues  bool
+		err             error
 	}{
-		{"Where by request without paginate", "/databases?dbname=$eq.prest&test=$eq.cool", []string{`"dbname" = $`, `"test" = $`, " AND "}, []string{"prest", "cool"}, nil},
-		{"Where by request with alias", "/databases?dbname=$eq.prest&c.test=$eq.cool", []string{`"dbname" = $`, `"c".`, `"test" = $`, " AND "}, []string{"prest", "cool"}, nil},
-		{"Where by request with spaced values", "/prest-test/public/test5?name=$eq.prest tester", []string{`"name" = $`}, []string{"prest tester"}, nil},
-		{"Where by request with jsonb field", "/prest-test/public/test_jsonb_bug?name=$eq.goku&data->>description:jsonb=$eq.testing", []string{`"name" = $`, `"data"->>'description' = $`, " AND "}, []string{"goku", "testing"}, nil},
-		{"Where by request with dot values", "/prest-test/public/test5?name=$eq.prest.txt tester", []string{`"name" = $`}, []string{"prest.txt tester"}, nil},
-		{"Where by request with like", "/prest-test/public/test5?name=$like.%25val%25&phonenumber=123456", []string{`"name" LIKE $`, `"phonenumber" = $`, " AND "}, []string{"%val%", "123456"}, nil},
-		{"Where by request with ilike", "/prest-test/public/test5?name=$ilike.%25vAl%25&phonenumber=123456", []string{`"name" ILIKE $`, `"phonenumber" = $`, " AND "}, []string{"%vAl%", "123456"}, nil},
-		{"Where by request with not like", "/prest-test/public/test5?name=$nlike.%25val%25&phonenumber=123456", []string{`"name" NOT LIKE $`, `"phonenumber" = $`, " AND "}, []string{"%val%", "123456"}, nil},
-		{"Where by request with not ilike", "/prest-test/public/test5?name=$nilike.%25vAl%25&phonenumber=123456", []string{`"name" NOT ILIKE $`, `"phonenumber" = $`, " AND "}, []string{"%vAl%", "123456"}, nil},
-		{"Where by request with multiple colunm values", "/prest-test/public/table?created_at='$gte.1997-11-03'&created_at='$lte.1997-12-05'", []string{`"created_at" >= $`, ` AND `, `"created_at" <= $`}, []string{`'1997-11-03'`, `'1997-12-05'`}, nil},
-		{"Where by request with tsquery", "/prest-test/public/test5?name:tsquery=prest", []string{`name @@ to_tsquery('prest')`}, []string{`'prest'`}, nil},
-		{"Where by request with ltree left acendent", "/prest-test/public/test5?path='$ltreelanc.Top.*'", []string{`"path" @> $`}, []string{`'Top.*'`}, nil},
-		{"Where by request with ltree right descendent", "/prest-test/public/test5?path='$ltreerdesc.Top.*'", []string{`"path" <@ $`}, []string{`'Top.*'`}, nil},
-		{"Where by request with ltree match lquery", "/prest-test/public/test5?path='$ltreematch.Top.*'", []string{`"path" ~ $`}, []string{`'Top.*'`}, nil},
-		{"Where by request with ltree match ltxtquery", "/prest-test/public/test5?path='$ltreematchtxt.Top*'", []string{`"path" @ $`}, []string{`'Top*'`}, nil},
+		{"Where by request without paginate", "/databases?dbname=$eq.prest&test=$eq.cool", []string{`"dbname" = $`, `"test" = $`, " AND "}, []string{"prest", "cool"}, false, false, nil},
+		{"Where by request with alias", "/databases?dbname=$eq.prest&c.test=$eq.cool", []string{`"dbname" = $`, `"c".`, `"test" = $`, " AND "}, []string{"prest", "cool"}, false, false, nil},
+		{"Where by request with spaced values", "/prest-test/public/test5?name=$eq.prest tester", []string{`"name" = $`}, []string{"prest tester"}, false, false, nil},
+		{"Where by request with jsonb field", "/prest-test/public/test_jsonb_bug?name=$eq.goku&data->>description:jsonb=$eq.testing", []string{`"name" = $`, `"data"->>'description' = $`, " AND "}, []string{"goku", "testing"}, false, false, nil},
+		{"Where by request with dot values", "/prest-test/public/test5?name=$eq.prest.txt tester", []string{`"name" = $`}, []string{"prest.txt tester"}, false, false, nil},
+		{"Where by request with like", "/prest-test/public/test5?name=$like.%25val%25&phonenumber=123456", []string{`"name" LIKE $`, `"phonenumber" = $`, " AND "}, []string{"%val%", "123456"}, false, false, nil},
+		{"Where by request with ilike", "/prest-test/public/test5?name=$ilike.%25vAl%25&phonenumber=123456", []string{`"name" ILIKE $`, `"phonenumber" = $`, " AND "}, []string{"%vAl%", "123456"}, false, false, nil},
+		{"Where by request with not like", "/prest-test/public/test5?name=$nlike.%25val%25&phonenumber=123456", []string{`"name" NOT LIKE $`, `"phonenumber" = $`, " AND "}, []string{"%val%", "123456"}, false, false, nil},
+		{"Where by request with not ilike", "/prest-test/public/test5?name=$nilike.%25vAl%25&phonenumber=123456", []string{`"name" NOT ILIKE $`, `"phonenumber" = $`, " AND "}, []string{"%vAl%", "123456"}, false, false, nil},
+		{"Where by request with multiple colunm values", "/prest-test/public/table?created_at='$gte.1997-11-03'&created_at='$lte.1997-12-05'", []string{`"created_at" >= $`, ` AND `, `"created_at" <= $`}, []string{`'1997-11-03'`, `'1997-12-05'`}, false, false, nil},
+		{"Where by request with tsquery", "/prest-test/public/test5?name:tsquery=prest", []string{`name @@ to_tsquery('prest')`}, []string{`'prest'`}, false, false, nil},
+		{"Where by request with ltree left acendent", "/prest-test/public/test5?path='$ltreelanc.Top.*'", []string{`"path" @> $`}, []string{`'Top.*'`}, false, false, nil},
+		{"Where by request with ltree right descendent", "/prest-test/public/test5?path='$ltreerdesc.Top.*'", []string{`"path" <@ $`}, []string{`'Top.*'`}, false, false, nil},
+		{"Where by request with ltree match lquery", "/prest-test/public/test5?path='$ltreematch.Top.*'", []string{`"path" ~ $`}, []string{`'Top.*'`}, false, false, nil},
+		{"Where by request with ltree match ltxtquery", "/prest-test/public/test5?path='$ltreematchtxt.Top*'", []string{`"path" @ $`}, []string{`'Top*'`}, false, false, nil},
+		{"Where by request with _or", "/prest-test/public/test5?_or=name=$eq.prest||phoneNumber=$eq.123", []string{`("name" = $`, ` OR "phoneNumber" = $`, `)`}, []string{"prest", "123"}, false, false, nil},
+		{"Where by request with _or and AND", "/prest-test/public/test5?_or=name=$eq.prest||phoneNumber=$eq.123&age=$gt.18", []string{`("name" = $`, ` OR "phoneNumber" = $`, `)`, `"age" > $`, ` AND `}, []string{"prest", "123", "18"}, false, false, nil},
+		{"Where by request with _or with OR separator", "/prest-test/public/test5?_or=name=$ilike.%25val%25%20OR%20phoneNumber=$eq.123", []string{`("name" ILIKE $`, ` OR "phoneNumber" = $`, `)`}, []string{"%val%", "123"}, false, false, nil},
+		{"Where by request with _or using $in", "/prest-test/public/test5?_or=name=$in.foo,bar||phoneNumber=$eq.123", []string{`("name" IN (`, ` OR "phoneNumber" = $`, `)`}, []string{"foo", "bar", "123"}, false, false, nil},
+		{"Where by request with empty _or", "/prest-test/public/test5?_or=", nil, nil, true, true, nil},
+		{"Where by request with malformed _or", "/prest-test/public/test5?_or=namevalue", nil, nil, true, true, nil},
 	}
 
 	for _, tc := range testCases {
@@ -215,18 +223,30 @@ func TestWhereByRequest(t *testing.T) {
 			t.Errorf("expected no errors in where by request, got %v", err)
 		}
 
-		for _, sql := range tc.expectedSQL {
-			if !strings.Contains(where, sql) {
-				t.Errorf("expected %s in %s, but not was!", sql, where)
+		if tc.expectNoWhere {
+			if where != "" {
+				t.Errorf("expected empty `where`, got %v", where)
+			}
+		} else {
+			for _, sql := range tc.expectedSQL {
+				if !strings.Contains(where, sql) {
+					t.Errorf("expected %s in %s, but not was!", sql, where)
+				}
 			}
 		}
 
 		expectedValuesSTR := strings.Join(tc.expectedValues, " ")
 		t.Log("expectedValuesSTR:", expectedValuesSTR)
-		for _, value := range values {
-			t.Log("in values:", values)
-			if !strings.Contains(expectedValuesSTR, value.(string)) {
-				t.Errorf("expected %s in %s", value, expectedValuesSTR)
+		if tc.expectNoValues {
+			if len(values) != 0 {
+				t.Errorf("expected empty `values`, got %v", values)
+			}
+		} else {
+			for _, value := range values {
+				t.Log("in values:", values)
+				if !strings.Contains(expectedValuesSTR, value.(string)) {
+					t.Errorf("expected %s in %s", value, expectedValuesSTR)
+				}
 			}
 		}
 	}

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -196,14 +196,14 @@ func TestWhereByRequest(t *testing.T) {
 		{"Where by request with not like", "/prest-test/public/test5?name=$nlike.%25val%25&phonenumber=123456", []string{`"name" NOT LIKE $`, `"phonenumber" = $`, " AND "}, []string{"%val%", "123456"}, false, false, nil},
 		{"Where by request with not ilike", "/prest-test/public/test5?name=$nilike.%25vAl%25&phonenumber=123456", []string{`"name" NOT ILIKE $`, `"phonenumber" = $`, " AND "}, []string{"%vAl%", "123456"}, false, false, nil},
 		{"Where by request with multiple colunm values", "/prest-test/public/table?created_at='$gte.1997-11-03'&created_at='$lte.1997-12-05'", []string{`"created_at" >= $`, ` AND `, `"created_at" <= $`}, []string{`'1997-11-03'`, `'1997-12-05'`}, false, false, nil},
-		{"Where by request with tsquery", "/prest-test/public/test5?name:tsquery=prest", []string{`name @@ to_tsquery('prest')`}, []string{`'prest'`}, false, false, nil},
+		{"Where by request with tsquery", "/prest-test/public/test5?name:tsquery=prest", []string{`name @@ to_tsquery('prest')`}, nil, false, true, nil},
 		{"Where by request with ltree left acendent", "/prest-test/public/test5?path='$ltreelanc.Top.*'", []string{`"path" @> $`}, []string{`'Top.*'`}, false, false, nil},
 		{"Where by request with ltree right descendent", "/prest-test/public/test5?path='$ltreerdesc.Top.*'", []string{`"path" <@ $`}, []string{`'Top.*'`}, false, false, nil},
 		{"Where by request with ltree match lquery", "/prest-test/public/test5?path='$ltreematch.Top.*'", []string{`"path" ~ $`}, []string{`'Top.*'`}, false, false, nil},
 		{"Where by request with ltree match ltxtquery", "/prest-test/public/test5?path='$ltreematchtxt.Top*'", []string{`"path" @ $`}, []string{`'Top*'`}, false, false, nil},
 		{"Where by request with _or", "/prest-test/public/test5?_or=name=$eq.prest||phoneNumber=$eq.123", []string{`("name" = $`, ` OR "phoneNumber" = $`, `)`}, []string{"prest", "123"}, false, false, nil},
 		{"Where by request with _or and AND", "/prest-test/public/test5?_or=name=$eq.prest||phoneNumber=$eq.123&age=$gt.18", []string{`("name" = $`, ` OR "phoneNumber" = $`, `)`, `"age" > $`, ` AND `}, []string{"prest", "123", "18"}, false, false, nil},
-		{"Where by request with _or with OR separator", "/prest-test/public/test5?_or=name=$ilike.%25val%25%20OR%20phoneNumber=$eq.123", []string{`("name" ILIKE $`, ` OR "phoneNumber" = $`, `)`}, []string{"%val%", "123"}, false, false, nil},
+		{"Where by request with _or using explicit separator", "/prest-test/public/test5?_or=name=$ilike.%25val%25||phoneNumber=$eq.123", []string{`("name" ILIKE $`, ` OR "phoneNumber" = $`, `)`}, []string{"%val%", "123"}, false, false, nil},
 		{"Where by request with _or using $in", "/prest-test/public/test5?_or=name=$in.foo,bar||phoneNumber=$eq.123", []string{`("name" IN (`, ` OR "phoneNumber" = $`, `)`}, []string{"foo", "bar", "123"}, false, false, nil},
 		{"Where by request with empty _or", "/prest-test/public/test5?_or=", nil, nil, true, true, nil},
 		{"Where by request with malformed _or", "/prest-test/public/test5?_or=namevalue", nil, nil, true, true, nil},
@@ -242,6 +242,9 @@ func TestWhereByRequest(t *testing.T) {
 				t.Errorf("expected empty `values`, got %v", values)
 			}
 		} else {
+			if len(values) != len(tc.expectedValues) {
+				t.Errorf("expected %d values, got %d: %v", len(tc.expectedValues), len(values), values)
+			}
 			for _, value := range values {
 				t.Log("in values:", values)
 				if !strings.Contains(expectedValuesSTR, value.(string)) {


### PR DESCRIPTION
Resolves: #957 

Problem

There should be a way to do an OR clause that is not a custom query. Specifically I want to chain a few ilike calls with OR, something like title=$ilike.%{search}% OR name=$ilike.%{search}%


I also adjusted validations and fixed the tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced OR-group handling: parenthesized OR groups combine with subsequent AND predicates and support multiple separators and mixed operators; improved handling of typed/value suffixes.

* **Bug Fixes**
  * Empty or malformed OR inputs now produce no WHERE clause or bind values, preventing invalid queries.

* **Tests**
  * Expanded coverage for OR grouping, operator mixing, IN scenarios, empty/malformed inputs, and stricter value assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->