### PR TITLE
docs: document mock adapter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,42 @@ docker compose -f docker-compose-test.yml down -v --remove-orphans
 
 The `tests` service runs `./testdata/runtest.sh`, provisioning databases and executing Go tests.
 
+### Mock adapter for tests
+
+Controller and middleware tests can use the mock adapter instead of a live
+Postgres connection. Create it with `mock.New(t)`, assign it to
+`config.PrestConf.Adapter`, then enqueue one response for each adapter operation
+the code under test will execute:
+
+```go
+package mypackage_test
+
+import (
+	"testing"
+
+	"github.com/prest/prest/v2/adapters/mock"
+	"github.com/prest/prest/v2/config"
+)
+
+func TestWithMockAdapter(t *testing.T) {
+	config.Load()
+
+	adapter := mock.New(t)
+	config.PrestConf.Adapter = adapter
+
+	adapter.AddItem([]byte(`[{"id":1,"name":"Ada"}]`), nil, false)
+
+	// Run code that calls config.PrestConf.Adapter.Query, Insert, Update,
+	// Delete, or another mock-backed adapter operation.
+}
+```
+
+Queued items are consumed in first-in, first-out order. `AddItem` accepts the
+JSON response body, an optional error, and an `isCount` flag used by clause
+helpers such as `DatabaseClause` and `SchemaClause`. If the code under test calls
+an adapter operation without a queued item, the mock fails the test, which helps
+catch missing expectations.
+
 ## Example: Docker Build
 
 You can build the Docker image locally for development (this compiles the code from source):
@@ -82,4 +118,3 @@ docker build \
   --build-arg DATE=2026-02-11 \
   -t prest/prest:latest .
 ```
-

--- a/adapters/mock/doc.go
+++ b/adapters/mock/doc.go
@@ -1,0 +1,20 @@
+// Package mock provides a lightweight pREST adapter for tests.
+//
+// The adapter lets tests exercise controllers and middleware without a live
+// PostgreSQL server. Create it with New(t), assign it to config.PrestConf.Adapter,
+// and enqueue the scanner results that each adapter operation should return:
+//
+//	m := mock.New(t)
+//	config.PrestConf.Adapter = m
+//	m.AddItem([]byte(`[{"id":1,"name":"Ada"}]`), nil, false)
+//
+// Results are consumed in FIFO order. Methods such as Query, QueryCtx, Insert,
+// Update, Delete, BatchInsertValues, and BatchInsertCopy pop one Item from the
+// queue and return it as an adapters.Scanner. Item.Body becomes the scanner
+// buffer, Item.Error becomes the scanner error, and Item.IsCount controls the
+// count flag used by clause helpers such as DatabaseClause and SchemaClause.
+//
+// Add one Item per expected adapter operation. If a test calls an operation
+// without a queued item, the mock fails the test immediately, making missing
+// expectations visible.
+package mock


### PR DESCRIPTION
## Summary
- add package-level GoDoc for the mock adapter
- document basic mock adapter usage in README testing docs
- explain AddItem FIFO behavior and missing expectation failures

Fixes #284

## Verification
- git diff --check
- gofmt -w adapters/mock/doc.go
- GOCACHE=/private/tmp/prest-gocache GOMODCACHE=/private/tmp/prest-gomodcache /opt/homebrew/bin/go test ./adapters/mock


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#284: Add documentation about mock adapter](https://oss.issuehunt.io/repos/74436942/issues/284)
---
</details>
<!-- /Issuehunt content-->