### PR TITLE
chore: upgrade Postgres version in Docker Compose files to 18

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,10 +21,10 @@ services:
       - PREST_SSL_MODE=disable
 
   postgres:
-    image: postgres:16
+    image: postgres:18
     restart: unless-stopped
     volumes:
-      - "postgres_data:/var/lib/postgresql/data"
+      - "postgres_data:/var/lib/postgresql"
     environment:
       - POSTGRES_USER=prest
       - POSTGRES_DB=prest

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,9 +1,9 @@
 version: "3"
 services:
   postgres:
-    image: postgres:16
+    image: postgres:18
     volumes:
-      - "./data/postgres:/var/lib/postgresql/data"
+      - "./data/postgres:/var/lib/postgresql"
     environment:
       - POSTGRES_USER=prest
       - POSTGRES_DB=prest

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -20,7 +20,7 @@ x-prestd-service: &prestd-service
 
 services:
   postgres:
-    image: postgres:16
+    image: postgres:18
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
@@ -31,10 +31,10 @@ services:
       timeout: 5s
       retries: 20
     tmpfs:
-      - /var/lib/postgresql/data
+      - /var/lib/postgresql
 
   postgres-b:
-    image: postgres:16
+    image: postgres:18
     environment:
       - POSTGRES_DB=secondary-cluster
       - POSTGRES_USER=postgres
@@ -45,7 +45,7 @@ services:
       timeout: 5s
       retries: 20
     tmpfs:
-      - /var/lib/postgresql/data
+      - /var/lib/postgresql
 
   db-init:
     <<: *prestd-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: "3"
 services:
   postgres:
-    image: postgres:16
+    image: postgres:18
     volumes:
-      - "./data/postgres:/var/lib/postgresql/data"
+      - "./data/postgres:/var/lib/postgresql"
     environment:
       - POSTGRES_DB=prest
       - POSTGRES_USER=postgres

--- a/testdata/docker-compose.yml
+++ b/testdata/docker-compose.yml
@@ -1,9 +1,9 @@
 version: "3"
 services:
   postgres:
-    image: postgres:16
+    image: postgres:18
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=prest-test


### PR DESCRIPTION
- Updated Postgres image from version 16 to 18 across all Docker Compose configurations.
- Adjusted volume paths for Postgres data storage to align with the new version requirements.

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL container images from version 16 to version 18 across development, production, testing, and test data environments.
  * Updated database storage mount paths to align with PostgreSQL 18’s layout.
  * Applied the same storage configuration changes to both test database services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->