### PR TITLE
chore: fix Dockerfile and GoReleaser configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.26
 
       - name: Cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -36,10 +36,13 @@ jobs:
 
       - name: goreleaser check
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: curl -sfL https://git.io/goreleaser | sh -s -- check
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: '~> v2'
+          args: check
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -55,7 +58,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -75,7 +78,7 @@ jobs:
 
       - name: Login to Docker Registry
         if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -87,9 +90,9 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         
       - name: Clear

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - binary: prestd
     main: ./cmd/prestd/main.go
@@ -56,6 +58,12 @@ dockers:
   - "ghcr.io/prest/prest:{{ .Tag }}"
   - "ghcr.io/prest/prest:v{{ .Major }}"
   dockerfile: Dockerfile
+  goos: linux
+  goarch: amd64
+  extra_files:
+    - etc/entrypoint.sh
+    - lib
+    - etc/plugin
   build_flag_templates:
   - "--build-arg=VERSION={{.Version}}"
   - "--build-arg=COMMIT={{.Commit}}"
@@ -71,6 +79,12 @@ dockers:
   - "ghcr.io/prest/prest:{{ .Tag }}-noplugins"
   - "ghcr.io/prest/prest:v{{ .Major }}-noplugins"
   dockerfile: Dockerfile.noplugins
+  goos: linux
+  goarch: amd64
+  extra_files:
+    - etc/entrypoint.sh
+    - lib
+    - etc/plugin
   build_flag_templates:
   - "--build-arg=VERSION={{.Version}}"
   - "--build-arg=COMMIT={{.Commit}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,13 @@ ARG COMMIT
 ARG DATE
 ENV GOOS linux
 ENV CGO_ENABLED 1
-RUN go mod vendor && \
-    go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o prestd cmd/prestd/main.go && \
-    apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -yq netcat-traditional && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install --no-install-recommends -yq netcat-traditional && \
+    rm -rf /var/lib/apt/lists/* && \
+    if [ -f go.mod ]; then \
+      go mod vendor && \
+      go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o prestd cmd/prestd/main.go; \
+    fi
 
 # Use golang image
 # needs go to compile the plugin system

--- a/Dockerfile.noplugins
+++ b/Dockerfile.noplugins
@@ -6,9 +6,13 @@ ARG COMMIT
 ARG DATE
 ENV GOOS linux
 ENV CGO_ENABLED 1
-RUN go mod vendor && \
-    go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o prestd cmd/prestd/main.go && \
-    apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -yq netcat-traditional && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install --no-install-recommends -yq netcat-traditional && \
+    rm -rf /var/lib/apt/lists/* && \
+    if [ -f go.mod ]; then \
+      go mod vendor && \
+      go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o prestd cmd/prestd/main.go; \
+    fi
 
 # Use runtime image
 # Plugins not supported

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can build the Docker image locally for development (this compiles the code f
 docker build -t prest/prest:latest .
 ```
 
-For release builds, GoReleaser uses the same `Dockerfile` but injects version information via build arguments:
+For release builds, GoReleaser uses the same `Dockerfile` / `Dockerfile.noplugins` with a pre-built `prestd` binary (no `go.mod` in the build context). Local source builds pass version metadata via build arguments:
 
 ```bash
 docker build \


### PR DESCRIPTION
- Added support for Linux amd64 architecture in GoReleaser configuration.
- Included additional files in the Docker image build process.
- Refactored Dockerfile and Dockerfile.noplugins to conditionally build the prestd binary only if go.mod is present
- Updated README to clarify the use of Dockerfiles in release builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Docker image packaging with clearer platform targeting and additional included files.
* **Bug Fixes**
  * Made container builds more reliable by installing system dependencies earlier and only running Go build steps when source module files are present.
  * Updated release and registry workflow steps to use newer, supported action versions.
* **Documentation**
  * Clarified Docker build instructions for release builds versus local source builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->