### PR TITLE
chore: update Dockerfile and GoReleaser configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,6 +65,7 @@ dockers:
     - lib
     - etc/plugin
   build_flag_templates:
+  - "--target=release"
   - "--build-arg=VERSION={{.Version}}"
   - "--build-arg=COMMIT={{.Commit}}"
   - "--build-arg=DATE={{.Date}}"
@@ -86,6 +87,7 @@ dockers:
     - lib
     - etc/plugin
   build_flag_templates:
+  - "--target=release"
   - "--build-arg=VERSION={{.Version}}"
   - "--build-arg=COMMIT={{.Commit}}"
   - "--build-arg=DATE={{.Date}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN apt-get update && apt-get upgrade -y && \
       go build -ldflags "-s -w -X github.com/prest/prest/v2/helpers.Version=${VERSION} -X github.com/prest/prest/v2/helpers.Commit=${COMMIT} -X github.com/prest/prest/v2/helpers.Date=${DATE}" -o prestd cmd/prestd/main.go; \
     fi
 
-# Use golang image
-# needs go to compile the plugin system
-FROM registry.hub.docker.com/library/golang:1.26
+# Full-repo build (default for docker build .)
+# Needs go to compile the plugin system
+FROM registry.hub.docker.com/library/golang:1.26 AS full
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 ENV CGO_ENABLED=1
 ENV PREST_BUILD_PLUGINS=1
@@ -40,3 +40,19 @@ COPY --from=builder /workspace/lib /app/lib
 COPY --from=builder /workspace/etc/plugin /app/plugin
 WORKDIR /app
 ENTRYPOINT ["sh", "/app/entrypoint.sh"]
+
+# GoReleaser: prebuilt binary + extra_files only (no studio/ in context)
+FROM registry.hub.docker.com/library/golang:1.26 AS release
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install --no-install-recommends -yq netcat-traditional && \
+    rm -rf /var/lib/apt/lists/*
+ENV CGO_ENABLED=1
+ENV PREST_BUILD_PLUGINS=1
+COPY prestd /bin/prestd
+COPY etc/entrypoint.sh /app/entrypoint.sh
+COPY lib /app/lib
+COPY etc/plugin /app/plugin
+WORKDIR /app
+ENTRYPOINT ["sh", "/app/entrypoint.sh"]
+
+FROM full

--- a/Dockerfile.noplugins
+++ b/Dockerfile.noplugins
@@ -27,9 +27,8 @@ RUN apt-get update && apt-get upgrade -y && \
       go build -ldflags "-s -w -X github.com/prest/prest/v2/helpers.Version=${VERSION} -X github.com/prest/prest/v2/helpers.Commit=${COMMIT} -X github.com/prest/prest/v2/helpers.Date=${DATE}" -o prestd cmd/prestd/main.go; \
     fi
 
-# Use runtime image
-# Plugins not supported
-FROM registry.hub.docker.com/library/debian:bookworm
+# Full-repo build (default for docker build .); plugins not supported
+FROM registry.hub.docker.com/library/debian:bookworm AS full
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/* \
     && groupadd --system prest \
     && useradd --system --gid prest --home-dir /app --shell /usr/sbin/nologin prest
@@ -43,3 +42,22 @@ RUN chown -R prest:prest /app
 WORKDIR /app
 USER prest
 ENTRYPOINT ["sh", "/app/entrypoint.sh"]
+
+# GoReleaser: prebuilt binary + extra_files only (no studio/ in context)
+FROM registry.hub.docker.com/library/debian:bookworm AS release
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install --no-install-recommends -yq netcat-traditional && \
+    rm -rf /var/lib/apt/lists/* \
+    && groupadd --system prest \
+    && useradd --system --gid prest --home-dir /app --shell /usr/sbin/nologin prest
+ENV PREST_BUILD_PLUGINS=0
+COPY prestd /bin/prestd
+COPY etc/entrypoint.sh /app/entrypoint.sh
+COPY lib /app/lib
+COPY etc/plugin /app/plugin
+RUN chown -R prest:prest /app
+WORKDIR /app
+USER prest
+ENTRYPOINT ["sh", "/app/entrypoint.sh"]
+
+FROM full


### PR DESCRIPTION
- Added a new build flag template for GoReleaser to target release builds.
- Refactored Dockerfile to define separate stages for full-repo builds and release builds, improving clarity and organization.
- Updated Dockerfile.noplugins to align with the new structure, ensuring consistent handling of plugin support across builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optimized release image build option using prebuilt application artifacts.
  * Added separate release builds for standard and no-plugin images.
  * Preserved the existing full-build image option as the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->