### PR TITLE
docs: document mock adapter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ docker compose -f docker-compose-test.yml down -v --remove-orphans
 
 The `tests` service runs `./testdata/runtest.sh`, provisioning databases and executing Go tests.
 
+For adapter-dependent unit tests that should not open PostgreSQL connections,
+see the [`adapters/mock`](adapters/mock/README.md) test adapter documentation.
+
 ## Example: Docker Build
 
 You can build the Docker image locally for development (this compiles the code from source):
@@ -82,4 +85,3 @@ docker build \
   --build-arg DATE=2026-02-11 \
   -t prest/prest:latest .
 ```
-

--- a/adapters/mock/README.md
+++ b/adapters/mock/README.md
@@ -1,0 +1,87 @@
+# Mock Adapter
+
+The `adapters/mock` package provides a test-only implementation of the pREST
+`adapters.Adapter` interface. It lets tests exercise code that depends on an
+adapter without opening a PostgreSQL connection.
+
+Use it when a test needs to control adapter responses directly. It is not an
+in-memory database, and it does not parse or execute SQL. Methods such as
+`Query`, `Insert`, `Update`, `Delete`, `QueryCount`, and batch insert helpers
+return the next queued item as a `scanner.PrestScanner`.
+
+## Basic usage
+
+Create a mock adapter with the current test handle, enqueue each expected
+adapter response with `AddItem`, then call the method under test.
+
+```go
+package example_test
+
+import (
+	"testing"
+
+	"github.com/prest/prest/v2/adapters/mock"
+)
+
+func TestQueryUsers(t *testing.T) {
+	adapter := mock.New(t)
+	adapter.AddItem([]byte(`[{"id":1,"name":"Ada"}]`), nil, false)
+
+	scanner := adapter.Query(`select id, name from users`)
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	var users []struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	count, err := scanner.Scan(&users)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected one user, got %d", count)
+	}
+}
+```
+
+## Queueing responses
+
+`AddItem` appends responses to a FIFO queue:
+
+```go
+adapter.AddItem([]byte(`[{"id":1}]`), nil, false)
+adapter.AddItem(nil, errors.New("database unavailable"), false)
+adapter.AddItem(nil, nil, true)
+```
+
+Each call to a supported adapter method consumes one queued item. If a method
+that needs a queued item is called with an empty queue, the mock fails the test
+through `testing.T`.
+
+The `isCount` argument is used by `DatabaseClause` and `SchemaClause` to return
+the `hasCount` value expected by callers that branch on count requests.
+
+## Transactions
+
+`New(t)` registers a `database/sql` driver named `mock` if it has not already
+been registered. `GetTransaction` and `GetTransactionCtx` open that driver with
+the `prest` DSN and return a transaction whose `Commit` and `Rollback` methods
+are no-ops.
+
+## Scope
+
+The mock adapter is intentionally small:
+
+- It verifies at compile time that `Mock` implements `adapters.Adapter`.
+- It mirrors table and field permission behavior enough for adapter-dependent
+  tests.
+- Most SQL construction helpers return zero values because SQL generation is
+  covered by the real PostgreSQL adapter tests.
+
+Run the package tests with:
+
+```bash
+go test ./adapters/mock
+```


### PR DESCRIPTION
Fixes #284

IssueHunt bounty: https://issuehunt.io/repos/74436942/issues/284

## What changed
- Added dedicated documentation for the `adapters/mock` package.
- Documented when to use the mock adapter, how queued responses work, transaction behavior, and scope/limitations.
- Linked the mock adapter docs from the README testing section.

## Reproduction / context
The funded issue asks for documentation about the mock adapter. Before this change, the package had implementation and tests but no usage documentation.

## Tests
- `go test ./adapters/mock`
- `go test ./adapters/scanner`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added testing guidance directing users to mock adapter documentation for unit tests.
  * Published comprehensive mock adapter documentation with usage examples and queue-based response handling details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#284: Add documentation about mock adapter](https://oss.issuehunt.io/repos/74436942/issues/284)
---
</details>
<!-- /Issuehunt content-->