### PR TITLE
docs: add mock adapter usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Deploy to Heroku and instantly get a realtime RESTFul API backed by Heroku Postg
 
 Visit <https://docs.prestd.com/>
 
+Testing-related adapter notes:
+- [Mock adapter usage](./adapters/mock/README.md)
+
 ## Testing
 
 Run the test suite inside Docker (no local Postgres required):

--- a/adapters/mock/README.md
+++ b/adapters/mock/README.md
@@ -1,0 +1,37 @@
+# Mock adapter for tests
+
+The `adapters/mock` package provides a lightweight in-memory adapter used by
+unit tests when a real PostgreSQL connection is unnecessary.
+
+## Why use it
+
+- Fast tests without Docker/PostgreSQL startup.
+- Deterministic responses for edge-case scenarios.
+- Clear separation between behavior tests and integration tests.
+
+## Basic setup
+
+```go
+package mypkg_test
+
+import (
+	"testing"
+
+	mockadapter "github.com/prest/prest/adapters/mock"
+)
+
+func TestWithMockAdapter(t *testing.T) {
+	adapter := mockadapter.New()
+	if adapter == nil {
+		t.Fatal("expected mock adapter")
+	}
+}
+```
+
+## Suggested strategy
+
+- Use `adapters/mock` in pure unit tests.
+- Use `docker-compose-test.yml` integration flow when validating SQL behavior.
+
+This split keeps the feedback loop short while preserving confidence in
+database-related features.

--- a/adapters/mock/README.md
+++ b/adapters/mock/README.md
@@ -21,7 +21,7 @@ import (
 )
 
 func TestWithMockAdapter(t *testing.T) {
-	adapter := mockadapter.New()
+	adapter := mockadapter.New(t)
 	if adapter == nil {
 		t.Fatal("expected mock adapter")
 	}


### PR DESCRIPTION
## Summary
- add dedicated docs for `adapters/mock` test adapter
- document when to use mock adapter vs integration tests
- add quick setup snippet and link from root README documentation section

## Context
This addresses IssueHunt-funded issue #284.

## Testing
- docs-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing documentation for the lightweight in-memory mock adapter, including setup examples and a recommended unit-vs-integration testing strategy.
  * Updated the main README to reference the mock adapter testing documentation and guide users on when to prefer the mock adapter for unit tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prest/prest/pull/964)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#284: Add documentation about mock adapter](https://oss.issuehunt.io/repos/74436942/issues/284)
---
</details>
<!-- /Issuehunt content-->