### PR TITLE
feat: enhance coverage reporting for pull requests from forks

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -42,7 +42,7 @@ jobs:
 
   coverage-report:
     name: Coverage PR comment
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: unit
     permissions:
@@ -57,3 +57,43 @@ jobs:
           root-package: github.com/prest/prest/v2
           trim: github.com/prest/prest/v2/
           github-baseline-workflow-ref: test-unit.yml
+
+  coverage-report-fork:
+    name: Coverage PR comment (fork)
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    needs: unit
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: fgrosse/go-coverage-report@v1.3.0
+        id: coverage
+        with:
+          skip-comment: true
+          coverage-artifact-name: code-coverage
+          coverage-file-name: coverage.out
+          root-package: github.com/prest/prest/v2
+          trim: github.com/prest/prest/v2/
+          github-baseline-workflow-ref: test-unit.yml
+
+      # Fork PRs: GITHUB_TOKEN cannot comment on the base repo; use PR_TOKEN (PAT).
+      - name: Post coverage comment
+        env:
+          GH_TOKEN: ${{ secrets.PR_TOKEN }}
+          COVERAGE_REPORT: ${{ steps.coverage.outputs.coverage_report }}
+        run: |
+          if [ -z "$COVERAGE_REPORT" ]; then
+            echo "No coverage report to post"
+            exit 0
+          fi
+
+          printf '%s\n' "$COVERAGE_REPORT" > coverage-comment.md
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            -q '.[] | select(.body | test("Coverage Δ")) | .id' | head -n 1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" || true
+          fi
+
+          gh pr comment "${{ github.event.pull_request.number }}" --body-file=coverage-comment.md


### PR DESCRIPTION
- Added a new job for coverage reporting on pull requests originating from forks, utilizing a separate GitHub token for commenting.
- Updated existing coverage report job to restrict execution to pull requests from the same repository.
- Improved handling of coverage comments by deleting previous comments before posting new ones, ensuring clarity in reporting.

fixes #983 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request coverage reporting for contributions from forked repositories.
  * Coverage comments now post correctly for both same-repository and fork-based pull requests.
  * Prevented duplicate coverage comments by replacing existing reports when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->