### PR TITLE
Fix JWT auth bypass when default enforcement runs without a key

### DIFF
--- a/cmd/prestd/main.go
+++ b/cmd/prestd/main.go
@@ -1,11 +1,21 @@
 package main
 
 import (
+	"log/slog"
+	"os"
+
 	"github.com/prest/prest/v2/cmd"
 	"github.com/prest/prest/v2/config"
 )
 
 func main() {
 	config.Load()
+	// Fail fast when default JWT enforcement is enabled but no verification
+	// material was provided — otherwise the middleware would validate bearer
+	// tokens against an empty HMAC key. See GHSA-fj7v-859r-2fm4.
+	if err := config.ValidateJWTConfig(config.PrestConf); err != nil {
+		slog.Error("invalid JWT configuration", "err", err)
+		os.Exit(1)
+	}
 	cmd.Execute()
 }

--- a/cmd/prestd/main.go
+++ b/cmd/prestd/main.go
@@ -1,21 +1,11 @@
 package main
 
 import (
-	"log/slog"
-	"os"
-
 	"github.com/prest/prest/v2/cmd"
 	"github.com/prest/prest/v2/config"
 )
 
 func main() {
 	config.Load()
-	// Fail fast when default JWT enforcement is enabled but no verification
-	// material was provided — otherwise the middleware would validate bearer
-	// tokens against an empty HMAC key. See GHSA-fj7v-859r-2fm4.
-	if err := config.ValidateJWTConfig(config.PrestConf); err != nil {
-		slog.Error("invalid JWT configuration", "err", err)
-		os.Exit(1)
-	}
 	cmd.Execute()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,16 @@ func Execute() {
 
 // startServer starts the server
 func startServer() {
+	// Fail fast when JWT enforcement is enabled but no verification material
+	// was provided — otherwise the middleware would validate bearer tokens
+	// against an empty HMAC key. Subcommands like `migrate` don't reach here,
+	// so they keep working without JWT material configured.
+	// See GHSA-fj7v-859r-2fm4.
+	if err := config.ValidateJWTConfig(config.PrestConf); err != nil {
+		slog.Error("invalid JWT configuration", "err", err)
+		os.Exit(1)
+	}
+
 	http.Handle(config.PrestConf.ContextPath, router.Routes())
 
 	if !config.PrestConf.AccessConf.Restrict {

--- a/config/config.go
+++ b/config/config.go
@@ -355,6 +355,35 @@ func parseDatabaseURL(cfg *Prest) {
 	}
 }
 
+// ErrJWTDefaultEnabledNoKey is returned when the default JWT middleware is
+// enabled but no verification material (HMAC key, JWKS or .well-known URL) was
+// provided. This guards against accidentally serving requests with an empty
+// HMAC key, which would let any client forge bearer tokens. See GHSA-fj7v-859r-2fm4.
+var ErrJWTDefaultEnabledNoKey = fmt.Errorf(
+	"jwt.default is enabled but no verification material was provided " +
+		"(set jwt.key, jwt.jwks or jwt.wellknownurl, or disable jwt.default)")
+
+// ValidateJWTConfig fails fast when the default JWT middleware will be
+// installed without any verification material. The middleware bypass also
+// triggers when Debug is true (see middlewares/config.go), so we mirror that
+// rule here to avoid blocking debug-mode startups.
+//
+// Call this from binary entrypoints after Load(); tests that exercise Load()
+// without setting JWT material rely on the middleware-level guard
+// (middlewares.JwtMiddleware) to fail closed at request time.
+func ValidateJWTConfig(cfg *Prest) error {
+	if !cfg.EnableDefaultJWT {
+		return nil
+	}
+	if cfg.Debug {
+		return nil
+	}
+	if cfg.JWTKey != "" || cfg.JWTJWKS != "" || cfg.JWTWellKnownURL != "" {
+		return nil
+	}
+	return ErrJWTDefaultEnabledNoKey
+}
+
 // fetchJWKS tries to get the JWKS from the URL in the config
 func fetchJWKS(cfg *Prest) {
 	if cfg.JWTWellKnownURL == "" {

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -359,19 +360,36 @@ func parseDatabaseURL(cfg *Prest) {
 // enabled but no verification material (HMAC key, JWKS or .well-known URL) was
 // provided. This guards against accidentally serving requests with an empty
 // HMAC key, which would let any client forge bearer tokens. See GHSA-fj7v-859r-2fm4.
-var ErrJWTDefaultEnabledNoKey = fmt.Errorf(
+var ErrJWTDefaultEnabledNoKey = errors.New(
 	"jwt.default is enabled but no verification material was provided " +
 		"(set jwt.key, jwt.jwks or jwt.wellknownurl, or disable jwt.default)")
 
-// ValidateJWTConfig fails fast when the default JWT middleware will be
-// installed without any verification material. The middleware bypass also
-// triggers when Debug is true (see middlewares/config.go), so we mirror that
+// ErrAuthEnabledNoJWTKey is returned when basic auth is enabled but jwt.key
+// is empty. AuthMiddleware uses the same []byte(JWTKey) to verify HS256
+// tokens, so an empty key opens the same auth-bypass as the default JWT
+// middleware. See GHSA-fj7v-859r-2fm4.
+var ErrAuthEnabledNoJWTKey = errors.New(
+	"auth.enabled is true but jwt.key is empty (required to verify HS256 tokens)")
+
+// ValidateJWTConfig fails fast when either of the JWT-validating middlewares
+// would be installed without any verification material:
+//
+//   - The default JWT middleware (jwt.default = true) requires jwt.key, a
+//     JWKS, or a .well-known URL.
+//   - AuthMiddleware (auth.enabled = true) verifies HS256 tokens with
+//     jwt.key, so an empty key is unsafe.
+//
+// The default JWT path also bypasses when Debug is true, so we mirror that
 // rule here to avoid blocking debug-mode startups.
 //
-// Call this from binary entrypoints after Load(); tests that exercise Load()
-// without setting JWT material rely on the middleware-level guard
-// (middlewares.JwtMiddleware) to fail closed at request time.
+// Call this from binary entrypoints before serving requests; tests that
+// exercise Load() without setting JWT material rely on the middleware-level
+// guards (middlewares.JwtMiddleware, middlewares.AuthMiddleware) to fail
+// closed at request time.
 func ValidateJWTConfig(cfg *Prest) error {
+	if cfg.AuthEnabled && cfg.JWTKey == "" {
+		return ErrAuthEnabledNoJWTKey
+	}
 	if !cfg.EnableDefaultJWT {
 		return nil
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,6 +153,60 @@ func TestParse(t *testing.T) {
 	})
 }
 
+// Regression coverage for GHSA-fj7v-859r-2fm4: when default JWT enforcement is
+// enabled but no verification material is configured, the default HMAC key is
+// the empty string and any forged HS256 token would validate. Startup callers
+// (binary entrypoints) must use ValidateJWTConfig to fail closed.
+func TestValidateJWTConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     *Prest
+		wantErr error
+	}{
+		{
+			name:    "default JWT on, no key, no JWKS, no well-known → reject",
+			cfg:     &Prest{EnableDefaultJWT: true},
+			wantErr: ErrJWTDefaultEnabledNoKey,
+		},
+		{
+			name:    "default JWT on, HMAC key set → ok",
+			cfg:     &Prest{EnableDefaultJWT: true, JWTKey: "s3cr3t"},
+			wantErr: nil,
+		},
+		{
+			name:    "default JWT on, JWKS set → ok",
+			cfg:     &Prest{EnableDefaultJWT: true, JWTJWKS: `{"keys":[]}`},
+			wantErr: nil,
+		},
+		{
+			name:    "default JWT on, well-known URL set → ok",
+			cfg:     &Prest{EnableDefaultJWT: true, JWTWellKnownURL: "http://example.test/.well-known"},
+			wantErr: nil,
+		},
+		{
+			name:    "default JWT off → ok regardless of empty key",
+			cfg:     &Prest{EnableDefaultJWT: false},
+			wantErr: nil,
+		},
+		{
+			name:    "debug bypass mirrors middleware/config.go → ok",
+			cfg:     &Prest{EnableDefaultJWT: true, Debug: true},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateJWTConfig(tc.cfg)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
 func Test_getPrestConfFile(t *testing.T) {
 	testCases := []struct {
 		name      string

--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -30,6 +30,10 @@ var (
 	ErrJWKSetParse       = errors.New("failed to parse JWKSet JSON string")
 	ErrJWKSetCreate      = errors.New("failed to create public key")
 	ErrJWKSetKeyNotFound = errors.New("the token's key was not found in the JWKS")
+	// ErrJWTEmptyKey is returned when the middleware would otherwise validate a
+	// bearer token using an empty HMAC key — that path lets clients forge
+	// tokens against `[]byte("")`. We fail closed instead. See GHSA-fj7v-859r-2fm4.
+	ErrJWTEmptyKey = errors.New("JWT verification key is empty; refusing to validate token")
 )
 
 // HandlerSet add content type header
@@ -166,6 +170,11 @@ func JwtMiddleware(key string, JWKSet, _ string) negroni.Handler {
 		}
 		out := auth.Claims{}
 		var rawkey interface{} = []byte(key)
+		// jwksMatched tracks whether a JWKS lookup actually populated rawkey
+		// with a real key. We need this because the loop below silently leaves
+		// rawkey as []byte("") when no kid matches — and HS256 happily
+		// validates against an empty HMAC key, which would be an auth bypass.
+		jwksMatched := false
 
 		if JWKSet != "" {
 			parsedJWKSet, err := jwk.ParseString(JWKSet)
@@ -184,15 +193,26 @@ func JwtMiddleware(key string, JWKSet, _ string) negroni.Handler {
 						http.Error(w, fmt.Sprintf(jsonErrFormat, ErrJWKSetCreate.Error()), http.StatusUnauthorized)
 						return
 					}
+					jwksMatched = true
 				}
 			}
-			//Check if rawkey is empty
-			if key, ok := rawkey.(string); ok {
-				if key == "" {
-					slog.Error("the token's key was not found in the JWKS")
-					http.Error(w, fmt.Sprintf(jsonErrFormat, ErrJWKSetKeyNotFound.Error()), http.StatusUnauthorized)
-					return
-				}
+			if !jwksMatched {
+				slog.Error("the token's key was not found in the JWKS")
+				http.Error(w, fmt.Sprintf(jsonErrFormat, ErrJWKSetKeyNotFound.Error()), http.StatusUnauthorized)
+				return
+			}
+		}
+
+		// Defense-in-depth: if no JWKS resolved and the configured HMAC key is
+		// empty, refuse the request instead of letting jose validate against
+		// []byte(""). config.validateJWTConfig should already prevent this on
+		// startup, but we keep the guard so a misconfigured runtime can't
+		// silently degrade to "any token accepted". GHSA-fj7v-859r-2fm4.
+		if !jwksMatched {
+			if b, ok := rawkey.([]byte); ok && len(b) == 0 {
+				slog.Error("JWT verification key is empty; refusing to validate token")
+				http.Error(w, fmt.Sprintf(jsonErrFormat, ErrJWTEmptyKey.Error()), http.StatusUnauthorized)
+				return
 			}
 		}
 

--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -78,6 +78,16 @@ func AuthMiddleware(_ string) negroni.Handler {
 				http.Error(rw, fmt.Sprintf(jsonErrFormat, ErrJWTParseFail.Error()), http.StatusUnauthorized)
 				return
 			}
+			// Defense-in-depth: refuse to verify with an empty HMAC key.
+			// config.ValidateJWTConfig should already prevent this on
+			// startup, but we keep the guard so a misconfigured runtime
+			// can't silently degrade to "any token accepted".
+			// GHSA-fj7v-859r-2fm4.
+			if config.PrestConf.JWTKey == "" {
+				slog.Error("JWT verification key is empty; refusing to validate token")
+				http.Error(rw, fmt.Sprintf(jsonErrFormat, ErrJWTEmptyKey.Error()), http.StatusUnauthorized)
+				return
+			}
 			claims := auth.Claims{}
 			if err := tok.Claims([]byte(config.PrestConf.JWTKey), &claims); err != nil {
 				http.Error(rw, fmt.Sprintf(jsonErrFormat, err.Error()), http.StatusUnauthorized)

--- a/middlewares/middlewares_test.go
+++ b/middlewares/middlewares_test.go
@@ -225,6 +225,10 @@ func TestJWKSetRSANoKey(t *testing.T) {
 // `tok.Claims([]byte(""), &out)` which jose's HMAC implementation accepts,
 // granting access to any caller able to forge `HMAC-SHA256("", header.payload)`.
 func TestJWTEmptyKeyRejectsForgedToken(t *testing.T) {
+	// MatchURL reads config.PrestConf.JWTWhiteList; initialize an empty
+	// config so the middleware can run in isolation without depending on
+	// env-driven config.Load() side effects.
+	config.PrestConf = &config.Prest{}
 	mw := JwtMiddleware("", "", "HS256")
 
 	// Forge a token signed with the empty secret. NotBefore/Expiry are valid,
@@ -259,6 +263,11 @@ func TestJWTEmptyKeyRejectsForgedToken(t *testing.T) {
 // silently fell through to verifying with []byte(""), which is the same
 // auth-bypass shape as GHSA-fj7v-859r-2fm4.
 func TestJWTJWKSWithoutMatchingKidRejected(t *testing.T) {
+	// MatchURL reads config.PrestConf.JWTWhiteList; initialize an empty
+	// config so the middleware can run in isolation without depending on
+	// env-driven config.Load() side effects.
+	config.PrestConf = &config.Prest{}
+
 	// Minimal JWKS containing one RSA key with kid="other".
 	raw, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)

--- a/middlewares/middlewares_test.go
+++ b/middlewares/middlewares_test.go
@@ -219,6 +219,86 @@ func TestJWKSetRSANoKey(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, respd.StatusCode)
 }
 
+// Regression coverage for GHSA-fj7v-859r-2fm4: an HS256 token signed with the
+// empty HMAC key must be rejected when JwtMiddleware is configured without
+// verification material. Before the fix the middleware called
+// `tok.Claims([]byte(""), &out)` which jose's HMAC implementation accepts,
+// granting access to any caller able to forge `HMAC-SHA256("", header.payload)`.
+func TestJWTEmptyKeyRejectsForgedToken(t *testing.T) {
+	mw := JwtMiddleware("", "", "HS256")
+
+	// Forge a token signed with the empty secret. NotBefore/Expiry are valid,
+	// so the only thing that should reject this request is the empty-key guard.
+	sig, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.HS256, Key: []byte("")},
+		(&jose.SignerOptions{}).WithType("JWT"))
+	require.NoError(t, err)
+
+	cl := auth.Claims{
+		NotBefore: jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+		Expiry:    jwt.NewNumericDate(time.Now().Add(time.Minute)),
+	}
+	forged, err := jwt.Signed(sig).Claims(cl).CompactSerialize()
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/prest/public/test", nil)
+	req.Header.Set("Authorization", "Bearer "+forged)
+	rec := httptest.NewRecorder()
+
+	mw.ServeHTTP(rec, req, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("next handler should not be called when the verification key is empty")
+	})
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Contains(t, rec.Body.String(), ErrJWTEmptyKey.Error())
+}
+
+// When a JWKS is provided but does not contain the kid from the bearer token,
+// the middleware must fail closed. Before the fix the code only flagged this
+// case when the rawkey happened to be a string — for the default []byte path it
+// silently fell through to verifying with []byte(""), which is the same
+// auth-bypass shape as GHSA-fj7v-859r-2fm4.
+func TestJWTJWKSWithoutMatchingKidRejected(t *testing.T) {
+	// Minimal JWKS containing one RSA key with kid="other".
+	raw, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	key, err := jwk.FromRaw(raw)
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.KeyIDKey, "other"))
+
+	set := jwk.NewSet()
+	set.AddKey(key)
+	pub, err := jwk.PublicSetOf(set)
+	require.NoError(t, err)
+	jwksJSON, err := json.Marshal(pub)
+	require.NoError(t, err)
+
+	mw := JwtMiddleware("", string(jwksJSON), "HS256")
+
+	// Forge a token whose kid does not match anything in the JWKS.
+	sig, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.HS256, Key: []byte("")},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", "missing"))
+	require.NoError(t, err)
+	cl := auth.Claims{
+		NotBefore: jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+		Expiry:    jwt.NewNumericDate(time.Now().Add(time.Minute)),
+	}
+	forged, err := jwt.Signed(sig).Claims(cl).CompactSerialize()
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/prest/public/test", nil)
+	req.Header.Set("Authorization", "Bearer "+forged)
+	rec := httptest.NewRecorder()
+
+	mw.ServeHTTP(rec, req, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("next handler should not be called when the kid is not in the JWKS")
+	})
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Contains(t, rec.Body.String(), ErrJWKSetKeyNotFound.Error())
+}
+
 func TestValidate(t *testing.T) {
 	type args struct {
 		c auth.Claims


### PR DESCRIPTION
When jwt.default is enabled (the shipped default) and no jwt.key, jwt.jwks or jwt.wellknownurl is set, JwtMiddleware called tok.Claims([]byte(""), ...). HS256 happily validates against the empty HMAC key, so any client can forge a bearer token and walk past the auth boundary into protected CRUD routes (GHSA-fj7v-859r-2fm4).

Two layers now fail closed. The binary entrypoint calls a new config.ValidateJWTConfig that aborts startup when default JWT is on, debug is off, and no verification material was provided. JwtMiddleware also rejects requests at runtime when the resolved key is empty or when a JWKS is configured but no kid in it matches the bearer token — the previous "empty rawkey" check was dead code (rawkey is []byte, never string) so the JWKS-without-match path was also vulnerable. Regression tests cover both.

Please check the following:

1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for bug fixes.
2. Read contributing guidelines: https://docs.prestd.com/prestd-documentation/contributing-to-prestd
3. Describe what your pull request does and which issue you're targeting (if any)

**You MUST delete the content above including this line before posting, otherwise your pull request will be invalid.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration validation at startup to ensure JWT verification material (keys, JWKS, or well-known URLs) is properly configured before the server starts.

* **Improvements**
  * JWT and authentication middleware now enforce stricter validation rules, immediately rejecting requests with missing or mismatched cryptographic keys instead of proceeding with incomplete verification material.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->