### PR TITLE
fixup: ignore Windows ARM architecture in build release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: windows
+        goarch: arm
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
 changelog:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release build settings to skip an unsupported Windows ARM package target, helping avoid failed or incomplete release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->