### PR TITLE
feat: Native MCP support over HTTP

### DIFF
--- a/.cursor/rules/agentic-loop.mdc
+++ b/.cursor/rules/agentic-loop.mdc
@@ -46,7 +46,7 @@ Follow repo conventions (details in @.github/copilot-instructions.md):
 | **SOLID** | One concern per handler/port; extend via new ports + wiring, not god handlers |
 | **State** | Stateless runtime — no package-level mutable app state; inject via constructors/`Deps` |
 | **Errors** | Wrap with `%w`; use `slog` for logging |
-| **Config** | **Resilience policy:** invalid/missing config → `slog.Warn`, safe default/zero, continue startup (see `config/config.go` helpers: `unmarshalKeyOrZero`, `ensure*Path`, `ensureJWTConfig`) |
+| **Config** | **Non-sensitive** invalid/missing → `slog.Warn`, safe default/zero, continue startup (`unmarshalKeyOrZero`, `ensure*Path`). **Auth/JWT/secrets/ACL/DB credentials** → fail closed (`ensureJWTConfig`, middleware empty-key guards); do not apply warn-and-continue |
 | **SQL** | Never concatenate untrusted input; keep adapter/query conventions |
 | **Formatting** | `gofmt`; idiomatic Go; comments only for non-obvious logic |
 | **Multi-DB** | Respect `DatabaseRegistry`, context DB switching (`pctx.DBNameKey`), multicluster config |
@@ -116,7 +116,7 @@ Before marking done, verify:
 
 - [ ] Diff is minimal — no unrelated formatting or drive-by refactors
 - [ ] No `adapters/postgres` imports in `controllers/`, `middlewares/`, or `router/`
-- [ ] Config additions follow warn-and-continue resilience (not hard-fail on bad TOML slices/paths)
+- [ ] Non-sensitive config uses warn-and-continue; auth/JWT/secrets/ACL/DB-credential settings fail closed (no silent weakening)
 - [ ] New behavior has tests; controller changes include integration coverage
 - [ ] Postgres unit tests use sqlmock helpers, not live DB
 - [ ] `t.Parallel()` / serial test rules respected

--- a/.cursor/rules/agentic-loop.mdc
+++ b/.cursor/rules/agentic-loop.mdc
@@ -1,0 +1,159 @@
+---
+description: pREST agentic develop→validate loop — follow on every coding task
+alwaysApply: true
+---
+
+# pREST Agentic Development Loop
+
+Follow this loop on **every** development task in this repository. For full conventions, architecture, and examples, see **@.github/copilot-instructions.md** (source of truth). This rule distills the workflow; do not duplicate that document.
+
+## The Loop
+
+Repeat until the definition-of-done checklist is green:
+
+```
+Understand → Locate → Plan → Implement → Validate → Self-review → (iterate)
+```
+
+### 1. Understand
+
+- Restate the task goal and constraints (behavior change vs refactor, breaking-change risk).
+- Check `go.mod` for the project's Go version before choosing APIs.
+- Identify affected layers: `controllers/`, `middlewares/`, `router/`, `config/`, `adapters/`, `integration/`.
+
+### 2. Locate
+
+- Find existing code before writing new code. Prefer extending ports/handlers over new top-level packages.
+- Key entrypoints: `cmd/prestd/main.go`, `router/router.go`, `controllers/deps.go`, `config/config.go`, `adapters/postgres/`.
+- For tests: co-located `*_test.go` (unit) or `integration/<package>/` (network/Docker).
+
+### 3. Plan (minimal change)
+
+- Propose the **smallest** diff that solves the task.
+- Map changes to hexagonal layers (ports → adapter → handler → route → tests).
+- Flag if `adapters/` interfaces change → plan `make mockgen`.
+- Flag if `controllers/` behavior changes → plan unit **and** integration tests.
+- Do not weaken auth/SQL safety or introduce breaking CLI/config/route changes unless explicitly requested.
+
+### 4. Implement
+
+Follow repo conventions (details in @.github/copilot-instructions.md):
+
+| Area | Rule |
+|------|------|
+| **Scope** | Small, focused diffs; preserve public behavior unless asked |
+| **Architecture** | Hexagonal: handlers depend on narrow `adapters/*` ports, not `adapters/postgres` |
+| **SOLID** | One concern per handler/port; extend via new ports + wiring, not god handlers |
+| **State** | Stateless runtime — no package-level mutable app state; inject via constructors/`Deps` |
+| **Errors** | Wrap with `%w`; use `slog` for logging |
+| **Config** | **Resilience policy:** invalid/missing config → `slog.Warn`, safe default/zero, continue startup (see `config/config.go` helpers: `unmarshalKeyOrZero`, `ensure*Path`, `ensureJWTConfig`) |
+| **SQL** | Never concatenate untrusted input; keep adapter/query conventions |
+| **Formatting** | `gofmt`; idiomatic Go; comments only for non-obvious logic |
+| **Multi-DB** | Respect `DatabaseRegistry`, context DB switching (`pctx.DBNameKey`), multicluster config |
+
+**Test isolation when writing tests:**
+
+- Unit tests: `t.Parallel()` when safe; **never** parallelize tests using `t.Setenv`, `config.Load()` on mutated env, `SetDBConnectForTest`, or shared globals.
+- `adapters/postgres/**` unit tests: sqlmock only (`withSQLMock`, `withFailingDBConnect`) — **no real Postgres, no `sqlx.Connect`**.
+- Never call `postgres.Load()` outside `integration/` and startup (`cmd/`).
+- Mock ports (`adapters/mockgen/`), not concrete postgres types, outside `adapters/postgres/`.
+
+### 5. Validate
+
+Run commands appropriate to the change scope. **Do not skip validation** — execute them, don't just suggest them.
+
+#### Always (any Go change)
+
+```sh
+go build ./...
+go vet ./...
+gofmt -l .          # fix any output before finishing
+```
+
+#### Unit tests (default for most changes)
+
+```sh
+make test              # alias for make test-unit
+# or targeted:
+go test -timeout 30s -race -count=1 ./path/to/package/...
+```
+
+`make test-unit` runs all non-integration packages with `-race`, `-timeout 30s`, and coverage (`coverage.out`).
+
+#### Postgres adapter unit tests
+
+```sh
+go test -timeout 30s -parallel 8 ./adapters/postgres/...
+```
+
+Must pass with **no Postgres process running** (sqlmock only).
+
+#### Controllers / HTTP behavior changes
+
+```sh
+go test -timeout 30s -race ./controllers/...
+make test-integration   # Docker: real prestd + Postgres (full CI parity)
+```
+
+Integration tests live under `integration/` only; use `integration/helpers` (`ServerURL`, `MultiClusterServerURL`, `AuthServerURL`) and `integration/testutils.DoRequest`. Local `go test ./integration/...` skips network tests when `PREST_*_TEST_URL` is unset.
+
+#### Port interface changes
+
+```sh
+make mockgen
+make test-unit
+```
+
+#### Lint (when available)
+
+```sh
+golangci-lint run --timeout=5m   # CI uses v2.8.0
+```
+
+### 6. Self-review
+
+Before marking done, verify:
+
+- [ ] Diff is minimal — no unrelated formatting or drive-by refactors
+- [ ] No `adapters/postgres` imports in `controllers/`, `middlewares/`, or `router/`
+- [ ] Config additions follow warn-and-continue resilience (not hard-fail on bad TOML slices/paths)
+- [ ] New behavior has tests; controller changes include integration coverage
+- [ ] Postgres unit tests use sqlmock helpers, not live DB
+- [ ] `t.Parallel()` / serial test rules respected
+- [ ] Mocks regenerated if ports changed
+- [ ] No accidental breaking changes to flags, config keys, routes, or plugin surface
+- [ ] Resources closed (`rows.Close`, response bodies) in hot paths
+- [ ] Validation commands above were run and passed
+
+### 7. Iterate
+
+If any validation or checklist item fails: fix, re-run targeted tests, return to self-review. Do not hand off red builds or failing tests.
+
+## Package Quick Map
+
+| Package | Role |
+|---------|------|
+| `cmd/` | Cobra CLI, startup wiring |
+| `controllers/` | HTTP handlers; depend on `adapters/*` ports via `Deps` |
+| `middlewares/` | Auth, ACL, cache, cross-cutting HTTP |
+| `router/` | Route registration, composition |
+| `config/` | TOML/env loading, graceful degradation |
+| `adapters/` | Port interfaces |
+| `adapters/postgres/` | PostgreSQL implementation, pooling, SQL |
+| `integration/` | Docker + network E2E tests |
+| `cache/`, `plugins/` | Driven/driving adapters |
+
+## Definition of Done
+
+A task is **done** only when all apply:
+
+1. Code compiles (`go build ./...`) and passes `go vet ./...`
+2. Relevant unit tests pass (`make test-unit` or scoped `go test` with `-race -timeout 30s`)
+3. All possible controller/HTTP behavior changes are added to `integration/`
+4. Controller/HTTP behavior changes pass `make test-integration` (or documented reason why not run)
+5. New code paths have tests (≥80% coverage target on new paths)
+6. Port changes include regenerated mocks (`make mockgen`)
+7. Self-review checklist (step 6) is satisfied
+8. No scope creep — only files required for the task were changed
+
+When in doubt about conventions, architecture, SOLID mapping, or test patterns, read **@.github/copilot-instructions.md** before implementing.

--- a/.cursor/rules/agentic-loop.mdc
+++ b/.cursor/rules/agentic-loop.mdc
@@ -46,7 +46,7 @@ Follow repo conventions (details in @.github/copilot-instructions.md):
 | **SOLID** | One concern per handler/port; extend via new ports + wiring, not god handlers |
 | **State** | Stateless runtime — no package-level mutable app state; inject via constructors/`Deps` |
 | **Errors** | Wrap with `%w`; use `slog` for logging |
-| **Config** | **Non-sensitive** invalid/missing → `slog.Warn`, safe default/zero, continue startup (`unmarshalKeyOrZero`, `ensure*Path`). **Auth/JWT/secrets/ACL/DB credentials** → fail closed (`ensureJWTConfig`, middleware empty-key guards); do not apply warn-and-continue |
+| **Config** | Warn-and-continue **only** for non-sensitive settings: viper scalar defaults, enum fallbacks (`getJSONAgg`), optional feature dirs (`ensureCacheStorage`, `ensureQueriesPath`), and non-security structured keys (`pluginmiddlewarelist`, `cache.endpoints` via `unmarshalKeyOrZero`). **Auth, ACL, JWT, secrets, DB credentials** → fail closed (hard error or disable the feature; `ensureJWTConfig`, middleware empty-key guards) — never zero/default into a weaker security posture; do not use `unmarshalKeyOrZero` for access/ACL |
 | **SQL** | Never concatenate untrusted input; keep adapter/query conventions |
 | **Formatting** | `gofmt`; idiomatic Go; comments only for non-obvious logic |
 | **Multi-DB** | Respect `DatabaseRegistry`, context DB switching (`pctx.DBNameKey`), multicluster config |

--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,0 +1,107 @@
+---
+description: Git commit safety — commits are human-only; AI suggests, never executes
+alwaysApply: true
+---
+
+# Git Commit Practices (pREST)
+
+Commits are a **human action**. The AI must **never** run `git commit`, `git add` (to stage for a commit), or `git commit --amend` — even when the user says "commit this" or "commit your changes."
+
+When commits are in scope, the AI may inspect the repo and **prepare** a commit for the human; the human runs the final git commands locally.
+
+## What the AI Must Never Do
+
+- Run `git commit` or `git commit --amend`
+- Run `git add` to stage files for a commit
+- Create commits to "save progress" or after finishing a task
+- Create empty commits
+- Push to the remote unless the user explicitly asks (see **Push** below)
+
+If the user asks you to commit, **decline the git command** and instead offer a ready-to-run suggestion (message + `git add` / `git commit` commands they can copy).
+
+## What the AI May Do
+
+- Run read-only inspection: `git status`, `git diff`, `git log`
+- Draft a commit message and list which paths to stage
+- Warn about secrets (`.env`, `credentials.json`, tokens, keys) that must not be committed
+- Fix hook/lint issues in code when asked — the human commits after validation
+
+## Git Safety Protocol
+
+When any git write command is in scope (e.g. push, branch ops), still follow:
+
+- **Never** update git config (`git config`, global or local)
+- **Never** run destructive or irreversible commands (`push --force`, `reset --hard`, etc.) unless the user explicitly requests them
+- **Never** skip hooks (`--no-verify`, `--no-gpg-sign`, etc.) unless the user explicitly requests it
+- **Never** force-push to `main` or `master`; warn the user if they ask
+- **Never** use interactive git (`git add -i`, `git rebase -i`)
+
+## Suggesting a Commit (human runs these)
+
+When the user wants to commit, or work is ready to land, follow this sequence.
+
+### 1. Inspect (run in parallel)
+
+```sh
+git status
+git diff          # staged and unstaged
+git log -10 --oneline   # match recent message style
+```
+
+Do not run extra exploration commands beyond these git commands.
+
+### 2. Draft the message
+
+- **1–2 sentences** focused on **why**, not a file list
+- Match repo style from `git log` (see **Message style** below)
+- List only the paths the human should stage; never include secrets
+
+### 3. Hand off to the human
+
+Provide copy-paste commands, for example:
+
+```sh
+git add <relevant paths>
+git commit -m "$(cat <<'EOF'
+Subject line here.
+
+Optional body when multiple distinct changes need context.
+EOF
+)"
+```
+
+Remind them to run `git status` after committing to verify success.
+
+If pre-commit hooks fail when **they** commit, help fix the reported issue in code; do not commit on their behalf.
+
+## Commit Message Style (this repo)
+
+Recent history favors [Conventional Commits](https://www.conventionalcommits.org/) prefixes:
+
+| Prefix | Use for |
+|--------|---------|
+| `feat:` | New behavior or capability |
+| `fix:` | Bug fix |
+| `refactor:` | Internal restructure, no behavior change |
+| `chore:` | Tooling, CI, deps, housekeeping |
+| `fixup:` | Small follow-up on a prior change |
+
+Also seen: scoped subject (`mcp: …`) or imperative sentence without prefix for focused fixes.
+
+**Examples from this repo:**
+
+```
+feat: add pREST agentic development loop guideline
+fix: update .gitignore and refine agentic-loop configuration guidelines
+refactor: enable DI for controllers and split Adapter interface (#968)
+```
+
+- Prefer the prefix that matches the **primary intent** of the change
+- Add a short body (bullets ok) when the subject alone does not convey enough **why**
+- Reference issue/PR numbers when the change is tied to one (`(#973)`)
+
+## Push and Pull Requests
+
+- **Do not push** to the remote unless the user explicitly asks
+- For PR creation, follow the user's PR workflow rule if present; otherwise use `gh` and base-branch diffs before opening
+- After suggesting a commit, do not push unless asked

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ _test
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out
-coverage.out
+*.out
 
 *.cgo1.go
 *.cgo2.c

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ The first implementation is intentionally read-only. It exposes generic discover
 
 The schema-aware `prest.select.{database}.{schema}.{table}` tools are generated from the catalog and give MCP clients a stable, explicit read path for known tables.
 
+Generated table tools now include typed input schemas derived from table metadata. MCP clients can inspect these schemas to discover:
+
+- allowed `columns`
+- allowed `order_by` fields (`field` and `-field` for descending)
+- column-aware `filters`
+- `limit` and `offset`
+
+In multi-database mode, tool generation expands across registered aliases.
+
 Example initialize request:
 
 ```http
@@ -112,12 +121,38 @@ Content-Type: application/json
 }
 ```
 
+Example schema-aware table tool call with projection, filter, and ordering:
+
+```http
+POST /_mcp
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "prest.select.prest-test.public.test",
+    "arguments": {
+      "columns": ["id", "name"],
+      "filters": {
+        "name": "prest tester"
+      },
+      "order_by": ["id"],
+      "limit": 5,
+      "offset": 0
+    }
+  }
+}
+```
+
 ### Safety model
 
 - The MCP endpoint is read-only by design in the current version.
 - Unsupported tools return `400 Bad Request`.
 - Existing pREST database routing and identifier validation still apply.
 - Auth and ACL stay in the HTTP stack instead of being reimplemented in the MCP layer.
+- When auth is enabled, `/_mcp` requires authentication like other protected routes.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,81 @@ Deploy to Heroku and instantly get a realtime RESTFul API backed by Heroku Postg
 
 Visit <https://docs.prestd.com/>
 
+## MCP over HTTP
+
+pREST can expose a read-only MCP-style HTTP endpoint at `/_mcp` on the same server that already serves catalog, CRUD, and script routes.
+
+This route is intended to reuse the existing pREST request pipeline rather than introduce a separate process or transport. That means the MCP surface inherits the same deployment model, auth, ACL, and database routing behavior already used by the rest of the API.
+
+### Endpoint shape
+
+- `GET /_mcp` returns a discovery payload with server metadata and available tools.
+- `POST /_mcp` accepts JSON-RPC style requests for MCP operations.
+
+Currently supported methods:
+
+- `initialize`
+- `tools/list`
+- `tools/call`
+
+### Read-only tools
+
+The first implementation is intentionally read-only. It exposes generic discovery tools and schema-aware table tools:
+
+- `prest.list_databases`
+- `prest.list_schemas`
+- `prest.list_tables`
+- `prest.describe_table`
+- `prest.select_table`
+- `prest.select.{database}.{schema}.{table}`
+
+The schema-aware `prest.select.{database}.{schema}.{table}` tools are generated from the catalog and give MCP clients a stable, explicit read path for known tables.
+
+Example initialize request:
+
+```http
+POST /_mcp
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize"
+}
+```
+
+Example tool call:
+
+```http
+POST /_mcp
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "prest.describe_table",
+    "arguments": {
+      "database": "prest-test",
+      "schema": "public",
+      "table": "test"
+    }
+  }
+}
+```
+
+### Safety model
+
+- The MCP endpoint is read-only by design in the current version.
+- Unsupported tools return `400 Bad Request`.
+- Existing pREST database routing and identifier validation still apply.
+- Auth and ACL stay in the HTTP stack instead of being reimplemented in the MCP layer.
+
+### Tests
+
+The MCP route is covered by unit and integration tests, including live HTTP checks under [`integration/controllers/mcp_test.go`](integration/controllers/mcp_test.go) and route coverage in [`integration/router/routes_test.go`](integration/router/routes_test.go).
+
 ## Multi-database
 
 pREST uses the first URL path segment as the **database selector** for CRUD, catalog, and optional script routes. Two modes are supported:

--- a/adapters/database_registry.go
+++ b/adapters/database_registry.go
@@ -2,6 +2,7 @@ package adapters
 
 // DatabaseRegistry tracks the active database connection name.
 type DatabaseRegistry interface {
+	Aliases() []string
 	SetDatabase(name string)
 	GetDatabase() string
 	IsRegistered(alias string) bool

--- a/adapters/mock/mock.go
+++ b/adapters/mock/mock.go
@@ -344,6 +344,11 @@ func (m *Mock) DistinctClause(r *http.Request) (distinctQuery string, err error)
 func (m *Mock) SetDatabase(name string) {
 }
 
+// Aliases mock
+func (m *Mock) Aliases() []string {
+	return nil
+}
+
 // IsRegistered mock
 func (m *Mock) IsRegistered(alias string) bool {
 	return true

--- a/adapters/mockgen/adapter.go
+++ b/adapters/mockgen/adapter.go
@@ -300,6 +300,20 @@ func (mr *MockAdapterMockRecorder) FieldsPermissions(arg0, arg1, arg2, arg3, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FieldsPermissions", reflect.TypeOf((*MockAdapter)(nil).FieldsPermissions), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
+// Aliases mocks base method.
+func (m *MockAdapter) Aliases() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Aliases")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// Aliases indicates an expected call of Aliases.
+func (mr *MockAdapterMockRecorder) Aliases() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Aliases", reflect.TypeOf((*MockAdapter)(nil).Aliases))
+}
+
 // GetDatabase mocks base method.
 func (m *MockAdapter) GetDatabase() string {
 	m.ctrl.T.Helper()

--- a/adapters/mockgen/database_registry.go
+++ b/adapters/mockgen/database_registry.go
@@ -33,6 +33,20 @@ func (m *MockDatabaseRegistry) EXPECT() *MockDatabaseRegistryMockRecorder {
 	return m.recorder
 }
 
+// Aliases mocks base method.
+func (m *MockDatabaseRegistry) Aliases() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Aliases")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// Aliases indicates an expected call of Aliases.
+func (mr *MockDatabaseRegistryMockRecorder) Aliases() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Aliases", reflect.TypeOf((*MockDatabaseRegistry)(nil).Aliases))
+}
+
 // GetDatabase mocks base method.
 func (m *MockDatabaseRegistry) GetDatabase() string {
 	m.ctrl.T.Helper()

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -125,6 +125,21 @@ func (p *postgres) PingAll(ctx context.Context) error {
 	return nil
 }
 
+// Aliases returns configured database aliases or the default database name.
+func (p *postgres) Aliases() []string {
+	if p.cfg.HasDatabaseRegistry() {
+		aliases := make([]string, 0, len(p.cfg.Databases))
+		for _, dbConf := range p.cfg.Databases {
+			aliases = append(aliases, dbConf.Alias)
+		}
+		return aliases
+	}
+	if p.cfg.PGDatabase == "" {
+		return nil
+	}
+	return []string{p.cfg.PGDatabase}
+}
+
 // IsRegistered reports whether alias is a configured database registry entry.
 func (p *postgres) IsRegistered(alias string) bool {
 	if !p.cfg.HasDatabaseRegistry() {

--- a/controllers/auth_test.go
+++ b/controllers/auth_test.go
@@ -431,3 +431,38 @@ func TestToken(t *testing.T) {
 	require.NoError(t, parsed.Claims([]byte("legacy-key"), &claims))
 	require.Equal(t, user.Username, claims.UserInfo.Username)
 }
+
+func TestAuthHandler_verifyStoredPassword_BcryptSuccessAndFailure(t *testing.T) {
+	t.Parallel()
+
+	h := NewAuthHandler(nil, testAuthConfig())
+	h.cfg.Encrypt = "bcrypt"
+
+	hash, err := HashPassword("secret")
+	require.NoError(t, err)
+
+	require.NoError(t, h.verifyStoredPassword("secret", hash))
+	require.ErrorIs(t, h.verifyStoredPassword("wrong", hash), ErrUserNotFound)
+}
+
+func TestAuthHandler_verifyStoredPassword_LegacyDigestAndInvalid(t *testing.T) {
+	t.Parallel()
+
+	h := NewAuthHandler(nil, testAuthConfig())
+
+	md5Digest, err := h.legacyDigestForAlgorithm("secret", "md5")
+	require.NoError(t, err)
+	require.NoError(t, h.verifyStoredPassword("secret", md5Digest))
+	require.ErrorIs(t, h.verifyStoredPassword("wrong", md5Digest), ErrUserNotFound)
+
+	sha1Digest, err := h.legacyDigestForAlgorithm("secret", "sha1")
+	require.NoError(t, err)
+	require.NoError(t, h.verifyStoredPassword("secret", sha1Digest))
+	require.ErrorIs(t, h.verifyStoredPassword("wrong", sha1Digest), ErrUserNotFound)
+
+	require.Equal(t, "MD5", storedLegacyDigestAlgorithm(md5Digest))
+	require.Equal(t, "SHA1", storedLegacyDigestAlgorithm(sha1Digest))
+	require.Equal(t, "", storedLegacyDigestAlgorithm("not-hex"))
+	require.True(t, isHexDigest(md5Digest))
+	require.False(t, isHexDigest("xyz"))
+}

--- a/controllers/catalog_test.go
+++ b/controllers/catalog_test.go
@@ -73,6 +73,36 @@ func TestCatalogHandler_ListDatabases_Success(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "prest-test")
 }
 
+func TestCatalogHandler_ListDatabases_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	builder := mockgen.NewMockRequestQueryBuilder(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	scanner := mockgen.NewMockScanner(ctrl)
+
+	builder.EXPECT().WhereByRequest(gomock.Any(), 1).Return("datname=$1", []interface{}{"prest"}, nil)
+	catalog.EXPECT().DatabaseWhere("datname=$1").Return("WHERE datistemplate = false AND datname=$1")
+	catalog.EXPECT().DatabaseClause(gomock.Any()).Return("SELECT datname FROM pg_database", false)
+	builder.EXPECT().DistinctClause(gomock.Any()).Return("DISTINCT", nil)
+	builder.EXPECT().OrderByRequest(gomock.Any()).Return("ORDER BY datname DESC", nil)
+	catalog.EXPECT().DatabaseOrderBy("ORDER BY datname DESC", false).Return("ORDER BY datname DESC")
+	builder.EXPECT().PaginateIfPossible(gomock.Any()).Return("LIMIT 5", nil)
+	executor.EXPECT().Query(gomock.Any(), "prest").Return(scanner)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[{"datname":"prest"}]`))
+
+	h := NewCatalogHandler(Deps{Catalog: catalog, Builder: builder, Executor: executor})
+	rec := httptest.NewRecorder()
+	h.ListDatabases(rec, httptest.NewRequest(http.MethodGet, "/databases?datname=$eq.prest&_distinct=true&_order=datname&_page=1", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "prest")
+}
+
 func TestCatalogHandler_ListDatabases_QueryError(t *testing.T) {
 	t.Parallel()
 
@@ -131,6 +161,35 @@ func TestCatalogHandler_ListSchemas_Success(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "public")
 }
 
+func TestCatalogHandler_ListSchemas_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	builder := mockgen.NewMockRequestQueryBuilder(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	scanner := mockgen.NewMockScanner(ctrl)
+
+	builder.EXPECT().WhereByRequest(gomock.Any(), 1).Return("nspname=$1", []interface{}{"public"}, nil)
+	catalog.EXPECT().SchemaClause(gomock.Any()).Return("SELECT nspname FROM pg_namespace", false)
+	builder.EXPECT().DistinctClause(gomock.Any()).Return("DISTINCT", nil)
+	builder.EXPECT().OrderByRequest(gomock.Any()).Return("ORDER BY nspname DESC", nil)
+	catalog.EXPECT().SchemaOrderBy("ORDER BY nspname DESC", false).Return("ORDER BY nspname DESC")
+	builder.EXPECT().PaginateIfPossible(gomock.Any()).Return("LIMIT 10", nil)
+	executor.EXPECT().Query(gomock.Any(), "public").Return(scanner)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[{"nspname":"public"}]`))
+
+	h := NewCatalogHandler(Deps{Catalog: catalog, Builder: builder, Executor: executor})
+	rec := httptest.NewRecorder()
+	h.ListSchemas(rec, httptest.NewRequest(http.MethodGet, "/schemas?nspname=$eq.public&_distinct=true&_order=nspname&_page=1", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "public")
+}
+
 func TestCatalogHandler_ListTables_Success(t *testing.T) {
 	t.Parallel()
 
@@ -156,6 +215,36 @@ func TestCatalogHandler_ListTables_Success(t *testing.T) {
 	h := NewCatalogHandler(Deps{Catalog: catalog, Builder: builder, Executor: executor})
 	rec := httptest.NewRecorder()
 	h.ListTables(rec, httptest.NewRequest(http.MethodGet, "/tables", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "users")
+}
+
+func TestCatalogHandler_ListTables_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	builder := mockgen.NewMockRequestQueryBuilder(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	scanner := mockgen.NewMockScanner(ctrl)
+
+	builder.EXPECT().WhereByRequest(gomock.Any(), 1).Return("tablename=$1", []interface{}{"users"}, nil)
+	catalog.EXPECT().TableWhere("tablename=$1").Return("WHERE has_schema_privilege(n.nspname, 'USAGE') AND tablename=$1")
+	builder.EXPECT().OrderByRequest(gomock.Any()).Return("ORDER BY tablename DESC", nil)
+	catalog.EXPECT().TableOrderBy("ORDER BY tablename DESC").Return("ORDER BY tablename DESC")
+	catalog.EXPECT().TableClause().Return("SELECT tablename FROM pg_tables")
+	builder.EXPECT().DistinctClause(gomock.Any()).Return("DISTINCT", nil)
+	builder.EXPECT().PaginateIfPossible(gomock.Any()).Return("LIMIT 5", nil)
+	executor.EXPECT().Query(gomock.Any(), "users").Return(scanner)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[{"tablename":"users"}]`))
+
+	h := NewCatalogHandler(Deps{Catalog: catalog, Builder: builder, Executor: executor})
+	rec := httptest.NewRecorder()
+	h.ListTables(rec, httptest.NewRequest(http.MethodGet, "/tables?tablename=$eq.users&_distinct=true&_order=tablename&_page=1", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "users")
@@ -203,6 +292,37 @@ func TestCatalogHandler_ListTablesByDatabaseAndSchema_Success(t *testing.T) {
 	builder.EXPECT().OrderByRequest(gomock.Any()).Return("", nil)
 	builder.EXPECT().PaginateIfPossible(gomock.Any()).Return("", nil)
 	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any(), "prest-test", "public").Return(scanner)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[{"tablename":"users"}]`))
+
+	h := NewCatalogHandler(Deps{Catalog: catalog, Builder: builder, Executor: executor, DB: db})
+	req := crudRequest(http.MethodGet, "/prest-test/public", map[string]string{"database": "prest-test", "schema": "public"})
+	rec := httptest.NewRecorder()
+	h.ListTablesByDatabaseAndSchema(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "users")
+}
+
+func TestCatalogHandler_ListTablesByDatabaseAndSchema_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	builder := mockgen.NewMockRequestQueryBuilder(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	scanner := mockgen.NewMockScanner(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	builder.EXPECT().WhereByRequest(gomock.Any(), 3).Return("tablename=$1", []interface{}{"users"}, nil)
+	catalog.EXPECT().SchemaTablesWhere("tablename=$1").Return(" AND tablename=$1")
+	catalog.EXPECT().SchemaTablesClause().Return("SELECT tablename FROM pg_tables WHERE table_catalog=$1")
+	builder.EXPECT().OrderByRequest(gomock.Any()).Return("ORDER BY tablename DESC", nil)
+	catalog.EXPECT().SchemaTablesOrderBy("ORDER BY tablename DESC").Return("ORDER BY tablename DESC")
+	builder.EXPECT().PaginateIfPossible(gomock.Any()).Return("LIMIT 5", nil)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any(), "prest-test", "public", "users").Return(scanner)
 	scanner.EXPECT().Err().Return(nil)
 	scanner.EXPECT().Bytes().Return([]byte(`[{"tablename":"users"}]`))
 

--- a/controllers/crud_test.go
+++ b/controllers/crud_test.go
@@ -146,6 +146,91 @@ func TestCRUDHandler_Select_Success(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "prest")
 }
 
+func TestCRUDHandler_Select_WithClauses(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "test", "read", "").Return([]string{"name"}, nil)
+
+	sqlBuilder := mockgen.NewMockSQLBuilder(ctrl)
+	sqlBuilder.EXPECT().SelectFields([]string{"name"}).Return(`"name"`, nil)
+	sqlBuilder.EXPECT().SelectSQL(`"name"`, "prest-test", "public", "test").Return(`SELECT "name" FROM "prest-test"."public"."test"`)
+
+	builder := mockgen.NewMockRequestQueryBuilder(ctrl)
+	builder.EXPECT().DistinctClause(gomock.Any()).Return("DISTINCT ON (name)", nil)
+	builder.EXPECT().CountByRequest(gomock.Any()).Return("", nil)
+	builder.EXPECT().JoinByRequest(gomock.Any()).Return([]string{" JOIN other ON other.id=test.id"}, nil)
+	builder.EXPECT().WhereByRequest(gomock.Any(), 1).Return("name=$1", []interface{}{"prest"}, nil)
+	builder.EXPECT().GroupByClause(gomock.Any()).Return("GROUP BY name")
+	builder.EXPECT().OrderByRequest(gomock.Any()).Return("ORDER BY name DESC", nil)
+	builder.EXPECT().PaginateIfPossible(gomock.Any()).Return("LIMIT 10", nil)
+
+	scanner := mockgen.NewMockScanner(ctrl)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[{"name":"prest"}]`))
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any(), "prest").Return(scanner)
+
+	db := mockDatabaseRegistry(ctrl)
+
+	h := NewCRUDHandler(Deps{Perms: perms, SQL: sqlBuilder, Builder: builder, Executor: executor, DB: db})
+	req := crudRequest(http.MethodGet, "/prest-test/public/test?name=$eq.prest", map[string]string{
+		"database": "prest-test", "schema": "public", "table": "test",
+	})
+	rec := httptest.NewRecorder()
+	h.Select(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "prest")
+}
+
+func TestCRUDHandler_Select_CountFirst(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "test", "read", "").Return([]string{"name"}, nil)
+
+	sqlBuilder := mockgen.NewMockSQLBuilder(ctrl)
+	sqlBuilder.EXPECT().SelectFields([]string{"name"}).Return(`"name"`, nil)
+	sqlBuilder.EXPECT().SelectSQL(`"name"`, "prest-test", "public", "test").Return(`SELECT "name" FROM "prest-test"."public"."test"`)
+	sqlBuilder.EXPECT().SelectSQL(`SELECT count(*) as count FROM "prest-test"."public"."test"`, "prest-test", "public", "test").Return(`SELECT count(*) as count FROM "prest-test"."public"."test"`)
+
+	builder := mockgen.NewMockRequestQueryBuilder(ctrl)
+	builder.EXPECT().DistinctClause(gomock.Any()).Return("", nil)
+	builder.EXPECT().CountByRequest(gomock.Any()).Return(`SELECT count(*) as count FROM "prest-test"."public"."test"`, nil)
+	builder.EXPECT().JoinByRequest(gomock.Any()).Return(nil, nil)
+	builder.EXPECT().WhereByRequest(gomock.Any(), 1).Return("", nil, nil)
+	builder.EXPECT().GroupByClause(gomock.Any()).Return("")
+	builder.EXPECT().OrderByRequest(gomock.Any()).Return("", nil)
+	builder.EXPECT().PaginateIfPossible(gomock.Any()).Return("", nil)
+
+	countScanner := mockgen.NewMockScanner(ctrl)
+	countScanner.EXPECT().Err().Return(nil)
+	countScanner.EXPECT().Bytes().Return([]byte(`[{"count":1}]`))
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	executor.EXPECT().QueryCountCtx(gomock.Any(), gomock.Any()).Return(countScanner)
+
+	db := mockDatabaseRegistry(ctrl)
+
+	h := NewCRUDHandler(Deps{Perms: perms, SQL: sqlBuilder, Builder: builder, Executor: executor, DB: db})
+	req := crudRequest(http.MethodGet, "/prest-test/public/test?_count=*&_count_first=true", map[string]string{
+		"database": "prest-test", "schema": "public", "table": "test",
+	})
+	rec := httptest.NewRecorder()
+	h.Select(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"count":1`)
+}
+
 func TestCRUDHandler_Select_WithCache(t *testing.T) {
 	t.Parallel()
 

--- a/controllers/crud_test.go
+++ b/controllers/crud_test.go
@@ -21,8 +21,10 @@ func withTestTimeout(ctx context.Context) context.Context {
 
 func mockDatabaseRegistry(ctrl *gomock.Controller) *mockgen.MockDatabaseRegistry {
 	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().Aliases().Return([]string{"prest-test"}).AnyTimes()
 	db.EXPECT().IsRegistered(gomock.Any()).Return(true).AnyTimes()
 	db.EXPECT().GetDatabase().Return("prest-test").AnyTimes()
+	db.EXPECT().PhysicalName(gomock.Any()).DoAndReturn(func(alias string) string { return alias }).AnyTimes()
 	return db
 }
 

--- a/controllers/deps.go
+++ b/controllers/deps.go
@@ -76,6 +76,7 @@ func NewDepsFromConfig(p *config.Prest) Deps {
 type Handlers struct {
 	Auth    *AuthHandler
 	Catalog *CatalogHandler
+	MCP     *MCPHandler
 	Table   *TableHandler
 	CRUD    *CRUDHandler
 	Script  *ScriptHandler
@@ -89,6 +90,7 @@ func NewHandlers(deps Deps) *Handlers {
 	return &Handlers{
 		Auth:    NewAuthHandler(deps.Executor, deps.Auth),
 		Catalog: NewCatalogHandler(deps),
+		MCP:     NewMCPHandler(deps),
 		Table:   NewTableHandler(deps.Executor, deps.DB, deps.SingleDB),
 		CRUD:    NewCRUDHandler(deps),
 		Script:  NewScriptHandler(deps),

--- a/controllers/deps_test.go
+++ b/controllers/deps_test.go
@@ -18,22 +18,23 @@ func TestNewDepsFromConfig(t *testing.T) {
 
 	adapter := mockgen.NewMockAdapter(ctrl)
 	p := &config.Prest{
-		Adapter:    adapter,
-		SingleDB:   true,
-		PGDatabase: "prest-test",
-		AuthEnabled: true,
-		AuthType:    "body",
-		JWTKey:      "secret",
-		AuthSchema:  "public",
-		AuthTable:   "users",
+		Adapter:      adapter,
+		SingleDB:     true,
+		PGDatabase:   "prest-test",
+		AuthEnabled:  true,
+		AuthType:     "body",
+		JWTKey:       "secret",
+		AuthSchema:   "public",
+		AuthTable:    "users",
 		AuthUsername: "username",
 		AuthPassword: "password",
 		AuthEncrypt:  "MD5",
-		Cache: cache.Config{Enabled: true},
+		Cache:        cache.Config{Enabled: true},
 	}
 
 	deps := NewDepsFromConfig(p)
 	require.Equal(t, adapter, deps.Catalog)
+	require.Equal(t, adapter, deps.DB)
 	require.Equal(t, adapter, deps.Executor)
 	require.True(t, deps.SingleDB)
 	require.Equal(t, "prest-test", deps.PGDatabase)
@@ -70,6 +71,7 @@ func TestNewHandlers(t *testing.T) {
 
 	require.NotNil(t, h.Auth)
 	require.NotNil(t, h.Catalog)
+	require.NotNil(t, h.MCP)
 	require.NotNil(t, h.Table)
 	require.NotNil(t, h.CRUD)
 	require.NotNil(t, h.Script)

--- a/controllers/mcp.go
+++ b/controllers/mcp.go
@@ -336,7 +336,7 @@ func (h *MCPHandler) listSchemas(r *http.Request, args mcpListSchemasArgs) (any,
 		if schema == "" {
 			continue
 		}
-		if len(schemas) == 0 || schemas[schema] {
+		if h.perms == nil || schemas[schema] {
 			filtered = append(filtered, row)
 		}
 	}
@@ -482,7 +482,7 @@ func (h *MCPHandler) tools(r *http.Request) ([]mcpTool, error) {
 
 	seen := make(map[string]struct{})
 	for _, database := range aliases {
-		rows, err := h.tableRows(r, database, "")
+		rows, err := h.rawTableRows(r, database, "")
 		if err != nil {
 			continue
 		}
@@ -529,21 +529,25 @@ func (h *MCPHandler) describeColumns(r *http.Request, database, schema, table st
 }
 
 func (h *MCPHandler) tableRows(r *http.Request, database, schema string) ([]map[string]any, error) {
-	if schema != "" {
-		query := fmt.Sprint(h.catalog.SchemaTablesClause(), h.catalog.SchemaTablesWhere(""), h.catalog.SchemaTablesOrderBy(""))
-		result, err := h.queryRows(r, query, database, database, schema)
-		if err != nil {
-			return nil, err
-		}
-		rows, ok := result.([]map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("unexpected table discovery result")
-		}
-		return h.filterAccessibleTables(r, database, rows)
+	rows, err := h.rawTableRows(r, database, schema)
+	if err != nil {
+		return nil, err
 	}
+	return h.filterAccessibleTables(r, database, rows)
+}
 
-	query := fmt.Sprint(h.catalog.TableClause(), " ", h.catalog.TableWhere(""), " ", h.catalog.TableOrderBy(""))
-	result, err := h.queryRows(r, query, database)
+func (h *MCPHandler) rawTableRows(r *http.Request, database, schema string) ([]map[string]any, error) {
+	var (
+		query  string
+		values []interface{}
+	)
+	if schema != "" {
+		query = fmt.Sprint(h.catalog.SchemaTablesClause(), h.catalog.SchemaTablesWhere(""), h.catalog.SchemaTablesOrderBy(""))
+		values = []interface{}{database, schema}
+	} else {
+		query = fmt.Sprint(h.catalog.TableClause(), " ", h.catalog.TableWhere(""), " ", h.catalog.TableOrderBy(""))
+	}
+	result, err := h.queryRows(r, query, database, values...)
 	if err != nil {
 		return nil, err
 	}
@@ -551,7 +555,7 @@ func (h *MCPHandler) tableRows(r *http.Request, database, schema string) ([]map[
 	if !ok {
 		return nil, fmt.Errorf("unexpected table discovery result")
 	}
-	return h.filterAccessibleTables(r, database, rows)
+	return rows, nil
 }
 
 func (h *MCPHandler) queryRows(r *http.Request, query string, database string, values ...interface{}) (any, error) {

--- a/controllers/mcp.go
+++ b/controllers/mcp.go
@@ -7,9 +7,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/prest/prest/v2/adapters"
+	pctx "github.com/prest/prest/v2/context"
+	"github.com/prest/prest/v2/controllers/auth"
 )
 
 const (
@@ -25,6 +28,7 @@ type MCPHandler struct {
 	builder  adapters.RequestQueryBuilder
 	executor adapters.QueryExecutor
 	db       adapters.DatabaseRegistry
+	perms    adapters.PermissionsChecker
 	singleDB bool
 	pgDB     string
 }
@@ -36,6 +40,7 @@ func NewMCPHandler(deps Deps) *MCPHandler {
 		builder:  deps.Builder,
 		executor: deps.Executor,
 		db:       deps.DB,
+		perms:    deps.Perms,
 		singleDB: deps.SingleDB,
 		pgDB:     deps.PGDatabase,
 	}
@@ -94,17 +99,47 @@ type mcpTool struct {
 }
 
 type mcpSelectArgs struct {
-	Database string `json:"database"`
-	Schema   string `json:"schema"`
-	Table    string `json:"table"`
-	Limit    int    `json:"limit"`
-	Offset   int    `json:"offset"`
+	Database string         `json:"database"`
+	Schema   string         `json:"schema"`
+	Table    string         `json:"table"`
+	Limit    int            `json:"limit"`
+	Offset   int            `json:"offset"`
+	Columns  []string       `json:"columns"`
+	OrderBy  []string       `json:"order_by"`
+	Filters  map[string]any `json:"filters"`
 }
 
 type mcpDescribeArgs struct {
 	Database string `json:"database"`
 	Schema   string `json:"schema"`
 	Table    string `json:"table"`
+}
+
+type mcpListSchemasArgs struct {
+	Database string `json:"database"`
+}
+
+type mcpListTablesArgs struct {
+	Database string `json:"database"`
+	Schema   string `json:"schema"`
+}
+
+type mcpColumn struct {
+	Name         string `json:"name"`
+	DataType     string `json:"data_type,omitempty"`
+	Nullable     bool   `json:"nullable"`
+	MaxLength    string `json:"max_length,omitempty"`
+	Generated    bool   `json:"generated,omitempty"`
+	Updatable    bool   `json:"updatable,omitempty"`
+	DefaultValue string `json:"default_value,omitempty"`
+	Position     int    `json:"position,omitempty"`
+}
+
+type mcpTableRef struct {
+	Database string
+	Schema   string
+	Table    string
+	Type     string
 }
 
 type mcpSelectResult struct {
@@ -194,7 +229,7 @@ func (h *MCPHandler) callTool(r *http.Request, params json.RawMessage) (any, err
 		Name      string          `json:"name"`
 		Arguments json.RawMessage `json:"arguments"`
 	}
-	if err := json.Unmarshal(params, &payload); err != nil {
+	if err := decodeWithNumbers(params, &payload); err != nil {
 		return nil, fmt.Errorf("invalid tool call arguments: %w", err)
 	}
 	if payload.Name == "" {
@@ -205,18 +240,26 @@ func (h *MCPHandler) callTool(r *http.Request, params json.RawMessage) (any, err
 	case "prest.list_databases":
 		return h.listDatabases(r)
 	case "prest.list_schemas":
-		return h.listSchemas(r)
+		var args mcpListSchemasArgs
+		if err := decodeWithNumbers(payload.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("invalid list schemas arguments: %w", err)
+		}
+		return h.listSchemas(r, args)
 	case "prest.list_tables":
-		return h.listTables(r)
+		var args mcpListTablesArgs
+		if err := decodeWithNumbers(payload.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("invalid list tables arguments: %w", err)
+		}
+		return h.listTables(r, args)
 	case "prest.describe_table":
 		var args mcpDescribeArgs
-		if err := json.Unmarshal(payload.Arguments, &args); err != nil {
+		if err := decodeWithNumbers(payload.Arguments, &args); err != nil {
 			return nil, fmt.Errorf("invalid describe arguments: %w", err)
 		}
 		return h.describeTable(r, args)
 	case "prest.select_table":
 		var args mcpSelectArgs
-		if err := json.Unmarshal(payload.Arguments, &args); err != nil {
+		if err := decodeWithNumbers(payload.Arguments, &args); err != nil {
 			return nil, fmt.Errorf("invalid select arguments: %w", err)
 		}
 		return h.selectTable(r, args)
@@ -229,45 +272,99 @@ func (h *MCPHandler) callTool(r *http.Request, params json.RawMessage) (any, err
 			return nil, err
 		}
 		if len(payload.Arguments) > 0 && string(payload.Arguments) != "null" {
-			if err := json.Unmarshal(payload.Arguments, &args); err != nil {
+			var override mcpSelectArgs
+			if err := decodeWithNumbers(payload.Arguments, &override); err != nil {
 				return nil, fmt.Errorf("invalid select arguments: %w", err)
 			}
+			override.Database = args.Database
+			override.Schema = args.Schema
+			override.Table = args.Table
+			if override.Limit == 0 {
+				override.Limit = args.Limit
+			}
+			args = override
 		}
 		return h.selectTable(r, args)
 	}
 }
 
 func (h *MCPHandler) listDatabases(r *http.Request) (any, error) {
+	aliases := h.databaseAliases()
+	if len(aliases) > 0 {
+		rows := make([]map[string]any, 0, len(aliases))
+		for _, alias := range aliases {
+			rows = append(rows, map[string]any{
+				"name":          alias,
+				"datname":       alias,
+				"physical_name": h.physicalDatabase(alias),
+			})
+		}
+		return rows, nil
+	}
+
 	query, hasCount := h.catalog.DatabaseClause(httptest.NewRequest(http.MethodGet, "/databases", nil))
 	query = fmt.Sprint(query, " ", h.catalog.DatabaseWhere(""), " ", h.catalog.DatabaseOrderBy("", hasCount))
-	return h.queryRows(r, query)
+	return h.queryRows(r, query, h.defaultDatabase())
 }
 
-func (h *MCPHandler) listSchemas(r *http.Request) (any, error) {
+func (h *MCPHandler) listSchemas(r *http.Request, args mcpListSchemasArgs) (any, error) {
+	if args.Database == "" {
+		args.Database = h.defaultDatabase()
+	}
+	if err := validateDatabase(args.Database, h.db, h.singleDB); err != nil {
+		return nil, err
+	}
+
 	query, hasCount := h.catalog.SchemaClause(httptest.NewRequest(http.MethodGet, "/schemas", nil))
 	query = fmt.Sprint(query, " ", h.catalog.SchemaOrderBy("", hasCount))
-	return h.queryRows(r, query)
+	result, err := h.queryRows(r, query, args.Database)
+	if err != nil {
+		return nil, err
+	}
+	rows, ok := result.([]map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected schema discovery result")
+	}
+	schemas, err := h.accessibleSchemas(r, args.Database)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		schema := firstString(row, "schema", "schema_name", "nspname")
+		if schema == "" {
+			continue
+		}
+		if len(schemas) == 0 || schemas[schema] {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered, nil
 }
 
-func (h *MCPHandler) listTables(r *http.Request) (any, error) {
-	query := fmt.Sprint(h.catalog.TableClause(), " ", h.catalog.TableWhere(""), " ", h.catalog.TableOrderBy(""))
-	return h.queryRows(r, query)
+func (h *MCPHandler) listTables(r *http.Request, args mcpListTablesArgs) (any, error) {
+	if args.Database == "" {
+		args.Database = h.defaultDatabase()
+	}
+	if err := validateDatabase(args.Database, h.db, h.singleDB); err != nil {
+		return nil, err
+	}
+	if args.Schema != "" && !validatePathSegments(args.Schema) {
+		return nil, fmt.Errorf("invalid identifier in path")
+	}
+	return h.tableRows(r, args.Database, args.Schema)
 }
 
 func (h *MCPHandler) describeTable(r *http.Request, args mcpDescribeArgs) (any, error) {
+	if args.Database == "" {
+		args.Database = h.defaultDatabase()
+	}
 	if err := h.validateToolTarget(args.Database, args.Schema, args.Table); err != nil {
 		return nil, err
 	}
 
-	ctx, cancel := requestContext(r, args.Database)
-	defer cancel()
-
-	sc := h.executor.ShowTableCtx(ctx, args.Schema, args.Table)
-	if err := sc.Err(); err != nil {
-		return nil, fmt.Errorf("describe table failed: %w", err)
-	}
-
-	rows, err := decodeJSONRows(sc.Bytes())
+	columns, err := h.describeColumns(r, args.Database, args.Schema, args.Table)
 	if err != nil {
 		return nil, err
 	}
@@ -276,12 +373,15 @@ func (h *MCPHandler) describeTable(r *http.Request, args mcpDescribeArgs) (any, 
 		"database": args.Database,
 		"schema":   args.Schema,
 		"table":    args.Table,
-		"columns":  columnNames(rows),
-		"rows":     rows,
+		"columns":  columns,
+		"count":    len(columns),
 	}, nil
 }
 
 func (h *MCPHandler) selectTable(r *http.Request, args mcpSelectArgs) (any, error) {
+	if args.Database == "" {
+		args.Database = h.defaultDatabase()
+	}
 	if args.Limit <= 0 || args.Limit > mcpMaxRows {
 		args.Limit = mcpMaxRows
 	}
@@ -292,11 +392,61 @@ func (h *MCPHandler) selectTable(r *http.Request, args mcpSelectArgs) (any, erro
 		return nil, err
 	}
 
-	query := fmt.Sprintf("SELECT * FROM %s.%s LIMIT %d OFFSET %d", quotePathSegment(args.Schema), quotePathSegment(args.Table), args.Limit, args.Offset)
+	columns, err := h.selectableColumns(r, args.Database, args.Schema, args.Table)
+	if err != nil {
+		return nil, err
+	}
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("you don't have permission for this action, please check the permitted fields for this table")
+	}
+
+	columnSet := make(map[string]mcpColumn, len(columns))
+	selectedColumns := make([]string, 0, len(columns))
+	for _, col := range columns {
+		columnSet[col.Name] = col
+		selectedColumns = append(selectedColumns, col.Name)
+	}
+	if len(args.Columns) > 0 {
+		selectedColumns = nil
+		seen := make(map[string]struct{}, len(args.Columns))
+		for _, name := range args.Columns {
+			if _, ok := columnSet[name]; !ok {
+				return nil, fmt.Errorf("unsupported column: %s", name)
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			selectedColumns = append(selectedColumns, name)
+		}
+	}
+
+	quotedColumns := make([]string, 0, len(selectedColumns))
+	for _, name := range selectedColumns {
+		quotedColumns = append(quotedColumns, quotePathSegment(name))
+	}
+
+	query := fmt.Sprintf("SELECT %s FROM %s.%s", strings.Join(quotedColumns, ", "), quotePathSegment(args.Schema), quotePathSegment(args.Table))
+	whereClause, values, err := buildFilterClause(args.Filters, columnSet)
+	if err != nil {
+		return nil, err
+	}
+	if whereClause != "" {
+		query = fmt.Sprintf("%s WHERE %s", query, whereClause)
+	}
+	orderClause, err := buildOrderClause(args.OrderBy, columnSet)
+	if err != nil {
+		return nil, err
+	}
+	if orderClause != "" {
+		query = fmt.Sprintf("%s %s", query, orderClause)
+	}
+	query = fmt.Sprintf("%s LIMIT %d OFFSET %d", query, args.Limit, args.Offset)
+
 	ctx, cancel := requestContext(r, args.Database)
 	defer cancel()
 
-	sc := h.executor.QueryCtx(ctx, query)
+	sc := h.executor.QueryCtx(ctx, query, values...)
 	if err := sc.Err(); err != nil {
 		return nil, fmt.Errorf("select table failed: %w", err)
 	}
@@ -310,7 +460,7 @@ func (h *MCPHandler) selectTable(r *http.Request, args mcpSelectArgs) (any, erro
 		Database: args.Database,
 		Schema:   args.Schema,
 		Table:    args.Table,
-		Columns:  columnNames(rows),
+		Columns:  selectedColumns,
 		Rows:     rows,
 		Count:    len(rows),
 	}, nil
@@ -319,66 +469,81 @@ func (h *MCPHandler) selectTable(r *http.Request, args mcpSelectArgs) (any, erro
 func (h *MCPHandler) tools(r *http.Request) ([]mcpTool, error) {
 	tools := []mcpTool{
 		{Name: "prest.list_databases", Description: "List accessible databases.", InputSchema: emptyObjectSchema()},
-		{Name: "prest.list_schemas", Description: "List schemas from the current database.", InputSchema: emptyObjectSchema()},
-		{Name: "prest.list_tables", Description: "List tables from the current database.", InputSchema: emptyObjectSchema()},
+		{Name: "prest.list_schemas", Description: "List readable schemas for a database alias.", InputSchema: mcpListSchemasSchema()},
+		{Name: "prest.list_tables", Description: "List readable tables for a database alias and optional schema.", InputSchema: mcpListTablesSchema()},
 		{Name: "prest.describe_table", Description: "Describe a table and return its columns.", InputSchema: mcpDescribeSchema()},
 		{Name: "prest.select_table", Description: "Read rows from a table in a read-only way.", InputSchema: mcpSelectSchema()},
 	}
 
-	defaultDB := h.defaultDatabase()
-	if defaultDB == "" {
+	aliases := h.databaseAliases()
+	if len(aliases) == 0 {
 		return tools, nil
 	}
 
-	rows, err := h.tableRows(r)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, row := range rows {
-		schema := firstString(row, "schema", "schemaname")
-		table := firstString(row, "name", "tablename", "table_name")
-		if schema == "" || table == "" {
-			continue
-		}
-
-		desc, err := h.describeToolDescription(r, defaultDB, schema, table)
+	seen := make(map[string]struct{})
+	for _, database := range aliases {
+		rows, err := h.tableRows(r, database, "")
 		if err != nil {
 			continue
 		}
-
-		name := strings.Join([]string{strings.TrimSuffix(mcpSelectPrefix, "."), defaultDB, schema, table}, ".")
-		tools = append(tools, mcpTool{Name: name, Description: desc, InputSchema: mcpLimitOffsetSchema()})
+		for _, row := range rows {
+			ref, ok := tableRefFromRow(database, row)
+			if !ok || !isQueryableTableType(ref.Type) {
+				continue
+			}
+			columns, err := h.selectableColumns(r, ref.Database, ref.Schema, ref.Table)
+			if err != nil || len(columns) == 0 {
+				continue
+			}
+			name := strings.Join([]string{strings.TrimSuffix(mcpSelectPrefix, "."), ref.Database, ref.Schema, ref.Table}, ".")
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			tools = append(tools, mcpTool{
+				Name:        name,
+				Description: describeToolDescription(ref, columns),
+				InputSchema: mcpTableSelectSchema(columns),
+			})
+		}
 	}
 
 	sort.SliceStable(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
 	return tools, nil
 }
 
-func (h *MCPHandler) describeToolDescription(r *http.Request, database, schema, table string) (string, error) {
+func (h *MCPHandler) describeColumns(r *http.Request, database, schema, table string) ([]mcpColumn, error) {
 	ctx, cancel := requestContext(r, database)
 	defer cancel()
 
 	sc := h.executor.ShowTableCtx(ctx, schema, table)
 	if err := sc.Err(); err != nil {
-		return "", err
+		return nil, fmt.Errorf("describe table failed: %w", err)
 	}
 
 	rows, err := decodeJSONRows(sc.Bytes())
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-
-	columns := columnNames(rows)
-	if len(columns) == 0 {
-		return fmt.Sprintf("Read rows from %s.%s.%s.", database, schema, table), nil
-	}
-	return fmt.Sprintf("Read rows from %s.%s.%s. Columns: %s.", database, schema, table, strings.Join(columns, ", ")), nil
+	return columnsFromRows(rows), nil
 }
 
-func (h *MCPHandler) tableRows(r *http.Request) ([]map[string]any, error) {
+func (h *MCPHandler) tableRows(r *http.Request, database, schema string) ([]map[string]any, error) {
+	if schema != "" {
+		query := fmt.Sprint(h.catalog.SchemaTablesClause(), h.catalog.SchemaTablesWhere(""), h.catalog.SchemaTablesOrderBy(""))
+		result, err := h.queryRows(r, query, database, database, schema)
+		if err != nil {
+			return nil, err
+		}
+		rows, ok := result.([]map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected table discovery result")
+		}
+		return h.filterAccessibleTables(r, database, rows)
+	}
+
 	query := fmt.Sprint(h.catalog.TableClause(), " ", h.catalog.TableWhere(""), " ", h.catalog.TableOrderBy(""))
-	result, err := h.queryRows(r, query)
+	result, err := h.queryRows(r, query, database)
 	if err != nil {
 		return nil, err
 	}
@@ -386,15 +551,14 @@ func (h *MCPHandler) tableRows(r *http.Request) ([]map[string]any, error) {
 	if !ok {
 		return nil, fmt.Errorf("unexpected table discovery result")
 	}
-	return rows, nil
+	return h.filterAccessibleTables(r, database, rows)
 }
 
-func (h *MCPHandler) queryRows(r *http.Request, query string) (any, error) {
-	db := h.defaultDatabase()
-	ctx, cancel := requestContext(r, db)
+func (h *MCPHandler) queryRows(r *http.Request, query string, database string, values ...interface{}) (any, error) {
+	ctx, cancel := requestContext(r, database)
 	defer cancel()
 
-	sc := h.executor.QueryCtx(ctx, query)
+	sc := h.executor.QueryCtx(ctx, query, values...)
 	if err := sc.Err(); err != nil {
 		return nil, err
 	}
@@ -403,6 +567,78 @@ func (h *MCPHandler) queryRows(r *http.Request, query string) (any, error) {
 		return nil, err
 	}
 	return rows, nil
+}
+
+func (h *MCPHandler) filterAccessibleTables(r *http.Request, database string, rows []map[string]any) ([]map[string]any, error) {
+	filtered := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		ref, ok := tableRefFromRow(database, row)
+		if !ok || !isQueryableTableType(ref.Type) {
+			continue
+		}
+		if h.perms != nil {
+			columns, err := h.selectableColumns(r, ref.Database, ref.Schema, ref.Table)
+			if err != nil {
+				return nil, err
+			}
+			if len(columns) == 0 {
+				continue
+			}
+		}
+		filtered = append(filtered, row)
+	}
+	return filtered, nil
+}
+
+func (h *MCPHandler) accessibleSchemas(r *http.Request, database string) (map[string]bool, error) {
+	tables, err := h.tableRows(r, database, "")
+	if err != nil {
+		return nil, err
+	}
+	schemas := make(map[string]bool, len(tables))
+	for _, row := range tables {
+		schema := firstString(row, "schema", "schema_name", "nspname")
+		if schema != "" {
+			schemas[schema] = true
+		}
+	}
+	return schemas, nil
+}
+
+func (h *MCPHandler) selectableColumns(r *http.Request, database, schema, table string) ([]mcpColumn, error) {
+	columns, err := h.describeColumns(r, database, schema, table)
+	if err != nil {
+		return nil, err
+	}
+	if h.perms == nil {
+		return columns, nil
+	}
+
+	userName := currentUserName(r)
+	if !h.perms.TablePermissions(database, schema, table, "read", userName) {
+		return nil, nil
+	}
+	fields, err := h.perms.FieldsPermissions(permissionRequest(r), database, schema, table, "read", userName)
+	if err != nil {
+		return nil, err
+	}
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	if containsString(fields, "*") {
+		return columns, nil
+	}
+	allowed := make(map[string]bool, len(fields))
+	for _, field := range fields {
+		allowed[field] = true
+	}
+	filtered := make([]mcpColumn, 0, len(columns))
+	for _, col := range columns {
+		if allowed[col.Name] {
+			filtered = append(filtered, col)
+		}
+	}
+	return filtered, nil
 }
 
 func (h *MCPHandler) validateToolTarget(database, schema, table string) error {
@@ -416,6 +652,34 @@ func (h *MCPHandler) validateToolTarget(database, schema, table string) error {
 		return fmt.Errorf("invalid identifier in path")
 	}
 	return nil
+}
+
+func (h *MCPHandler) physicalDatabase(alias string) string {
+	if h.db == nil {
+		return alias
+	}
+	return h.db.PhysicalName(alias)
+}
+
+func (h *MCPHandler) databaseAliases() []string {
+	if h.singleDB {
+		database := h.defaultDatabase()
+		if database == "" {
+			return nil
+		}
+		return []string{database}
+	}
+	if h.db != nil {
+		aliases := uniqueStrings(h.db.Aliases())
+		if len(aliases) > 0 {
+			return aliases
+		}
+	}
+	database := h.defaultDatabase()
+	if database == "" {
+		return nil
+	}
+	return []string{database}
 }
 
 func (h *MCPHandler) defaultDatabase() string {
@@ -451,6 +715,15 @@ func decodeJSONRows(raw []byte) ([]map[string]any, error) {
 	return rows, nil
 }
 
+func decodeWithNumbers(raw []byte, dst any) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	return dec.Decode(dst)
+}
+
 func columnNames(rows []map[string]any) []string {
 	cols := make([]string, 0, len(rows))
 	for _, row := range rows {
@@ -460,6 +733,28 @@ func columnNames(rows []map[string]any) []string {
 		}
 	}
 	return cols
+}
+
+func columnsFromRows(rows []map[string]any) []mcpColumn {
+	columns := make([]mcpColumn, 0, len(rows))
+	for _, row := range rows {
+		name := firstString(row, "column_name", "name", "field")
+		if name == "" {
+			continue
+		}
+		columns = append(columns, mcpColumn{
+			Name:         name,
+			DataType:     firstString(row, "data_type"),
+			Nullable:     yesNoBool(firstString(row, "is_nullable")),
+			MaxLength:    firstString(row, "max_length"),
+			Generated:    yesNoBool(firstString(row, "is_generated")),
+			Updatable:    yesNoBool(firstString(row, "is_updatable")),
+			DefaultValue: firstString(row, "default_value"),
+			Position:     intValue(row["position"]),
+		})
+	}
+	sort.SliceStable(columns, func(i, j int) bool { return columns[i].Position < columns[j].Position })
+	return columns
 }
 
 func firstString(row map[string]any, keys ...string) string {
@@ -478,12 +773,61 @@ func firstString(row map[string]any, keys ...string) string {
 	return ""
 }
 
+func yesNoBool(value string) bool {
+	switch strings.ToUpper(value) {
+	case "YES", "ALWAYS", "TRUE":
+		return true
+	default:
+		return false
+	}
+}
+
+func intValue(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int32:
+		return int(v)
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		i, _ := v.Int64()
+		return int(i)
+	case string:
+		i, _ := strconv.Atoi(v)
+		return i
+	default:
+		return 0
+	}
+}
+
 func quotePathSegment(segment string) string {
 	return `"` + strings.ReplaceAll(segment, `"`, `""`) + `"`
 }
 
 func emptyObjectSchema() map[string]any {
 	return map[string]any{"type": "object", "properties": map[string]any{}}
+}
+
+func mcpListSchemasSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"database": map[string]any{"type": "string"},
+		},
+	}
+}
+
+func mcpListTablesSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"database": map[string]any{"type": "string"},
+			"schema":   map[string]any{"type": "string"},
+		},
+	}
 }
 
 func mcpDescribeSchema() map[string]any {
@@ -507,19 +851,260 @@ func mcpSelectSchema() map[string]any {
 			"table":    map[string]any{"type": "string"},
 			"limit":    map[string]any{"type": "integer", "minimum": 1, "maximum": mcpMaxRows},
 			"offset":   map[string]any{"type": "integer", "minimum": 0},
+			"columns":  map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "uniqueItems": true},
+			"order_by": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "uniqueItems": true},
+			"filters":  genericFilterSchema(),
 		},
 		"required": []string{"database", "schema", "table"},
 	}
 }
 
-func mcpLimitOffsetSchema() map[string]any {
+func genericFilterSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"additionalProperties": map[string]any{
+			"anyOf": []any{
+				map[string]any{"type": "string"},
+				map[string]any{"type": "number"},
+				map[string]any{"type": "integer"},
+				map[string]any{"type": "boolean"},
+				map[string]any{"type": "null"},
+				map[string]any{
+					"type": "array",
+					"items": map[string]any{
+						"anyOf": []any{
+							map[string]any{"type": "string"},
+							map[string]any{"type": "number"},
+							map[string]any{"type": "integer"},
+							map[string]any{"type": "boolean"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func mcpTableSelectSchema(columns []mcpColumn) map[string]any {
+	columnNames := make([]string, 0, len(columns))
+	orderValues := make([]string, 0, len(columns)*2)
+	filterProperties := make(map[string]any, len(columns))
+	for _, col := range columns {
+		columnNames = append(columnNames, col.Name)
+		orderValues = append(orderValues, col.Name, "-"+col.Name)
+		filterProperties[col.Name] = nullableSchema(filterSchemaForColumn(col))
+	}
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"limit":  map[string]any{"type": "integer", "minimum": 1, "maximum": mcpMaxRows},
 			"offset": map[string]any{"type": "integer", "minimum": 0},
+			"columns": map[string]any{
+				"type":        "array",
+				"uniqueItems": true,
+				"items":       map[string]any{"type": "string", "enum": columnNames},
+			},
+			"order_by": map[string]any{
+				"type":        "array",
+				"uniqueItems": true,
+				"items":       map[string]any{"type": "string", "enum": orderValues},
+			},
+			"filters": map[string]any{
+				"type":                 "object",
+				"properties":           filterProperties,
+				"additionalProperties": false,
+			},
 		},
 	}
+}
+
+func filterSchemaForColumn(col mcpColumn) map[string]any {
+	base := valueSchemaForColumn(col)
+	return map[string]any{
+		"anyOf": []any{
+			base,
+			map[string]any{"type": "array", "items": base},
+		},
+	}
+}
+
+func valueSchemaForColumn(col mcpColumn) map[string]any {
+	switch strings.ToLower(col.DataType) {
+	case "smallint", "integer", "bigint", "serial", "bigserial":
+		return map[string]any{"type": "integer"}
+	case "numeric", "decimal", "real", "double precision":
+		return map[string]any{"type": "number"}
+	case "boolean":
+		return map[string]any{"type": "boolean"}
+	case "json", "jsonb":
+		return map[string]any{"type": "object"}
+	case "date":
+		return map[string]any{"type": "string", "format": "date"}
+	case "timestamp without time zone", "timestamp with time zone":
+		return map[string]any{"type": "string", "format": "date-time"}
+	case "time without time zone", "time with time zone":
+		return map[string]any{"type": "string", "format": "time"}
+	default:
+		return map[string]any{"type": "string"}
+	}
+}
+
+func nullableSchema(schema map[string]any) map[string]any {
+	return map[string]any{"anyOf": []any{schema, map[string]any{"type": "null"}}}
+}
+
+func buildFilterClause(filters map[string]any, columns map[string]mcpColumn) (string, []interface{}, error) {
+	if len(filters) == 0 {
+		return "", nil, nil
+	}
+	keys := make([]string, 0, len(filters))
+	for key := range filters {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	clauses := make([]string, 0, len(keys))
+	values := make([]interface{}, 0, len(keys))
+	index := 1
+	for _, key := range keys {
+		col, ok := columns[key]
+		if !ok {
+			return "", nil, fmt.Errorf("unsupported filter column: %s", key)
+		}
+		quoted := quotePathSegment(col.Name)
+		value := filters[key]
+		if value == nil {
+			clauses = append(clauses, fmt.Sprintf("%s IS NULL", quoted))
+			continue
+		}
+		if arr, ok := value.([]any); ok {
+			if len(arr) == 0 {
+				return "", nil, fmt.Errorf("filter array cannot be empty: %s", key)
+			}
+			placeholders := make([]string, 0, len(arr))
+			for _, item := range arr {
+				placeholders = append(placeholders, fmt.Sprintf("$%d", index))
+				values = append(values, item)
+				index++
+			}
+			clauses = append(clauses, fmt.Sprintf("%s IN (%s)", quoted, strings.Join(placeholders, ", ")))
+			continue
+		}
+		clauses = append(clauses, fmt.Sprintf("%s = $%d", quoted, index))
+		values = append(values, value)
+		index++
+	}
+	return strings.Join(clauses, " AND "), values, nil
+}
+
+func buildOrderClause(orderBy []string, columns map[string]mcpColumn) (string, error) {
+	if len(orderBy) == 0 {
+		return "", nil
+	}
+	parts := make([]string, 0, len(orderBy))
+	for _, item := range orderBy {
+		direction := "ASC"
+		name := item
+		if strings.HasPrefix(name, "-") {
+			direction = "DESC"
+			name = strings.TrimPrefix(name, "-")
+		}
+		if _, ok := columns[name]; !ok {
+			return "", fmt.Errorf("unsupported order column: %s", name)
+		}
+		parts = append(parts, fmt.Sprintf("%s %s", quotePathSegment(name), direction))
+	}
+	return "ORDER BY " + strings.Join(parts, ", "), nil
+}
+
+func describeToolDescription(ref mcpTableRef, columns []mcpColumn) string {
+	if len(columns) == 0 {
+		return fmt.Sprintf("Read rows from %s.%s.%s.", ref.Database, ref.Schema, ref.Table)
+	}
+	parts := make([]string, 0, len(columns))
+	for _, col := range columns {
+		if col.DataType == "" {
+			parts = append(parts, col.Name)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s)", col.Name, col.DataType))
+	}
+	return fmt.Sprintf("Read rows from %s.%s.%s. Readable columns: %s.", ref.Database, ref.Schema, ref.Table, strings.Join(parts, ", "))
+}
+
+func tableRefFromRow(database string, row map[string]any) (mcpTableRef, bool) {
+	schema := firstString(row, "schema", "schemaname", "schema_name")
+	table := firstString(row, "name", "tablename", "table_name")
+	if schema == "" || table == "" {
+		return mcpTableRef{}, false
+	}
+	rowDB := firstString(row, "database", "catalog_name")
+	if rowDB == "" {
+		rowDB = database
+	}
+	return mcpTableRef{
+		Database: rowDB,
+		Schema:   schema,
+		Table:    table,
+		Type:     firstString(row, "type"),
+	}, true
+}
+
+func isQueryableTableType(kind string) bool {
+	if kind == "" {
+		return true
+	}
+	switch kind {
+	case "table", "view", "materialized_view", "foreign_table":
+		return true
+	default:
+		return false
+	}
+}
+
+func permissionRequest(r *http.Request) *http.Request {
+	req := r.Clone(r.Context())
+	copyURL := *req.URL
+	copyURL.RawQuery = ""
+	req.URL = &copyURL
+	return req
+}
+
+func currentUserName(r *http.Request) string {
+	userInfo := r.Context().Value(pctx.UserInfoKey)
+	if user, ok := userInfo.(auth.User); ok {
+		return user.Username
+	}
+	return ""
+}
+
+func containsString(items []string, needle string) bool {
+	for _, item := range items {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func uniqueStrings(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(items))
+	uniq := make([]string, 0, len(items))
+	for _, item := range items {
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		uniq = append(uniq, item)
+	}
+	sort.Strings(uniq)
+	return uniq
 }
 
 func parseSelectToolName(name string) (mcpSelectArgs, error) {

--- a/controllers/mcp.go
+++ b/controllers/mcp.go
@@ -1,0 +1,539 @@
+package controllers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+
+	"github.com/prest/prest/v2/adapters"
+)
+
+const (
+	mcpProtocolVersion = "0.1"
+	mcpServerName      = "prest"
+	mcpSelectPrefix    = "prest.select."
+	mcpMaxRows         = 100
+)
+
+// MCPHandler serves a read-only MCP-style HTTP endpoint.
+type MCPHandler struct {
+	catalog  adapters.CatalogQuerier
+	builder  adapters.RequestQueryBuilder
+	executor adapters.QueryExecutor
+	db       adapters.DatabaseRegistry
+	singleDB bool
+	pgDB     string
+}
+
+// NewMCPHandler creates an MCPHandler.
+func NewMCPHandler(deps Deps) *MCPHandler {
+	return &MCPHandler{
+		catalog:  deps.Catalog,
+		builder:  deps.Builder,
+		executor: deps.Executor,
+		db:       deps.DB,
+		singleDB: deps.SingleDB,
+		pgDB:     deps.PGDatabase,
+	}
+}
+
+// Handler returns an http.HandlerFunc for route registration.
+func (h *MCPHandler) Handler() http.HandlerFunc {
+	return h.ServeHTTP
+}
+
+// ServeHTTP returns discovery data on GET and handles JSON-RPC style calls on POST.
+func (h *MCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.writeJSON(w, http.StatusOK, h.discoveryPayload(r))
+	case http.MethodPost:
+		h.handleRPC(w, r)
+	default:
+		jsonError(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+type mcpDiscoveryPayload struct {
+	Name         string    `json:"name"`
+	Protocol     string    `json:"protocol"`
+	Endpoint     string    `json:"endpoint"`
+	Description  string    `json:"description"`
+	Tools        []mcpTool `json:"tools"`
+	Capabilities any       `json:"capabilities,omitempty"`
+}
+
+type mcpJSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type mcpJSONRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *mcpError       `json:"error,omitempty"`
+}
+
+type mcpError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+type mcpTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type mcpSelectArgs struct {
+	Database string `json:"database"`
+	Schema   string `json:"schema"`
+	Table    string `json:"table"`
+	Limit    int    `json:"limit"`
+	Offset   int    `json:"offset"`
+}
+
+type mcpDescribeArgs struct {
+	Database string `json:"database"`
+	Schema   string `json:"schema"`
+	Table    string `json:"table"`
+}
+
+type mcpSelectResult struct {
+	Database string           `json:"database"`
+	Schema   string           `json:"schema"`
+	Table    string           `json:"table"`
+	Columns  []string         `json:"columns,omitempty"`
+	Rows     []map[string]any `json:"rows"`
+	Count    int              `json:"count"`
+}
+
+func (h *MCPHandler) handleRPC(w http.ResponseWriter, r *http.Request) {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	var req mcpJSONRPCRequest
+	if err := dec.Decode(&req); err != nil {
+		h.writeRPCError(w, nil, http.StatusBadRequest, "invalid request", err.Error())
+		return
+	}
+	if req.Method == "" {
+		h.writeRPCError(w, req.ID, http.StatusBadRequest, "invalid request", "missing method")
+		return
+	}
+
+	result, err := h.dispatchRPC(r, req.Method, req.Params)
+	if err != nil {
+		h.writeRPCError(w, req.ID, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, mcpJSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  result,
+	})
+}
+
+func (h *MCPHandler) dispatchRPC(r *http.Request, method string, params json.RawMessage) (any, error) {
+	switch method {
+	case "initialize":
+		return map[string]any{
+			"serverInfo": map[string]any{"name": mcpServerName, "version": mcpProtocolVersion},
+			"capabilities": map[string]any{
+				"tools": map[string]any{"listChanged": false},
+			},
+			"instructions": "Read-only tools are exposed through pREST auth and ACL.",
+		}, nil
+	case "tools/list":
+		tools, err := h.tools(r)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"tools": tools}, nil
+	case "tools/call":
+		return h.callTool(r, params)
+	default:
+		return nil, fmt.Errorf("unsupported method: %s", method)
+	}
+}
+
+func (h *MCPHandler) discoveryPayload(r *http.Request) mcpDiscoveryPayload {
+	tools, err := h.tools(r)
+	if err != nil {
+		return mcpDiscoveryPayload{
+			Name:        mcpServerName,
+			Protocol:    mcpProtocolVersion,
+			Endpoint:    r.URL.Path,
+			Description: err.Error(),
+		}
+	}
+
+	return mcpDiscoveryPayload{
+		Name:        mcpServerName,
+		Protocol:    mcpProtocolVersion,
+		Endpoint:    r.URL.Path,
+		Description: "Read-only MCP endpoint backed by pREST catalog and query execution.",
+		Tools:       tools,
+		Capabilities: map[string]any{
+			"tools": map[string]any{"listChanged": false},
+		},
+	}
+}
+
+func (h *MCPHandler) callTool(r *http.Request, params json.RawMessage) (any, error) {
+	var payload struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &payload); err != nil {
+		return nil, fmt.Errorf("invalid tool call arguments: %w", err)
+	}
+	if payload.Name == "" {
+		return nil, fmt.Errorf("tool name is required")
+	}
+
+	switch payload.Name {
+	case "prest.list_databases":
+		return h.listDatabases(r)
+	case "prest.list_schemas":
+		return h.listSchemas(r)
+	case "prest.list_tables":
+		return h.listTables(r)
+	case "prest.describe_table":
+		var args mcpDescribeArgs
+		if err := json.Unmarshal(payload.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("invalid describe arguments: %w", err)
+		}
+		return h.describeTable(r, args)
+	case "prest.select_table":
+		var args mcpSelectArgs
+		if err := json.Unmarshal(payload.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("invalid select arguments: %w", err)
+		}
+		return h.selectTable(r, args)
+	default:
+		if !strings.HasPrefix(payload.Name, mcpSelectPrefix) {
+			return nil, fmt.Errorf("unsupported tool: %s", payload.Name)
+		}
+		args, err := parseSelectToolName(payload.Name)
+		if err != nil {
+			return nil, err
+		}
+		if len(payload.Arguments) > 0 && string(payload.Arguments) != "null" {
+			if err := json.Unmarshal(payload.Arguments, &args); err != nil {
+				return nil, fmt.Errorf("invalid select arguments: %w", err)
+			}
+		}
+		return h.selectTable(r, args)
+	}
+}
+
+func (h *MCPHandler) listDatabases(r *http.Request) (any, error) {
+	query, hasCount := h.catalog.DatabaseClause(httptest.NewRequest(http.MethodGet, "/databases", nil))
+	query = fmt.Sprint(query, " ", h.catalog.DatabaseWhere(""), " ", h.catalog.DatabaseOrderBy("", hasCount))
+	return h.queryRows(r, query)
+}
+
+func (h *MCPHandler) listSchemas(r *http.Request) (any, error) {
+	query, hasCount := h.catalog.SchemaClause(httptest.NewRequest(http.MethodGet, "/schemas", nil))
+	query = fmt.Sprint(query, " ", h.catalog.SchemaOrderBy("", hasCount))
+	return h.queryRows(r, query)
+}
+
+func (h *MCPHandler) listTables(r *http.Request) (any, error) {
+	query := fmt.Sprint(h.catalog.TableClause(), " ", h.catalog.TableWhere(""), " ", h.catalog.TableOrderBy(""))
+	return h.queryRows(r, query)
+}
+
+func (h *MCPHandler) describeTable(r *http.Request, args mcpDescribeArgs) (any, error) {
+	if err := h.validateToolTarget(args.Database, args.Schema, args.Table); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := requestContext(r, args.Database)
+	defer cancel()
+
+	sc := h.executor.ShowTableCtx(ctx, args.Schema, args.Table)
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("describe table failed: %w", err)
+	}
+
+	rows, err := decodeJSONRows(sc.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"database": args.Database,
+		"schema":   args.Schema,
+		"table":    args.Table,
+		"columns":  columnNames(rows),
+		"rows":     rows,
+	}, nil
+}
+
+func (h *MCPHandler) selectTable(r *http.Request, args mcpSelectArgs) (any, error) {
+	if args.Limit <= 0 || args.Limit > mcpMaxRows {
+		args.Limit = mcpMaxRows
+	}
+	if args.Offset < 0 {
+		args.Offset = 0
+	}
+	if err := h.validateToolTarget(args.Database, args.Schema, args.Table); err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf("SELECT * FROM %s.%s LIMIT %d OFFSET %d", quotePathSegment(args.Schema), quotePathSegment(args.Table), args.Limit, args.Offset)
+	ctx, cancel := requestContext(r, args.Database)
+	defer cancel()
+
+	sc := h.executor.QueryCtx(ctx, query)
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("select table failed: %w", err)
+	}
+
+	rows, err := decodeJSONRows(sc.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	return mcpSelectResult{
+		Database: args.Database,
+		Schema:   args.Schema,
+		Table:    args.Table,
+		Columns:  columnNames(rows),
+		Rows:     rows,
+		Count:    len(rows),
+	}, nil
+}
+
+func (h *MCPHandler) tools(r *http.Request) ([]mcpTool, error) {
+	tools := []mcpTool{
+		{Name: "prest.list_databases", Description: "List accessible databases.", InputSchema: emptyObjectSchema()},
+		{Name: "prest.list_schemas", Description: "List schemas from the current database.", InputSchema: emptyObjectSchema()},
+		{Name: "prest.list_tables", Description: "List tables from the current database.", InputSchema: emptyObjectSchema()},
+		{Name: "prest.describe_table", Description: "Describe a table and return its columns.", InputSchema: mcpDescribeSchema()},
+		{Name: "prest.select_table", Description: "Read rows from a table in a read-only way.", InputSchema: mcpSelectSchema()},
+	}
+
+	defaultDB := h.defaultDatabase()
+	if defaultDB == "" {
+		return tools, nil
+	}
+
+	rows, err := h.tableRows(r)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		schema := firstString(row, "schema", "schemaname")
+		table := firstString(row, "name", "tablename", "table_name")
+		if schema == "" || table == "" {
+			continue
+		}
+
+		desc, err := h.describeToolDescription(r, defaultDB, schema, table)
+		if err != nil {
+			continue
+		}
+
+		name := strings.Join([]string{strings.TrimSuffix(mcpSelectPrefix, "."), defaultDB, schema, table}, ".")
+		tools = append(tools, mcpTool{Name: name, Description: desc, InputSchema: mcpLimitOffsetSchema()})
+	}
+
+	sort.SliceStable(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+	return tools, nil
+}
+
+func (h *MCPHandler) describeToolDescription(r *http.Request, database, schema, table string) (string, error) {
+	ctx, cancel := requestContext(r, database)
+	defer cancel()
+
+	sc := h.executor.ShowTableCtx(ctx, schema, table)
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+
+	rows, err := decodeJSONRows(sc.Bytes())
+	if err != nil {
+		return "", err
+	}
+
+	columns := columnNames(rows)
+	if len(columns) == 0 {
+		return fmt.Sprintf("Read rows from %s.%s.%s.", database, schema, table), nil
+	}
+	return fmt.Sprintf("Read rows from %s.%s.%s. Columns: %s.", database, schema, table, strings.Join(columns, ", ")), nil
+}
+
+func (h *MCPHandler) tableRows(r *http.Request) ([]map[string]any, error) {
+	query := fmt.Sprint(h.catalog.TableClause(), " ", h.catalog.TableWhere(""), " ", h.catalog.TableOrderBy(""))
+	result, err := h.queryRows(r, query)
+	if err != nil {
+		return nil, err
+	}
+	rows, ok := result.([]map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected table discovery result")
+	}
+	return rows, nil
+}
+
+func (h *MCPHandler) queryRows(r *http.Request, query string) (any, error) {
+	db := h.defaultDatabase()
+	ctx, cancel := requestContext(r, db)
+	defer cancel()
+
+	sc := h.executor.QueryCtx(ctx, query)
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	rows, err := decodeJSONRows(sc.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (h *MCPHandler) validateToolTarget(database, schema, table string) error {
+	if database == "" {
+		database = h.defaultDatabase()
+	}
+	if err := validateDatabase(database, h.db, h.singleDB); err != nil {
+		return err
+	}
+	if !validatePathSegments(database, schema, table) {
+		return fmt.Errorf("invalid identifier in path")
+	}
+	return nil
+}
+
+func (h *MCPHandler) defaultDatabase() string {
+	if h.pgDB != "" {
+		return h.pgDB
+	}
+	if h.db != nil {
+		return h.db.GetDatabase()
+	}
+	return ""
+}
+
+func (h *MCPHandler) writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (h *MCPHandler) writeRPCError(w http.ResponseWriter, id json.RawMessage, status int, message string, data any) {
+	h.writeJSON(w, status, mcpJSONRPCResponse{JSONRPC: "2.0", ID: id, Error: &mcpError{Code: status, Message: message, Data: data}})
+}
+
+func decodeJSONRows(raw []byte) ([]map[string]any, error) {
+	if len(raw) == 0 {
+		return []map[string]any{}, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var rows []map[string]any
+	if err := dec.Decode(&rows); err != nil {
+		return nil, fmt.Errorf("decode query result: %w", err)
+	}
+	return rows, nil
+}
+
+func columnNames(rows []map[string]any) []string {
+	cols := make([]string, 0, len(rows))
+	for _, row := range rows {
+		name := firstString(row, "column_name", "name", "field")
+		if name != "" {
+			cols = append(cols, name)
+		}
+	}
+	return cols
+}
+
+func firstString(row map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := row[key]; ok {
+			switch v := value.(type) {
+			case string:
+				return v
+			case json.Number:
+				return v.String()
+			case fmt.Stringer:
+				return v.String()
+			}
+		}
+	}
+	return ""
+}
+
+func quotePathSegment(segment string) string {
+	return `"` + strings.ReplaceAll(segment, `"`, `""`) + `"`
+}
+
+func emptyObjectSchema() map[string]any {
+	return map[string]any{"type": "object", "properties": map[string]any{}}
+}
+
+func mcpDescribeSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"database": map[string]any{"type": "string"},
+			"schema":   map[string]any{"type": "string"},
+			"table":    map[string]any{"type": "string"},
+		},
+		"required": []string{"database", "schema", "table"},
+	}
+}
+
+func mcpSelectSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"database": map[string]any{"type": "string"},
+			"schema":   map[string]any{"type": "string"},
+			"table":    map[string]any{"type": "string"},
+			"limit":    map[string]any{"type": "integer", "minimum": 1, "maximum": mcpMaxRows},
+			"offset":   map[string]any{"type": "integer", "minimum": 0},
+		},
+		"required": []string{"database", "schema", "table"},
+	}
+}
+
+func mcpLimitOffsetSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"limit":  map[string]any{"type": "integer", "minimum": 1, "maximum": mcpMaxRows},
+			"offset": map[string]any{"type": "integer", "minimum": 0},
+		},
+	}
+}
+
+func parseSelectToolName(name string) (mcpSelectArgs, error) {
+	trimmed := strings.TrimPrefix(name, mcpSelectPrefix)
+	parts := strings.Split(trimmed, ".")
+	if len(parts) != 3 {
+		return mcpSelectArgs{}, fmt.Errorf("invalid select tool name: %s", name)
+	}
+	if !validatePathSegments(parts...) {
+		return mcpSelectArgs{}, fmt.Errorf("invalid select tool name: %s", name)
+	}
+	limit := mcpMaxRows
+	if limit < 1 {
+		limit = mcpMaxRows
+	}
+	return mcpSelectArgs{Database: parts[0], Schema: parts[1], Table: parts[2], Limit: limit}, nil
+}

--- a/controllers/mcp_test.go
+++ b/controllers/mcp_test.go
@@ -175,6 +175,46 @@ func TestMCPHandler_AccessDeniedFiltersTools(t *testing.T) {
 	}
 }
 
+func TestMCPHandler_ListSchemasDoesNotLeakWhenAllFiltered(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	catalog.EXPECT().SchemaClause(gomock.Any()).Return("SELECT schema", false)
+	catalog.EXPECT().SchemaOrderBy("", false).Return("")
+	catalog.EXPECT().TableClause().Return("SELECT table")
+	catalog.EXPECT().TableWhere("").Return("")
+	catalog.EXPECT().TableOrderBy("").Return("")
+
+	schemaScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), "SELECT schema ").Return(schemaScanner)
+	schemaScanner.EXPECT().Err().Return(nil)
+	schemaScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public"},{"schema":"secret"}]`))
+
+	tableScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), "SELECT table  ").Return(tableScanner)
+	tableScanner.EXPECT().Err().Return(nil)
+	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users","type":"table"}]`))
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(false)
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	result, err := h.listSchemas(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpListSchemasArgs{Database: "prest-test"})
+	require.NoError(t, err)
+	require.Empty(t, result.([]map[string]any))
+}
+
 func TestMCPHandler_ToolsCallRejectsUnknownTool(t *testing.T) {
 	t.Parallel()
 

--- a/controllers/mcp_test.go
+++ b/controllers/mcp_test.go
@@ -228,7 +228,453 @@ func TestMCPHandler_ToolsCallRejectsUnknownTool(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "unsupported tool")
 }
 
-func TestParseSelectToolName(t *testing.T) {
+func TestMCPHandler_ServeHTTP_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	h := NewMCPHandler(Deps{})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/_mcp", nil))
+
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.Contains(t, rec.Body.String(), "method not allowed")
+}
+
+func TestMCPHandler_DispatchRPC_Initialize(t *testing.T) {
+	t.Parallel()
+
+	h := NewMCPHandler(Deps{})
+	result, err := h.dispatchRPC(httptest.NewRequest(http.MethodPost, "/_mcp", nil), "initialize", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestMCPHandler_DispatchRPC_ToolsList(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	catalog.EXPECT().TableClause().Return("SELECT table")
+	catalog.EXPECT().TableWhere("").Return("")
+	catalog.EXPECT().TableOrderBy("").Return("")
+
+	tableScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner).AnyTimes()
+	tableScanner.EXPECT().Err().Return(nil).AnyTimes()
+	tableScanner.EXPECT().Bytes().Return([]byte(`[]`)).AnyTimes()
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
+	result, err := h.dispatchRPC(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "tools/list", nil)
+	require.NoError(t, err)
+	payload := result.(map[string]any)
+	require.NotEmpty(t, payload["tools"])
+}
+
+func TestMCPHandler_DispatchRPC_UnsupportedMethod(t *testing.T) {
+	t.Parallel()
+
+	h := NewMCPHandler(Deps{})
+	_, err := h.dispatchRPC(httptest.NewRequest(http.MethodPost, "/_mcp", nil), "unknown/method", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported method")
+}
+
+func TestMCPHandler_RPC_ListDatabases(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().Aliases().Return([]string{"prest-test"}).AnyTimes()
+	db.EXPECT().PhysicalName("prest-test").Return("prest-test")
+
+	h := NewMCPHandler(Deps{DB: db, PGDatabase: "prest-test"})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.list_databases"}}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "prest-test")
+}
+
+func TestMCPHandler_RPC_ListSchemas(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog, executor, perms, db := setupSchemaListMocks(ctrl)
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.list_schemas","arguments":{"database":"prest-test"}}}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "public")
+}
+
+func TestMCPHandler_RPC_ListTables(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog, executor, perms, db := setupTableListMocks(ctrl, "")
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.list_tables","arguments":{"database":"prest-test"}}}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "users")
+}
+
+func TestMCPHandler_RPC_ListTablesWithSchema(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog, executor, perms, db := setupTableListMocks(ctrl, "public")
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.list_tables","arguments":{"database":"prest-test","schema":"public"}}}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "users")
+}
+
+func TestMCPHandler_RPC_DescribeTable(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+
+	h := NewMCPHandler(Deps{Executor: executor, DB: db, PGDatabase: "prest-test"})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.describe_table","arguments":{"database":"prest-test","schema":"public","table":"users"}}}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"name":"id"`)
+}
+
+func TestMCPHandler_RPC_SelectTable(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor, perms, db := setupSelectMocks(ctrl)
+
+	h := NewMCPHandler(Deps{Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.select_table","arguments":{"database":"prest-test","schema":"public","table":"users","limit":5}}}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"count":1`)
+}
+
+func TestMCPHandler_RPC_SchemaAwareSelectTool(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor, perms, db := setupSelectMocks(ctrl)
+
+	h := NewMCPHandler(Deps{Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.select.prest-test.public.users"}}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"count":1`)
+}
+
+func TestMCPHandler_RPC_SchemaAwareSelectToolWithOverrides(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor, perms, db := setupSelectMocks(ctrl)
+
+	h := NewMCPHandler(Deps{Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.select.prest-test.public.users","arguments":{"columns":["id"],"limit":10}}}`)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"count":1`)
+}
+
+func TestMCPHandler_ListDatabasesViaCatalog(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+
+	catalog.EXPECT().DatabaseClause(gomock.Any()).Return("SELECT datname", true)
+	catalog.EXPECT().DatabaseWhere("").Return("WHERE true")
+	catalog.EXPECT().DatabaseOrderBy("", true).Return("ORDER BY datname")
+
+	scanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), "SELECT datname WHERE true ORDER BY datname").Return(scanner)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[{"datname":"prest-test"}]`))
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor})
+	rows, err := h.listDatabases(httptest.NewRequest(http.MethodGet, "/_mcp", nil))
+	require.NoError(t, err)
+	require.Len(t, rows.([]map[string]any), 1)
+}
+
+func TestMCPHandler_SelectTable_NoPermission(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(false)
+
+	h := NewMCPHandler(Deps{Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	_, err := h.selectTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpSelectArgs{
+		Database: "prest-test", Schema: "public", Table: "users",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "permission")
+}
+
+func TestMCPHandler_SelectTable_UnsupportedColumn(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(true)
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "users", "read", "").Return([]string{"id"}, nil)
+
+	h := NewMCPHandler(Deps{Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	_, err := h.selectTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpSelectArgs{
+		Database: "prest-test", Schema: "public", Table: "users", Columns: []string{"missing"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported column")
+}
+
+func TestMCPHandler_SelectTable_LimitClampAndDuplicateColumns(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(true)
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "users", "read", "").Return([]string{"id"}, nil)
+
+	scanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), `SELECT "id" FROM "public"."users" LIMIT 100 OFFSET 0`, gomock.Any()).Return(scanner)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[]`))
+
+	h := NewMCPHandler(Deps{Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	result, err := h.selectTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpSelectArgs{
+		Database: "prest-test", Schema: "public", Table: "users",
+		Columns: []string{"id", "id"}, Limit: 500, Offset: -1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, result.(mcpSelectResult).Count)
+}
+
+func TestMCPHandler_FilterAccessibleTables_SkipsNonQueryable(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h := NewMCPHandler(Deps{PGDatabase: "prest-test"})
+	rows := []map[string]any{
+		{"schema": "public", "name": "seq", "type": "sequence"},
+		{"schema": "public", "name": "users", "type": "table"},
+	}
+	filtered, err := h.filterAccessibleTables(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "prest-test", rows)
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	require.Equal(t, "users", filtered[0]["name"])
+}
+
+func TestMCPHandler_DatabaseAliases_SingleDB(t *testing.T) {
+	t.Parallel()
+
+	h := NewMCPHandler(Deps{SingleDB: true, PGDatabase: "only-db"})
+	require.Equal(t, []string{"only-db"}, h.databaseAliases())
+}
+
+func TestMCPHandler_DefaultDatabaseFromRegistry(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().GetDatabase().Return("registry-db")
+
+	h := NewMCPHandler(Deps{DB: db})
+	require.Equal(t, "registry-db", h.defaultDatabase())
+}
+
+func TestMCPHandler_CallTool_InvalidArguments(t *testing.T) {
+	t.Parallel()
+
+	h := NewMCPHandler(Deps{})
+	_, err := h.callTool(httptest.NewRequest(http.MethodPost, "/_mcp", nil), json.RawMessage(`{"name":"prest.list_schemas","arguments":"bad"}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid list schemas arguments")
+}
+
+func TestMCPHandler_CallTool_MissingToolName(t *testing.T) {
+	t.Parallel()
+
+	h := NewMCPHandler(Deps{})
+	_, err := h.callTool(httptest.NewRequest(http.MethodPost, "/_mcp", nil), json.RawMessage(`{}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tool name is required")
+}
+
+func setupSchemaListMocks(ctrl *gomock.Controller) (*mockgen.MockCatalogQuerier, *mockgen.MockQueryExecutor, *mockgen.MockPermissionsChecker, *mockgen.MockDatabaseRegistry) {
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	catalog.EXPECT().SchemaClause(gomock.Any()).Return("SELECT schema", false)
+	catalog.EXPECT().SchemaOrderBy("", false).Return("")
+	catalog.EXPECT().TableClause().Return("SELECT table")
+	catalog.EXPECT().TableWhere("").Return("")
+	catalog.EXPECT().TableOrderBy("").Return("")
+
+	schemaScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), "SELECT schema ").Return(schemaScanner)
+	schemaScanner.EXPECT().Err().Return(nil)
+	schemaScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public"}]`))
+
+	tableScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), "SELECT table  ").Return(tableScanner)
+	tableScanner.EXPECT().Err().Return(nil)
+	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users","type":"table"}]`))
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(true)
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "users", "read", "").Return([]string{"id"}, nil)
+
+	return catalog, executor, perms, db
+}
+
+func setupTableListMocks(ctrl *gomock.Controller, schema string) (*mockgen.MockCatalogQuerier, *mockgen.MockQueryExecutor, *mockgen.MockPermissionsChecker, *mockgen.MockDatabaseRegistry) {
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	if schema != "" {
+		catalog.EXPECT().SchemaTablesClause().Return("SELECT schema tables")
+		catalog.EXPECT().SchemaTablesWhere("").Return(" WHERE schema=$2")
+		catalog.EXPECT().SchemaTablesOrderBy("").Return("")
+		scanner := mockgen.NewMockScanner(ctrl)
+		executor.EXPECT().QueryCtx(gomock.Any(), "SELECT schema tables WHERE schema=$2", "prest-test", "public").Return(scanner)
+		scanner.EXPECT().Err().Return(nil)
+		scanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users","type":"table"}]`))
+	} else {
+		catalog.EXPECT().TableClause().Return("SELECT table")
+		catalog.EXPECT().TableWhere("").Return("")
+		catalog.EXPECT().TableOrderBy("").Return("")
+		scanner := mockgen.NewMockScanner(ctrl)
+		executor.EXPECT().QueryCtx(gomock.Any(), "SELECT table  ").Return(scanner)
+		scanner.EXPECT().Err().Return(nil)
+		scanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users","type":"table"}]`))
+	}
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(true)
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "users", "read", "").Return([]string{"id"}, nil)
+
+	return catalog, executor, perms, db
+}
+
+func setupSelectMocks(ctrl *gomock.Controller) (*mockgen.MockQueryExecutor, *mockgen.MockPermissionsChecker, *mockgen.MockDatabaseRegistry) {
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(true)
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "users", "read", "").Return([]string{"id"}, nil)
+
+	scanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any(), gomock.Any()).Return(scanner)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[{"id":1}]`))
+
+	return executor, perms, db
+}
+
+func TestMCP_ParseSelectToolName(t *testing.T) {
 	t.Parallel()
 
 	args, err := parseSelectToolName("prest.select.prest-test.public.users")
@@ -241,7 +687,7 @@ func TestParseSelectToolName(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestDecodeJSONRows(t *testing.T) {
+func TestMCP_DecodeJSONRows(t *testing.T) {
 	t.Parallel()
 
 	rows, err := decodeJSONRows([]byte(`[{"id":1},{"id":2}]`))
@@ -249,7 +695,7 @@ func TestDecodeJSONRows(t *testing.T) {
 	require.Len(t, rows, 2)
 }
 
-func TestDecodeWithNumbers(t *testing.T) {
+func TestMCP_DecodeWithNumbers(t *testing.T) {
 	t.Parallel()
 
 	var out map[string]any
@@ -258,7 +704,7 @@ func TestDecodeWithNumbers(t *testing.T) {
 	require.Equal(t, "1", out["n"].(json.Number).String())
 }
 
-func TestBuildFilterClause(t *testing.T) {
+func TestMCP_BuildFilterClause(t *testing.T) {
 	t.Parallel()
 
 	columns := map[string]mcpColumn{"id": {Name: "id"}, "name": {Name: "name"}}
@@ -268,11 +714,24 @@ func TestBuildFilterClause(t *testing.T) {
 	require.Contains(t, clause, `"name" = $2`)
 	require.Len(t, values, 2)
 
+	nullClause, nullValues, err := buildFilterClause(map[string]any{"name": nil}, columns)
+	require.NoError(t, err)
+	require.Contains(t, nullClause, `"name" IS NULL`)
+	require.Empty(t, nullValues)
+
+	inClause, inValues, err := buildFilterClause(map[string]any{"id": []any{float64(1), float64(2)}}, columns)
+	require.NoError(t, err)
+	require.Contains(t, inClause, `"id" IN ($1, $2)`)
+	require.Len(t, inValues, 2)
+
+	_, _, err = buildFilterClause(map[string]any{"id": []any{}}, columns)
+	require.Error(t, err)
+
 	_, _, err = buildFilterClause(map[string]any{"unknown": 1}, columns)
 	require.Error(t, err)
 }
 
-func TestBuildOrderClause(t *testing.T) {
+func TestMCP_BuildOrderClause(t *testing.T) {
 	t.Parallel()
 
 	columns := map[string]mcpColumn{"id": {Name: "id"}, "name": {Name: "name"}}

--- a/controllers/mcp_test.go
+++ b/controllers/mcp_test.go
@@ -1,0 +1,367 @@
+package controllers
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prest/prest/v2/adapters/mockgen"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPHandler_GetDiscovery(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
+	catalog.EXPECT().TableWhere("").Return("")
+	catalog.EXPECT().TableOrderBy("").Return("")
+
+	tableScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner)
+	tableScanner.EXPECT().Err().Return(nil)
+	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users","type":"table","owner":"postgres"}]`))
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id"},{"column_name":"name"}]`))
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/_mcp", nil)
+
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "prest.select.prest-test.public.users")
+	require.Contains(t, rec.Body.String(), "columns")
+}
+
+func TestMCPHandler_Handler(t *testing.T) {
+	t.Parallel()
+
+	h := NewMCPHandler(Deps{})
+	require.NotNil(t, h.Handler())
+}
+
+func TestMCPHandler_ServeHTTP_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	h := NewMCPHandler(Deps{})
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/_mcp", nil))
+
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestMCPHandler_HandleRPC_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	h := NewMCPHandler(Deps{})
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", bytes.NewBufferString("{")))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "invalid request")
+}
+
+func TestMCPHandler_HandleRPC_MissingMethod(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	h := NewMCPHandler(Deps{})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1}`)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "missing method")
+}
+
+func TestMCPHandler_DispatchRPC(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
+	catalog.EXPECT().TableWhere("").Return("")
+	catalog.EXPECT().TableOrderBy("").Return("")
+
+	tableScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner)
+	tableScanner.EXPECT().Err().Return(nil)
+	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users"}]`))
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner).Times(2)
+	showScanner.EXPECT().Err().Return(nil).AnyTimes()
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id"}]`)).AnyTimes()
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
+
+	result, err := h.dispatchRPC(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "initialize", nil)
+	require.NoError(t, err)
+	require.Contains(t, result.(map[string]any), "serverInfo")
+
+	result, err = h.dispatchRPC(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "tools/list", nil)
+	require.NoError(t, err)
+	require.Contains(t, result.(map[string]any), "tools")
+
+	result, err = h.dispatchRPC(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "tools/call", []byte(`{"name":"prest.describe_table","arguments":{"database":"prest-test","schema":"public","table":"users"}}`))
+	require.NoError(t, err)
+	require.Contains(t, result.(map[string]any), "columns")
+
+	_, err = h.dispatchRPC(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "unsupported", nil)
+	require.Error(t, err)
+}
+
+func TestMCPHandler_DiscoveryErrorAndQueryError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
+	catalog.EXPECT().TableWhere("").Return("")
+	catalog.EXPECT().TableOrderBy("").Return("")
+	tableScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner)
+	tableScanner.EXPECT().Err().Return(errors.New("query failed"))
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/_mcp", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "query failed")
+}
+
+func TestMCPHandler_ListToolsAndSelectHelpers(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	db.EXPECT().IsRegistered("prest-test").Return(true).AnyTimes()
+	db.EXPECT().GetDatabase().Return("prest-test").AnyTimes()
+
+	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
+	catalog.EXPECT().TableWhere("").Return("")
+	catalog.EXPECT().TableOrderBy("").Return("")
+
+	tableScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner).Times(1)
+	tableScanner.EXPECT().Err().Return(nil).AnyTimes()
+	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users"}]`)).AnyTimes()
+
+	selectScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), `SELECT * FROM "public"."users" LIMIT 100 OFFSET 0`).Return(selectScanner)
+	selectScanner.EXPECT().Err().Return(nil)
+	selectScanner.EXPECT().Bytes().Return([]byte(`[{"id":1,"name":"Alice"}]`))
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id"},{"column_name":"name"}]`))
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
+
+	tools, err := h.tools(httptest.NewRequest(http.MethodGet, "/_mcp", nil))
+	require.NoError(t, err)
+	require.NotEmpty(t, tools)
+	require.Contains(t, tools[0].Name, "prest.")
+
+	args, err := parseSelectToolName("prest.select.prest-test.public.users")
+	require.NoError(t, err)
+	selectResult, err := h.selectTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), args)
+	require.NoError(t, err)
+	require.Len(t, selectResult.(mcpSelectResult).Rows, 1)
+	require.Equal(t, 1, selectResult.(mcpSelectResult).Count)
+
+	_, err = parseSelectToolName("invalid")
+	require.Error(t, err)
+	require.Equal(t, "prest-test", h.defaultDatabase())
+	err = h.validateToolTarget("invalid db", "public", "users")
+	require.Error(t, err)
+}
+
+func TestMCPHandler_DefaultDatabaseAndHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "prest-test", NewMCPHandler(Deps{PGDatabase: "prest-test"}).defaultDatabase())
+	require.Equal(t, "", NewMCPHandler(Deps{}).defaultDatabase())
+	require.Equal(t, []map[string]any{}, mustDecodeRows(t, []byte("[]")))
+	require.Equal(t, "abc", firstString(map[string]any{"name": "abc"}, "name"))
+	require.Equal(t, `"x"`, quotePathSegment("x"))
+}
+
+func mustDecodeRows(t *testing.T, raw []byte) []map[string]any {
+	t.Helper()
+	rows, err := decodeJSONRows(raw)
+	require.NoError(t, err)
+	return rows
+}
+
+func TestMCPHandler_ToolsCallSelectTable(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	scanner := mockgen.NewMockScanner(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	db.EXPECT().IsRegistered("prest-test").Return(true).AnyTimes()
+	db.EXPECT().GetDatabase().Return("prest-test").AnyTimes()
+
+	executor.EXPECT().QueryCtx(gomock.Any(), `SELECT * FROM "public"."users" LIMIT 100 OFFSET 0`).Return(scanner)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[{"id":1,"name":"Alice"}]`))
+
+	h := NewMCPHandler(Deps{Executor: executor, DB: db, PGDatabase: "prest-test"})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.select.prest-test.public.users"}}`)
+	req := httptest.NewRequest(http.MethodPost, "/_mcp", body)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"Alice"`)
+	require.Contains(t, rec.Body.String(), `"count":1`)
+}
+
+func TestMCPHandler_ToolsCallListMethods(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	catalog.EXPECT().DatabaseClause(gomock.Any()).Return("SELECT datname FROM pg_database", false)
+	catalog.EXPECT().DatabaseWhere("").Return("")
+	catalog.EXPECT().DatabaseOrderBy("", false).Return("")
+	dbScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(dbScanner)
+	dbScanner.EXPECT().Err().Return(nil)
+	dbScanner.EXPECT().Bytes().Return([]byte(`[{"datname":"prest-test"}]`))
+
+	catalog.EXPECT().SchemaClause(gomock.Any()).Return("SELECT nspname FROM pg_namespace", false)
+	catalog.EXPECT().SchemaOrderBy("", false).Return("")
+	schemaScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(schemaScanner)
+	schemaScanner.EXPECT().Err().Return(nil)
+	schemaScanner.EXPECT().Bytes().Return([]byte(`[{"nspname":"public"}]`))
+
+	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
+	catalog.EXPECT().TableWhere("").Return("")
+	catalog.EXPECT().TableOrderBy("").Return("")
+	tableScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner)
+	tableScanner.EXPECT().Err().Return(nil)
+	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users"}]`))
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
+
+	for _, tool := range []string{"prest.list_databases", "prest.list_schemas", "prest.list_tables"} {
+		body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + tool + `"}}`)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+}
+
+func TestMCPHandler_DescribeTableInvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().IsRegistered("missing").Return(false)
+
+	h := NewMCPHandler(Deps{DB: db})
+	_, err := h.describeTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpDescribeArgs{Database: "missing", Schema: "public", Table: "users"})
+	require.Error(t, err)
+}
+
+func TestMCPHandler_WriteRPCError(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	NewMCPHandler(Deps{}).writeRPCError(rec, json.RawMessage("1"), http.StatusBadRequest, "boom", nil)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "boom")
+}
+
+func TestMCPHandler_ToolsCallRejectsUnknownTool(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h := NewMCPHandler(Deps{})
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.drop_table","arguments":{"sql":"DROP TABLE users"}}}`)
+	req := httptest.NewRequest(http.MethodPost, "/_mcp", body)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "unsupported tool")
+}
+
+func TestParseSelectToolName(t *testing.T) {
+	t.Parallel()
+
+	args, err := parseSelectToolName("prest.select.prest-test.public.users")
+	require.NoError(t, err)
+	require.Equal(t, "prest-test", args.Database)
+	require.Equal(t, "public", args.Schema)
+	require.Equal(t, "users", args.Table)
+}
+
+func TestDecodeJSONRows(t *testing.T) {
+	t.Parallel()
+
+	rows, err := decodeJSONRows([]byte(`[{"id":1},{"id":2}]`))
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+}
+
+func TestMCPHandler_WriteJSON(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	NewMCPHandler(Deps{}).writeJSON(rec, http.StatusOK, map[string]any{"ok": true})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var decoded map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&decoded))
+	require.Equal(t, true, decoded["ok"])
+}

--- a/controllers/mcp_test.go
+++ b/controllers/mcp_test.go
@@ -21,6 +21,7 @@ func TestMCPHandler_GetDiscovery(t *testing.T) {
 
 	catalog := mockgen.NewMockCatalogQuerier(ctrl)
 	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
 	db := mockDatabaseRegistry(ctrl)
 
 	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
@@ -30,14 +31,17 @@ func TestMCPHandler_GetDiscovery(t *testing.T) {
 	tableScanner := mockgen.NewMockScanner(ctrl)
 	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner)
 	tableScanner.EXPECT().Err().Return(nil)
-	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users","type":"table","owner":"postgres"}]`))
+	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users","type":"table"}]`))
+
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(true).AnyTimes()
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "users", "read", "").Return([]string{"*"}, nil).AnyTimes()
 
 	showScanner := mockgen.NewMockScanner(ctrl)
-	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
-	showScanner.EXPECT().Err().Return(nil)
-	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id"},{"column_name":"name"}]`))
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner).AnyTimes()
+	showScanner.EXPECT().Err().Return(nil).AnyTimes()
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1},{"column_name":"name","data_type":"text","position":2}]`)).AnyTimes()
 
-	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/_mcp", nil)
 
@@ -45,24 +49,8 @@ func TestMCPHandler_GetDiscovery(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "prest.select.prest-test.public.users")
-	require.Contains(t, rec.Body.String(), "columns")
-}
-
-func TestMCPHandler_Handler(t *testing.T) {
-	t.Parallel()
-
-	h := NewMCPHandler(Deps{})
-	require.NotNil(t, h.Handler())
-}
-
-func TestMCPHandler_ServeHTTP_MethodNotAllowed(t *testing.T) {
-	t.Parallel()
-
-	rec := httptest.NewRecorder()
-	h := NewMCPHandler(Deps{})
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut, "/_mcp", nil))
-
-	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.Contains(t, rec.Body.String(), "order_by")
+	require.Contains(t, rec.Body.String(), "filters")
 }
 
 func TestMCPHandler_HandleRPC_InvalidJSON(t *testing.T) {
@@ -88,250 +76,114 @@ func TestMCPHandler_HandleRPC_MissingMethod(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "missing method")
 }
 
-func TestMCPHandler_DispatchRPC(t *testing.T) {
+func TestMCPHandler_SelectTableWithFiltersAndOrder(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	catalog := mockgen.NewMockCatalogQuerier(ctrl)
 	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
 	db := mockDatabaseRegistry(ctrl)
 
-	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
-	catalog.EXPECT().TableWhere("").Return("")
-	catalog.EXPECT().TableOrderBy("").Return("")
-
-	tableScanner := mockgen.NewMockScanner(ctrl)
-	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner)
-	tableScanner.EXPECT().Err().Return(nil)
-	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users"}]`))
-
-	showScanner := mockgen.NewMockScanner(ctrl)
-	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner).Times(2)
-	showScanner.EXPECT().Err().Return(nil).AnyTimes()
-	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id"}]`)).AnyTimes()
-
-	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
-
-	result, err := h.dispatchRPC(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "initialize", nil)
-	require.NoError(t, err)
-	require.Contains(t, result.(map[string]any), "serverInfo")
-
-	result, err = h.dispatchRPC(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "tools/list", nil)
-	require.NoError(t, err)
-	require.Contains(t, result.(map[string]any), "tools")
-
-	result, err = h.dispatchRPC(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "tools/call", []byte(`{"name":"prest.describe_table","arguments":{"database":"prest-test","schema":"public","table":"users"}}`))
-	require.NoError(t, err)
-	require.Contains(t, result.(map[string]any), "columns")
-
-	_, err = h.dispatchRPC(httptest.NewRequest(http.MethodGet, "/_mcp", nil), "unsupported", nil)
-	require.Error(t, err)
-}
-
-func TestMCPHandler_DiscoveryErrorAndQueryError(t *testing.T) {
-	t.Parallel()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	catalog := mockgen.NewMockCatalogQuerier(ctrl)
-	executor := mockgen.NewMockQueryExecutor(ctrl)
-	db := mockDatabaseRegistry(ctrl)
-
-	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
-	catalog.EXPECT().TableWhere("").Return("")
-	catalog.EXPECT().TableOrderBy("").Return("")
-	tableScanner := mockgen.NewMockScanner(ctrl)
-	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner)
-	tableScanner.EXPECT().Err().Return(errors.New("query failed"))
-
-	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/_mcp", nil))
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.Contains(t, rec.Body.String(), "query failed")
-}
-
-func TestMCPHandler_ListToolsAndSelectHelpers(t *testing.T) {
-	t.Parallel()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	catalog := mockgen.NewMockCatalogQuerier(ctrl)
-	executor := mockgen.NewMockQueryExecutor(ctrl)
-	db := mockDatabaseRegistry(ctrl)
-
-	db.EXPECT().IsRegistered("prest-test").Return(true).AnyTimes()
-	db.EXPECT().GetDatabase().Return("prest-test").AnyTimes()
-
-	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
-	catalog.EXPECT().TableWhere("").Return("")
-	catalog.EXPECT().TableOrderBy("").Return("")
-
-	tableScanner := mockgen.NewMockScanner(ctrl)
-	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner).Times(1)
-	tableScanner.EXPECT().Err().Return(nil).AnyTimes()
-	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users"}]`)).AnyTimes()
-
-	selectScanner := mockgen.NewMockScanner(ctrl)
-	executor.EXPECT().QueryCtx(gomock.Any(), `SELECT * FROM "public"."users" LIMIT 100 OFFSET 0`).Return(selectScanner)
-	selectScanner.EXPECT().Err().Return(nil)
-	selectScanner.EXPECT().Bytes().Return([]byte(`[{"id":1,"name":"Alice"}]`))
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(true)
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "users", "read", "").Return([]string{"id", "name"}, nil)
 
 	showScanner := mockgen.NewMockScanner(ctrl)
 	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
 	showScanner.EXPECT().Err().Return(nil)
-	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id"},{"column_name":"name"}]`))
+	showScanner.EXPECT().Bytes().Return([]byte(`[
+		{"column_name":"id","data_type":"integer","position":1},
+		{"column_name":"name","data_type":"text","position":2}
+	]`))
 
-	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
-
-	tools, err := h.tools(httptest.NewRequest(http.MethodGet, "/_mcp", nil))
-	require.NoError(t, err)
-	require.NotEmpty(t, tools)
-	require.Contains(t, tools[0].Name, "prest.")
-
-	args, err := parseSelectToolName("prest.select.prest-test.public.users")
-	require.NoError(t, err)
-	selectResult, err := h.selectTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), args)
-	require.NoError(t, err)
-	require.Len(t, selectResult.(mcpSelectResult).Rows, 1)
-	require.Equal(t, 1, selectResult.(mcpSelectResult).Count)
-
-	_, err = parseSelectToolName("invalid")
-	require.Error(t, err)
-	require.Equal(t, "prest-test", h.defaultDatabase())
-	err = h.validateToolTarget("invalid db", "public", "users")
-	require.Error(t, err)
-}
-
-func TestMCPHandler_DefaultDatabaseAndHelpers(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, "prest-test", NewMCPHandler(Deps{PGDatabase: "prest-test"}).defaultDatabase())
-	require.Equal(t, "", NewMCPHandler(Deps{}).defaultDatabase())
-	require.Equal(t, []map[string]any{}, mustDecodeRows(t, []byte("[]")))
-	require.Equal(t, "abc", firstString(map[string]any{"name": "abc"}, "name"))
-	require.Equal(t, `"x"`, quotePathSegment("x"))
-}
-
-func mustDecodeRows(t *testing.T, raw []byte) []map[string]any {
-	t.Helper()
-	rows, err := decodeJSONRows(raw)
-	require.NoError(t, err)
-	return rows
-}
-
-func TestMCPHandler_ToolsCallSelectTable(t *testing.T) {
-	t.Parallel()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	executor := mockgen.NewMockQueryExecutor(ctrl)
 	scanner := mockgen.NewMockScanner(ctrl)
-	db := mockDatabaseRegistry(ctrl)
-
-	db.EXPECT().IsRegistered("prest-test").Return(true).AnyTimes()
-	db.EXPECT().GetDatabase().Return("prest-test").AnyTimes()
-
-	executor.EXPECT().QueryCtx(gomock.Any(), `SELECT * FROM "public"."users" LIMIT 100 OFFSET 0`).Return(scanner)
+	executor.EXPECT().QueryCtx(
+		gomock.Any(),
+		`SELECT "id", "name" FROM "public"."users" WHERE "name" = $1 ORDER BY "id" DESC LIMIT 10 OFFSET 5`,
+		"Alice",
+	).Return(scanner)
 	scanner.EXPECT().Err().Return(nil)
 	scanner.EXPECT().Bytes().Return([]byte(`[{"id":1,"name":"Alice"}]`))
 
-	h := NewMCPHandler(Deps{Executor: executor, DB: db, PGDatabase: "prest-test"})
-	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.select.prest-test.public.users"}}`)
-	req := httptest.NewRequest(http.MethodPost, "/_mcp", body)
-	rec := httptest.NewRecorder()
-
-	h.ServeHTTP(rec, req)
-
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.Contains(t, rec.Body.String(), `"Alice"`)
-	require.Contains(t, rec.Body.String(), `"count":1`)
+	h := NewMCPHandler(Deps{Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	result, err := h.selectTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpSelectArgs{
+		Database: "prest-test",
+		Schema:   "public",
+		Table:    "users",
+		Columns:  []string{"id", "name"},
+		Filters:  map[string]any{"name": "Alice"},
+		OrderBy:  []string{"-id"},
+		Limit:    10,
+		Offset:   5,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.(mcpSelectResult).Count)
 }
 
-func TestMCPHandler_ToolsCallListMethods(t *testing.T) {
-	t.Parallel()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	catalog := mockgen.NewMockCatalogQuerier(ctrl)
-	executor := mockgen.NewMockQueryExecutor(ctrl)
-	db := mockDatabaseRegistry(ctrl)
-
-	catalog.EXPECT().DatabaseClause(gomock.Any()).Return("SELECT datname FROM pg_database", false)
-	catalog.EXPECT().DatabaseWhere("").Return("")
-	catalog.EXPECT().DatabaseOrderBy("", false).Return("")
-	dbScanner := mockgen.NewMockScanner(ctrl)
-	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(dbScanner)
-	dbScanner.EXPECT().Err().Return(nil)
-	dbScanner.EXPECT().Bytes().Return([]byte(`[{"datname":"prest-test"}]`))
-
-	catalog.EXPECT().SchemaClause(gomock.Any()).Return("SELECT nspname FROM pg_namespace", false)
-	catalog.EXPECT().SchemaOrderBy("", false).Return("")
-	schemaScanner := mockgen.NewMockScanner(ctrl)
-	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(schemaScanner)
-	schemaScanner.EXPECT().Err().Return(nil)
-	schemaScanner.EXPECT().Bytes().Return([]byte(`[{"nspname":"public"}]`))
-
-	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
-	catalog.EXPECT().TableWhere("").Return("")
-	catalog.EXPECT().TableOrderBy("").Return("")
-	tableScanner := mockgen.NewMockScanner(ctrl)
-	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner)
-	tableScanner.EXPECT().Err().Return(nil)
-	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users"}]`))
-
-	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
-
-	for _, tool := range []string{"prest.list_databases", "prest.list_schemas", "prest.list_tables"} {
-		body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + tool + `"}}`)
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/_mcp", body))
-		require.Equal(t, http.StatusOK, rec.Code)
-	}
-}
-
-func TestMCPHandler_DescribeTableInvalidTarget(t *testing.T) {
+func TestMCPHandler_ListDatabasesUsesAliases(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	db := mockgen.NewMockDatabaseRegistry(ctrl)
-	db.EXPECT().IsRegistered("missing").Return(false)
+	db.EXPECT().Aliases().Return([]string{"prest-test", "secondary-db"})
+	db.EXPECT().PhysicalName("prest-test").Return("prest-test")
+	db.EXPECT().PhysicalName("secondary-db").Return("secondary-cluster")
 
-	h := NewMCPHandler(Deps{DB: db})
-	_, err := h.describeTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpDescribeArgs{Database: "missing", Schema: "public", Table: "users"})
-	require.Error(t, err)
+	h := NewMCPHandler(Deps{DB: db, PGDatabase: "prest-test"})
+	rows, err := h.listDatabases(httptest.NewRequest(http.MethodGet, "/_mcp", nil))
+	require.NoError(t, err)
+	payload := rows.([]map[string]any)
+	require.Len(t, payload, 2)
+	require.Equal(t, "secondary-cluster", payload[1]["physical_name"])
 }
 
-func TestMCPHandler_WriteRPCError(t *testing.T) {
-	t.Parallel()
-
-	rec := httptest.NewRecorder()
-	NewMCPHandler(Deps{}).writeRPCError(rec, json.RawMessage("1"), http.StatusBadRequest, "boom", nil)
-	require.Equal(t, http.StatusBadRequest, rec.Code)
-	require.Contains(t, rec.Body.String(), "boom")
-}
-
-func TestMCPHandler_ToolsCallRejectsUnknownTool(t *testing.T) {
+func TestMCPHandler_AccessDeniedFiltersTools(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	catalog := mockgen.NewMockCatalogQuerier(ctrl)
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	catalog.EXPECT().TableClause().Return(`SELECT n.nspname as "schema", c.relname as "name" FROM pg_catalog.pg_class c`)
+	catalog.EXPECT().TableWhere("").Return("")
+	catalog.EXPECT().TableOrderBy("").Return("")
+
+	tableScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().QueryCtx(gomock.Any(), gomock.Any()).Return(tableScanner)
+	tableScanner.EXPECT().Err().Return(nil)
+	tableScanner.EXPECT().Bytes().Return([]byte(`[{"schema":"public","name":"users","type":"table"}]`))
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(false).AnyTimes()
+
+	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	tools, err := h.tools(httptest.NewRequest(http.MethodGet, "/_mcp", nil))
+	require.NoError(t, err)
+
+	for _, tool := range tools {
+		require.NotContains(t, tool.Name, "prest.select.prest-test.public.users")
+	}
+}
+
+func TestMCPHandler_ToolsCallRejectsUnknownTool(t *testing.T) {
+	t.Parallel()
+
 	h := NewMCPHandler(Deps{})
-	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.drop_table","arguments":{"sql":"DROP TABLE users"}}}`)
+	body := bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"prest.drop_table"}}`)
 	req := httptest.NewRequest(http.MethodPost, "/_mcp", body)
 	rec := httptest.NewRecorder()
 
 	h.ServeHTTP(rec, req)
-
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, rec.Body.String(), "unsupported tool")
 }
@@ -344,6 +196,9 @@ func TestParseSelectToolName(t *testing.T) {
 	require.Equal(t, "prest-test", args.Database)
 	require.Equal(t, "public", args.Schema)
 	require.Equal(t, "users", args.Table)
+
+	_, err = parseSelectToolName("prest.select.invalid")
+	require.Error(t, err)
 }
 
 func TestDecodeJSONRows(t *testing.T) {
@@ -354,14 +209,53 @@ func TestDecodeJSONRows(t *testing.T) {
 	require.Len(t, rows, 2)
 }
 
-func TestMCPHandler_WriteJSON(t *testing.T) {
+func TestDecodeWithNumbers(t *testing.T) {
 	t.Parallel()
 
-	rec := httptest.NewRecorder()
-	NewMCPHandler(Deps{}).writeJSON(rec, http.StatusOK, map[string]any{"ok": true})
+	var out map[string]any
+	err := decodeWithNumbers([]byte(`{"n":1}`), &out)
+	require.NoError(t, err)
+	require.Equal(t, "1", out["n"].(json.Number).String())
+}
 
+func TestBuildFilterClause(t *testing.T) {
+	t.Parallel()
+
+	columns := map[string]mcpColumn{"id": {Name: "id"}, "name": {Name: "name"}}
+	clause, values, err := buildFilterClause(map[string]any{"id": float64(1), "name": "Alice"}, columns)
+	require.NoError(t, err)
+	require.Contains(t, clause, `"id" = $1`)
+	require.Contains(t, clause, `"name" = $2`)
+	require.Len(t, values, 2)
+
+	_, _, err = buildFilterClause(map[string]any{"unknown": 1}, columns)
+	require.Error(t, err)
+}
+
+func TestBuildOrderClause(t *testing.T) {
+	t.Parallel()
+
+	columns := map[string]mcpColumn{"id": {Name: "id"}, "name": {Name: "name"}}
+	clause, err := buildOrderClause([]string{"-id", "name"}, columns)
+	require.NoError(t, err)
+	require.Equal(t, `ORDER BY "id" DESC, "name" ASC`, clause)
+
+	_, err = buildOrderClause([]string{"missing"}, columns)
+	require.Error(t, err)
+}
+
+func TestMCPHandler_HandlerAndWriteHelpers(t *testing.T) {
+	t.Parallel()
+
+	h := NewMCPHandler(Deps{})
+	require.NotNil(t, h.Handler())
+
+	rec := httptest.NewRecorder()
+	h.writeJSON(rec, http.StatusOK, map[string]any{"ok": true})
 	require.Equal(t, http.StatusOK, rec.Code)
-	var decoded map[string]any
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&decoded))
-	require.Equal(t, true, decoded["ok"])
+
+	recErr := httptest.NewRecorder()
+	h.writeRPCError(recErr, json.RawMessage("1"), http.StatusBadRequest, "boom", errors.New("x"))
+	require.Equal(t, http.StatusBadRequest, recErr.Code)
+	require.Contains(t, recErr.Body.String(), "boom")
 }

--- a/integration/controllers/mcp_test.go
+++ b/integration/controllers/mcp_test.go
@@ -73,7 +73,7 @@ func TestMCPToolCalls(t *testing.T) {
 				},
 			},
 			status:       http.StatusOK,
-			expectedBody: `"prest-test"`,
+			expectedBody: `"physical_name":"prest-test"`,
 		},
 		{
 			name: "ListSchemas",
@@ -127,10 +127,17 @@ func TestMCPToolCalls(t *testing.T) {
 				"method":  "tools/call",
 				"params": map[string]any{
 					"name": "prest.select.prest-test.public.test",
+					"arguments": map[string]any{
+						"columns":  []string{"id", "name"},
+						"filters":  map[string]any{"name": "prest tester"},
+						"order_by": []string{"id"},
+						"limit":    5,
+						"offset":   0,
+					},
 				},
 			},
 			status:       http.StatusOK,
-			expectedBody: `"rows"`,
+			expectedBody: `"prest tester"`,
 		},
 	}
 

--- a/integration/controllers/mcp_test.go
+++ b/integration/controllers/mcp_test.go
@@ -1,0 +1,174 @@
+package controllers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/prest/prest/v2/integration/helpers"
+	"github.com/prest/prest/v2/integration/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPDiscovery(t *testing.T) {
+	base := helpers.ServerURL(t)
+	testutils.DoRequest(t, base+"/_mcp", nil, http.MethodGet, http.StatusOK, "MCPDiscovery",
+		`"name":"prest"`,
+		`"protocol":"0.1"`,
+		`"tools"`,
+		`prest.list_databases`,
+		`prest.list_schemas`,
+		`prest.list_tables`,
+	)
+}
+
+func TestMCPInitialize(t *testing.T) {
+	base := helpers.ServerURL(t)
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+	})
+	require.NoError(t, err)
+
+	testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), http.MethodPost, http.StatusOK, "MCPInitialize",
+		`"serverInfo"`,
+		`"name":"prest"`,
+		`"instructions"`,
+	)
+}
+
+func TestMCPToolsList(t *testing.T) {
+	base := helpers.ServerURL(t)
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+	})
+	require.NoError(t, err)
+
+	testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), http.MethodPost, http.StatusOK, "MCPToolsList",
+		`"tools"`,
+		`prest.list_databases`,
+		`prest.list_schemas`,
+		`prest.list_tables`,
+		`prest.describe_table`,
+		`prest.select_table`,
+	)
+}
+
+func TestMCPToolCalls(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	toolCalls := []struct {
+		name         string
+		payload      map[string]any
+		status       int
+		expectedBody string
+	}{
+		{
+			name: "ListDatabases",
+			payload: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      3,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": "prest.list_databases",
+				},
+			},
+			status:       http.StatusOK,
+			expectedBody: `"prest-test"`,
+		},
+		{
+			name: "ListSchemas",
+			payload: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      4,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": "prest.list_schemas",
+				},
+			},
+			status:       http.StatusOK,
+			expectedBody: `"public"`,
+		},
+		{
+			name: "ListTables",
+			payload: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      5,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": "prest.list_tables",
+				},
+			},
+			status:       http.StatusOK,
+			expectedBody: `"users"`,
+		},
+		{
+			name: "DescribeTable",
+			payload: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      6,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": "prest.describe_table",
+					"arguments": map[string]any{
+						"database": "prest-test",
+						"schema":   "public",
+						"table":    "test",
+					},
+				},
+			},
+			status:       http.StatusOK,
+			expectedBody: `"columns"`,
+		},
+		{
+			name: "SelectTable",
+			payload: map[string]any{
+				"jsonrpc": "2.0",
+				"id":      7,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": "prest.select.prest-test.public.test",
+				},
+			},
+			status:       http.StatusOK,
+			expectedBody: `"rows"`,
+		},
+	}
+
+	for _, tc := range toolCalls {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(tc.payload)
+			require.NoError(t, err)
+			testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), http.MethodPost, tc.status, tc.name, tc.expectedBody)
+		})
+	}
+}
+
+func TestMCPUnsupportedTool(t *testing.T) {
+	base := helpers.ServerURL(t)
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      8,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "prest.drop_table",
+		},
+	})
+	require.NoError(t, err)
+
+	testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), http.MethodPost, http.StatusBadRequest, "MCPUnsupportedTool",
+		`unsupported tool`,
+	)
+}
+
+func TestMCPMultiClusterDiscovery(t *testing.T) {
+	base := helpers.MultiClusterServerURL(t)
+	testutils.DoRequest(t, base+"/_mcp", nil, http.MethodGet, http.StatusOK, "MCPMultiClusterDiscovery",
+		`"name":"prest"`,
+		`"tools"`,
+	)
+}

--- a/integration/controllers/mcp_test.go
+++ b/integration/controllers/mcp_test.go
@@ -120,13 +120,18 @@ func TestMCPToolCalls(t *testing.T) {
 			expectedBody: `"columns"`,
 		},
 		{
+			// Reply carries a single stable seed row ("prest tester") and is
+			// never mutated by the integration suite, so this assertion stays
+			// reliable even when other packages run concurrently against the
+			// shared database (unlike the "test" table, which is emptied by the
+			// delete CRUD/router tests).
 			name: "SelectTable",
 			payload: map[string]any{
 				"jsonrpc": "2.0",
 				"id":      7,
 				"method":  "tools/call",
 				"params": map[string]any{
-					"name": "prest.select.prest-test.public.test",
+					"name": "prest.select.prest-test.public.Reply",
 					"arguments": map[string]any{
 						"columns":  []string{"id", "name"},
 						"filters":  map[string]any{"name": "prest tester"},

--- a/integration/controllers/mcp_test.go
+++ b/integration/controllers/mcp_test.go
@@ -1,14 +1,11 @@
 package controllers_test
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/prest/prest/v2/integration/helpers"
 	"github.com/prest/prest/v2/integration/testutils"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMCPDiscovery(t *testing.T) {
@@ -25,14 +22,13 @@ func TestMCPDiscovery(t *testing.T) {
 
 func TestMCPInitialize(t *testing.T) {
 	base := helpers.ServerURL(t)
-	body, err := json.Marshal(map[string]any{
+	payload := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
 		"method":  "initialize",
-	})
-	require.NoError(t, err)
+	}
 
-	testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), http.MethodPost, http.StatusOK, "MCPInitialize",
+	testutils.DoRequest(t, base+"/_mcp", payload, http.MethodPost, http.StatusOK, "MCPInitialize",
 		`"serverInfo"`,
 		`"name":"prest"`,
 		`"instructions"`,
@@ -41,14 +37,13 @@ func TestMCPInitialize(t *testing.T) {
 
 func TestMCPToolsList(t *testing.T) {
 	base := helpers.ServerURL(t)
-	body, err := json.Marshal(map[string]any{
+	payload := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      2,
 		"method":  "tools/list",
-	})
-	require.NoError(t, err)
+	}
 
-	testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), http.MethodPost, http.StatusOK, "MCPToolsList",
+	testutils.DoRequest(t, base+"/_mcp", payload, http.MethodPost, http.StatusOK, "MCPToolsList",
 		`"tools"`,
 		`prest.list_databases`,
 		`prest.list_schemas`,
@@ -104,7 +99,7 @@ func TestMCPToolCalls(t *testing.T) {
 				},
 			},
 			status:       http.StatusOK,
-			expectedBody: `"users"`,
+			expectedBody: `"name":"test"`,
 		},
 		{
 			name: "DescribeTable",
@@ -141,26 +136,23 @@ func TestMCPToolCalls(t *testing.T) {
 
 	for _, tc := range toolCalls {
 		t.Run(tc.name, func(t *testing.T) {
-			body, err := json.Marshal(tc.payload)
-			require.NoError(t, err)
-			testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), http.MethodPost, tc.status, tc.name, tc.expectedBody)
+			testutils.DoRequest(t, base+"/_mcp", tc.payload, http.MethodPost, tc.status, tc.name, tc.expectedBody)
 		})
 	}
 }
 
 func TestMCPUnsupportedTool(t *testing.T) {
 	base := helpers.ServerURL(t)
-	body, err := json.Marshal(map[string]any{
+	payload := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      8,
 		"method":  "tools/call",
 		"params": map[string]any{
 			"name": "prest.drop_table",
 		},
-	})
-	require.NoError(t, err)
+	}
 
-	testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), http.MethodPost, http.StatusBadRequest, "MCPUnsupportedTool",
+	testutils.DoRequest(t, base+"/_mcp", payload, http.MethodPost, http.StatusBadRequest, "MCPUnsupportedTool",
 		`unsupported tool`,
 	)
 }

--- a/integration/router/routes_test.go
+++ b/integration/router/routes_test.go
@@ -1,14 +1,11 @@
 package router_test
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/prest/prest/v2/integration/helpers"
 	"github.com/prest/prest/v2/integration/testutils"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRoutes(t *testing.T) {
@@ -20,13 +17,12 @@ func TestMCPRoute(t *testing.T) {
 	base := helpers.ServerURL(t)
 	testutils.DoRequest(t, base+"/_mcp", nil, "GET", http.StatusOK, "MCPDiscovery")
 
-	body, err := json.Marshal(map[string]any{
+	payload := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
 		"method":  "initialize",
-	})
-	require.NoError(t, err)
-	testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), "POST", http.StatusOK, "MCPInitialize")
+	}
+	testutils.DoRequest(t, base+"/_mcp", payload, "POST", http.StatusOK, "MCPInitialize")
 }
 
 func TestDefaultRouters(t *testing.T) {

--- a/integration/router/routes_test.go
+++ b/integration/router/routes_test.go
@@ -1,16 +1,32 @@
 package router_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/prest/prest/v2/integration/helpers"
 	"github.com/prest/prest/v2/integration/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoutes(t *testing.T) {
 	base := helpers.ServerURL(t)
 	testutils.DoRequest(t, base+"/_health", nil, "GET", http.StatusOK, "Routes")
+}
+
+func TestMCPRoute(t *testing.T) {
+	base := helpers.ServerURL(t)
+	testutils.DoRequest(t, base+"/_mcp", nil, "GET", http.StatusOK, "MCPDiscovery")
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+	})
+	require.NoError(t, err)
+	testutils.DoRequest(t, base+"/_mcp", bytes.NewReader(body), "POST", http.StatusOK, "MCPInitialize")
 }
 
 func TestDefaultRouters(t *testing.T) {
@@ -22,6 +38,7 @@ func TestDefaultRouters(t *testing.T) {
 		status int
 	}{
 		{"/databases", "GET", http.StatusOK},
+		{"/_mcp", "GET", http.StatusOK},
 		{"/schemas", "GET", http.StatusOK},
 		{"/_QUERIES/missing/script", "GET", http.StatusBadRequest},
 		{"/prest-test/public", "GET", http.StatusOK},

--- a/integration/router/routes_test.go
+++ b/integration/router/routes_test.go
@@ -58,6 +58,7 @@ func TestAuthRouterActive(t *testing.T) {
 	base := helpers.AuthServerURL(t)
 	testutils.DoRequest(t, base+"/auth", nil, "GET", http.StatusMethodNotAllowed, "AuthEnable")
 	testutils.DoRequest(t, base+"/auth", nil, "POST", http.StatusUnauthorized, "AuthEnable")
+	testutils.DoRequest(t, base+"/_mcp", nil, "GET", http.StatusUnauthorized, "MCPAuthRequired")
 }
 
 func TestMultiClusterRoutes(t *testing.T) {

--- a/router/router.go
+++ b/router/router.go
@@ -18,6 +18,7 @@ func RegisterRoutes(router *mux.Router, cfg *config.Prest, h *controllers.Handle
 	if cfg.AuthEnabled {
 		router.HandleFunc("/auth", h.Auth.Login).Methods("POST")
 	}
+	router.HandleFunc("/_mcp", h.MCP.Handler()).Methods("GET", "POST")
 	router.HandleFunc("/databases", h.Catalog.ListDatabases).Methods("GET")
 	router.HandleFunc("/schemas", h.Catalog.ListSchemas).Methods("GET")
 	router.HandleFunc("/tables", h.Catalog.ListTables).Methods("GET")

--- a/router/router.go
+++ b/router/router.go
@@ -18,7 +18,7 @@ func RegisterRoutes(router *mux.Router, cfg *config.Prest, h *controllers.Handle
 	if cfg.AuthEnabled {
 		router.HandleFunc("/auth", h.Auth.Login).Methods("POST")
 	}
-	router.HandleFunc("/_mcp", h.MCP.Handler()).Methods("GET", "POST")
+	router.Handle("/_mcp", mcpRoute(cfg, h.MCP.Handler())).Methods("GET", "POST")
 	router.HandleFunc("/databases", h.Catalog.ListDatabases).Methods("GET")
 	router.HandleFunc("/schemas", h.Catalog.ListSchemas).Methods("GET")
 	router.HandleFunc("/tables", h.Catalog.ListTables).Methods("GET")
@@ -41,4 +41,18 @@ func RegisterRoutes(router *mux.Router, cfg *config.Prest, h *controllers.Handle
 
 func crudRoute(stack *middlewares.CRUDStack, handler http.HandlerFunc) http.Handler {
 	return negroni.New(append(stack.Handlers(), negroni.Wrap(handler))...)
+}
+
+func mcpRoute(cfg *config.Prest, handler http.HandlerFunc) http.Handler {
+	if !cfg.AuthEnabled {
+		return handler
+	}
+	return negroni.New(
+		middlewares.AuthMiddleware(middlewares.AuthSettings{
+			Enabled:      cfg.AuthEnabled,
+			JWTKey:       cfg.JWTKey,
+			JWTWhiteList: cfg.JWTWhiteList,
+		}),
+		negroni.Wrap(handler),
+	)
 }


### PR DESCRIPTION
- fix prest/prest#959


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a read-only MCP-compatible HTTP endpoint at `/_mcp` supporting JSON-RPC `initialize`, `tools/list`, and `tools/call`, including schema-aware per-table select tools.
  * Tool discovery and execution are permission-aware, and HTTP access is enforced when authentication is enabled.
* **Documentation**
  * Updated the README with `/_mcp` usage, supported tools/methods, safety guarantees, and error/auth expectations.
* **Tests**
  * Expanded unit and integration coverage for the MCP endpoint, plus additional validation for auth password verification and option-driven catalog/CRUD query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->