### PR TITLE
feat: add pgvector support for nearest-neighbor ordering and distance threshold filtering

### DIFF
--- a/adapters/postgres/errors.go
+++ b/adapters/postgres/errors.go
@@ -13,4 +13,10 @@ var (
 	// ErrBodyEmpty err throw when body is empty
 	ErrBodyEmpty           = errors.New("body is empty")
 	ErrEmptyOrInvalidSlice = errors.New("empty or invalid slice")
+	// pgvector errors
+	ErrInvalidVector          = errors.New("invalid vector literal")
+	ErrInvalidVectorMetric    = errors.New("invalid vector distance metric")
+	ErrInvalidVectorOrder     = errors.New("invalid vector order specification")
+	ErrInvalidVectorFilter    = errors.New("invalid vector distance filter")
+	ErrInvalidVectorThreshold = errors.New("invalid vector distance threshold")
 )

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -617,6 +617,11 @@ func (adapter *postgres) whereKeyAndValue(rawKey, v string, pid *int) (key strin
 				tsQuery = fmt.Sprintf(`%s @@ to_tsquery('%s', '%s')`, tsQueryField[0], safeCfg, safeVal)
 			}
 			key = tsQuery
+		case "vecdist":
+			// pgvector distance-threshold filter:
+			// embedding:vecdist=<metric>:<comparison>:<vector>:<threshold>
+			key, values, err = buildVectorFilter(keyInfo[0], value, pid)
+			return
 		default:
 			if !ident.IsValid(keyInfo[0]) {
 				err = errors.Wrapf(ErrInvalidIdentifier, "%s", keyInfo[0])
@@ -959,12 +964,16 @@ func (adapter *postgres) SelectFields(fields []string) (sql string, err error) {
 func (adapter *postgres) OrderByRequest(r *http.Request) (values string, err error) {
 	queries := r.URL.Query()
 	reqOrder := queries.Get("_order")
+	reqKOrder := queries.Get("_korder")
+
+	if reqOrder == "" && reqKOrder == "" {
+		return
+	}
+
+	terms := []string{}
 
 	if reqOrder != "" {
-		values = " ORDER BY "
-		orderingArr := strings.Split(reqOrder, ",")
-
-		for i, fld := range orderingArr {
+		for _, fld := range strings.Split(reqOrder, ",") {
 			desc := false
 			field := fld
 			if strings.HasPrefix(field, "-") {
@@ -973,19 +982,28 @@ func (adapter *postgres) OrderByRequest(r *http.Request) (values string, err err
 			}
 			if !ident.IsValid(field) {
 				err = ErrInvalidIdentifier
-				values = ""
 				return
 			}
 			q, _ := ident.Quote(field)
 			if desc {
 				q = fmt.Sprintf("%s DESC", q)
 			}
-			values = fmt.Sprintf("%s %s", values, q)
-			if i < len(orderingArr)-1 {
-				values = fmt.Sprintf("%s ,", values)
-			}
+			terms = append(terms, q)
 		}
 	}
+
+	// _korder adds a pgvector nearest-neighbor ordering term, e.g.
+	// _korder=embedding:l2:[1,2,3] -> "embedding" <-> '[1,2,3]'::vector
+	if reqKOrder != "" {
+		term, kerr := buildVectorOrderTerm(reqKOrder)
+		if kerr != nil {
+			err = kerr
+			return
+		}
+		terms = append(terms, term)
+	}
+
+	values = " ORDER BY " + strings.Join(terms, " , ")
 	return
 }
 

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -972,6 +972,18 @@ func (adapter *postgres) OrderByRequest(r *http.Request) (values string, err err
 
 	terms := []string{}
 
+	// _korder must lead the ORDER BY so pgvector can use an ANN index for the
+	// nearest-neighbor scan; a preceding regular _order term would force an
+	// exact sort. e.g. _korder=embedding:l2:[1,2,3] -> "embedding" <-> '[1,2,3]'::vector
+	if reqKOrder != "" {
+		term, kerr := buildVectorOrderTerm(reqKOrder)
+		if kerr != nil {
+			err = kerr
+			return
+		}
+		terms = append(terms, term)
+	}
+
 	if reqOrder != "" {
 		for _, fld := range strings.Split(reqOrder, ",") {
 			desc := false
@@ -990,17 +1002,6 @@ func (adapter *postgres) OrderByRequest(r *http.Request) (values string, err err
 			}
 			terms = append(terms, q)
 		}
-	}
-
-	// _korder adds a pgvector nearest-neighbor ordering term, e.g.
-	// _korder=embedding:l2:[1,2,3] -> "embedding" <-> '[1,2,3]'::vector
-	if reqKOrder != "" {
-		term, kerr := buildVectorOrderTerm(reqKOrder)
-		if kerr != nil {
-			err = kerr
-			return
-		}
-		terms = append(terms, term)
 	}
 
 	values = " ORDER BY " + strings.Join(terms, " , ")

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -847,6 +847,42 @@ func TestOrderByRequest(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestOrderByRequest_KNN(t *testing.T) {
+	t.Parallel()
+
+	adapter := testAdapter()
+
+	// _korder alone: nearest-neighbor ordering by L2 distance
+	req, err := http.NewRequest(http.MethodGet, "/public/test?_korder=embedding:l2:[1,2,3]", nil)
+	require.NoError(t, err)
+	order, err := adapter.OrderByRequest(req)
+	require.NoError(t, err)
+	require.Contains(t, order, "ORDER BY")
+	require.Contains(t, order, `"embedding" <-> '[1,2,3]'::vector`)
+
+	// _order and _korder combine into a single ORDER BY
+	req, err = http.NewRequest(http.MethodGet, "/public/test?_order=name&_korder=embedding:cosine:[0.1,0.2]", nil)
+	require.NoError(t, err)
+	order, err = adapter.OrderByRequest(req)
+	require.NoError(t, err)
+	require.Contains(t, order, `"name"`)
+	require.Contains(t, order, `"embedding" <=> '[0.1,0.2]'::vector`)
+
+	// invalid metric surfaces an error and empty order
+	req, err = http.NewRequest(http.MethodGet, "/public/test?_korder=embedding:bogus:[1,2]", nil)
+	require.NoError(t, err)
+	order, err = adapter.OrderByRequest(req)
+	require.Error(t, err)
+	require.Empty(t, order)
+
+	// a non-numeric / malformed vector is rejected (no bytes reach SQL)
+	req, err = http.NewRequest(http.MethodGet, "/public/test?_korder=embedding:l2:notavector", nil)
+	require.NoError(t, err)
+	order, err = adapter.OrderByRequest(req)
+	require.Error(t, err)
+	require.Empty(t, order)
+}
+
 func TestSelectFields(t *testing.T) {
 
 	t.Parallel()
@@ -1793,6 +1829,56 @@ func Test_postgres_whereKeyAndValue(t *testing.T) {
 			rawKey: "name:unknown",
 			v:      "$eq.x",
 			errMsg: "unknown type suffix",
+		},
+		{
+			name:     "vecdist l2 less-than threshold",
+			rawKey:   "embedding:vecdist",
+			v:        "l2:lt:[1,2,3]:0.5",
+			wantKey:  `("embedding" <-> $1::vector) < $2`,
+			wantVals: []interface{}{"[1,2,3]", 0.5},
+		},
+		{
+			name:     "vecdist cosine less-than-equal on aliased column",
+			rawKey:   "d.embedding:vecdist",
+			v:        "cosine:lte:[0.1,0.2]:0.25",
+			wantKey:  `("d"."embedding" <=> $1::vector) <= $2`,
+			wantVals: []interface{}{"[0.1,0.2]", 0.25},
+		},
+		{
+			name:    "vecdist missing threshold",
+			rawKey:  "embedding:vecdist",
+			v:       "l2:lt:[1,2,3]",
+			wantErr: ErrInvalidVectorFilter,
+		},
+		{
+			name:    "vecdist invalid metric",
+			rawKey:  "embedding:vecdist",
+			v:       "bogus:lt:[1,2,3]:0.5",
+			wantErr: ErrInvalidVectorMetric,
+		},
+		{
+			name:    "vecdist non-comparison operator rejected",
+			rawKey:  "embedding:vecdist",
+			v:       "l2:like:[1,2,3]:0.5",
+			wantErr: ErrInvalidOperator,
+		},
+		{
+			name:    "vecdist invalid vector",
+			rawKey:  "embedding:vecdist",
+			v:       "l2:lt:[a,b]:0.5",
+			wantErr: ErrInvalidVector,
+		},
+		{
+			name:    "vecdist non-numeric threshold",
+			rawKey:  "embedding:vecdist",
+			v:       "l2:lt:[1,2,3]:notanumber",
+			wantErr: ErrInvalidVectorThreshold,
+		},
+		{
+			name:    "vecdist invalid column identifier",
+			rawKey:  "0col:vecdist",
+			v:       "l2:lt:[1,2,3]:0.5",
+			wantErr: ErrInvalidIdentifier,
 		},
 	}
 	for _, tt := range tests {

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -860,13 +860,18 @@ func TestOrderByRequest_KNN(t *testing.T) {
 	require.Contains(t, order, "ORDER BY")
 	require.Contains(t, order, `"embedding" <-> '[1,2,3]'::vector`)
 
-	// _order and _korder combine into a single ORDER BY
+	// _order and _korder combine into a single ORDER BY, with the KNN distance
+	// term LEADING so pgvector can use an ANN index (a preceding regular _order
+	// term would force an exact sort).
 	req, err = http.NewRequest(http.MethodGet, "/public/test?_order=name&_korder=embedding:cosine:[0.1,0.2]", nil)
 	require.NoError(t, err)
 	order, err = adapter.OrderByRequest(req)
 	require.NoError(t, err)
 	require.Contains(t, order, `"name"`)
 	require.Contains(t, order, `"embedding" <=> '[0.1,0.2]'::vector`)
+	require.Less(t,
+		strings.Index(order, `"embedding" <=>`), strings.Index(order, `"name"`),
+		"KNN term must lead the ORDER BY, before the regular _order term")
 
 	// invalid metric surfaces an error and empty order
 	req, err = http.NewRequest(http.MethodGet, "/public/test?_korder=embedding:bogus:[1,2]", nil)

--- a/adapters/postgres/vector.go
+++ b/adapters/postgres/vector.go
@@ -1,0 +1,142 @@
+package postgres
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/prest/prest/v2/internal/ident"
+)
+
+// maxVectorDims mirrors pgvector's hard limit for the `vector` type (16000
+// dimensions). Rejecting oversized inputs bounds the work done per request.
+const maxVectorDims = 16000
+
+// GetVectorOperator maps a pgvector distance metric name to its SQL operator.
+// The result is a fixed constant from this whitelist — never derived from user
+// bytes — so it is safe to interpolate directly into SQL.
+func GetVectorOperator(metric string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(metric)) {
+	case "l2", "euclidean":
+		return "<->", nil
+	case "cosine", "cos":
+		return "<=>", nil
+	case "ip", "inner", "dot":
+		return "<#>", nil
+	case "l1", "manhattan":
+		return "<+>", nil
+	}
+	return "", ErrInvalidVectorMetric
+}
+
+// normalizeVectorLiteral validates a pgvector literal like "[1,2,3]" and
+// rebuilds it exclusively from parsed float64 values. Because every element is
+// round-tripped through strconv.ParseFloat/FormatFloat, the returned string can
+// only ever contain the byte set produced by FormatFloat ('g' format: digits,
+// '.', '-', '+', 'e', plus the brackets and commas added here). No caller-
+// supplied byte survives, which makes the literal safe to embed in SQL even
+// where a bound parameter is not available (e.g. ORDER BY).
+func normalizeVectorLiteral(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 || s[0] != '[' || s[len(s)-1] != ']' {
+		return "", ErrInvalidVector
+	}
+	inner := strings.TrimSpace(s[1 : len(s)-1])
+	if inner == "" {
+		return "", ErrInvalidVector
+	}
+	parts := strings.Split(inner, ",")
+	if len(parts) > maxVectorDims {
+		return "", ErrInvalidVector
+	}
+	nums := make([]string, len(parts))
+	for i, p := range parts {
+		f, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+			return "", ErrInvalidVector
+		}
+		nums[i] = strconv.FormatFloat(f, 'g', -1, 64)
+	}
+	return "[" + strings.Join(nums, ",") + "]", nil
+}
+
+// buildVectorOrderTerm parses a "<column>:<metric>:<vector>" spec (from the
+// _korder query parameter) into a single ORDER BY term such as
+// `"embedding" <-> '[1,2,3]'::vector`. Nearest-first ordering is the pgvector
+// KNN default for every supported metric, so no direction is emitted.
+//
+// Safety: the column is validated and quoted via the ident package, the
+// operator comes from GetVectorOperator's whitelist, and the vector literal is
+// reconstructed by normalizeVectorLiteral. The single-quoted literal therefore
+// cannot break out of its string context.
+func buildVectorOrderTerm(spec string) (string, error) {
+	parts := strings.SplitN(spec, ":", 3)
+	if len(parts) != 3 {
+		return "", ErrInvalidVectorOrder
+	}
+	col, metric, vec := parts[0], parts[1], parts[2]
+
+	if !ident.IsValid(col) {
+		return "", ErrInvalidIdentifier
+	}
+	op, err := GetVectorOperator(metric)
+	if err != nil {
+		return "", err
+	}
+	lit, err := normalizeVectorLiteral(vec)
+	if err != nil {
+		return "", err
+	}
+	q, _ := ident.Quote(col)
+	return fmt.Sprintf(`%s %s '%s'::vector`, q, op, lit), nil
+}
+
+// buildVectorFilter parses a distance-threshold predicate for the :vecdist key
+// suffix. The value format is "<metric>:<comparison>:<vector>:<threshold>", e.g.
+// "l2:lt:[1,2,3]:0.5", producing `("col" <-> $n::vector) < $n+1`.
+//
+// Safety: the column is validated/quoted, the distance operator comes from the
+// metric whitelist, and the comparison operator is restricted to scalar
+// comparisons. Both the vector (normalized) and the threshold (parsed float)
+// are passed as bound parameters, so no user value is interpolated into SQL.
+func buildVectorFilter(column, value string, pid *int) (key string, values []interface{}, err error) {
+	if !ident.IsValid(column) {
+		return "", nil, ErrInvalidIdentifier
+	}
+	parts := strings.SplitN(value, ":", 4)
+	if len(parts) != 4 {
+		return "", nil, ErrInvalidVectorFilter
+	}
+	metric, cmp, vec, thr := parts[0], parts[1], parts[2], parts[3]
+
+	distOp, err := GetVectorOperator(metric)
+	if err != nil {
+		return "", nil, err
+	}
+	cmpOp, err := GetQueryOperator(cmp)
+	if err != nil {
+		return "", nil, err
+	}
+	// Restrict to scalar comparisons; distance is a float, so IN/LIKE/IS NULL
+	// and friends must not be accepted here.
+	switch cmpOp {
+	case "=", "!=", ">", ">=", "<", "<=":
+	default:
+		return "", nil, ErrInvalidOperator
+	}
+	lit, err := normalizeVectorLiteral(vec)
+	if err != nil {
+		return "", nil, err
+	}
+	threshold, perr := strconv.ParseFloat(strings.TrimSpace(thr), 64)
+	if perr != nil || math.IsNaN(threshold) || math.IsInf(threshold, 0) {
+		return "", nil, ErrInvalidVectorThreshold
+	}
+
+	q, _ := ident.Quote(column)
+	key = fmt.Sprintf(`(%s %s $%d::vector) %s $%d`, q, distOp, *pid, cmpOp, *pid+1)
+	values = []interface{}{lit, threshold}
+	*pid += 2
+	return key, values, nil
+}

--- a/adapters/postgres/vector_test.go
+++ b/adapters/postgres/vector_test.go
@@ -1,0 +1,131 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetVectorOperator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		metric  string
+		want    string
+		wantErr error
+	}{
+		{name: "l2", metric: "l2", want: "<->"},
+		{name: "euclidean alias", metric: "euclidean", want: "<->"},
+		{name: "cosine", metric: "cosine", want: "<=>"},
+		{name: "inner product", metric: "ip", want: "<#>"},
+		{name: "l1", metric: "l1", want: "<+>"},
+		{name: "case insensitive + spaces", metric: " L2 ", want: "<->"},
+		{name: "unknown metric", metric: "hamming", wantErr: ErrInvalidVectorMetric},
+		{name: "empty metric", metric: "", wantErr: ErrInvalidVectorMetric},
+		{name: "injection attempt", metric: "l2; DROP TABLE users", wantErr: ErrInvalidVectorMetric},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetVectorOperator(tt.metric)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNormalizeVectorLiteral(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr error
+	}{
+		{name: "simple", in: "[1,2,3]", want: "[1,2,3]"},
+		{name: "floats", in: "[0.1,0.2,0.3]", want: "[0.1,0.2,0.3]"},
+		{name: "negatives", in: "[-1.5,2,-3]", want: "[-1.5,2,-3]"},
+		{name: "whitespace tolerant", in: " [ 1 , 2 , 3 ] ", want: "[1,2,3]"},
+		{name: "exponent", in: "[1e2,2]", want: "[100,2]"},
+		{name: "not bracketed", in: "1,2,3", wantErr: ErrInvalidVector},
+		{name: "empty vector", in: "[]", wantErr: ErrInvalidVector},
+		{name: "non numeric", in: "[1,abc,3]", wantErr: ErrInvalidVector},
+		{name: "single quote injection", in: "[1,2]'; DROP TABLE t --", wantErr: ErrInvalidVector},
+		{name: "quote inside", in: "[1,'2',3]", wantErr: ErrInvalidVector},
+		{name: "nan rejected", in: "[NaN,1]", wantErr: ErrInvalidVector},
+		{name: "inf rejected", in: "[Inf,1]", wantErr: ErrInvalidVector},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeVectorLiteral(tt.in)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNormalizeVectorLiteral_DimensionCap(t *testing.T) {
+	t.Parallel()
+
+	// build a vector with more than the pgvector max dimensions
+	parts := make([]string, maxVectorDims+1)
+	for i := range parts {
+		parts[i] = "1"
+	}
+	oversized := "[" + strings.Join(parts, ",") + "]"
+
+	_, err := normalizeVectorLiteral(oversized)
+	require.ErrorIs(t, err, ErrInvalidVector)
+}
+
+func TestBuildVectorOrderTerm(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		spec    string
+		want    string
+		wantErr error
+	}{
+		{
+			name: "l2 order",
+			spec: "embedding:l2:[0.1,0.2,0.3]",
+			want: `"embedding" <-> '[0.1,0.2,0.3]'::vector`,
+		},
+		{
+			name: "cosine order with alias column",
+			spec: "docs.embedding:cosine:[1,2]",
+			want: `"docs"."embedding" <=> '[1,2]'::vector`,
+		},
+		{name: "missing parts", spec: "embedding:l2", wantErr: ErrInvalidVectorOrder},
+		{name: "invalid column", spec: "0col:l2:[1,2]", wantErr: ErrInvalidIdentifier},
+		{name: "invalid metric", spec: "embedding:bogus:[1,2]", wantErr: ErrInvalidVectorMetric},
+		{name: "invalid vector", spec: "embedding:l2:[a,b]", wantErr: ErrInvalidVector},
+		{
+			name:    "column injection blocked",
+			spec:    `embedding") ; DROP TABLE t --:l2:[1,2]`,
+			wantErr: ErrInvalidIdentifier,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildVectorOrderTerm(tt.spec)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/integration/postgres/controllers/vector_test.go
+++ b/integration/postgres/controllers/vector_test.go
@@ -1,0 +1,171 @@
+package controllers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/prest/prest/v2/integration/helpers"
+	"github.com/prest/prest/v2/integration/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// getJSONArray performs a GET and decodes the pREST JSON array response so the
+// test can assert on row order (testutils.DoRequest only does substring checks,
+// which cannot prove nearest-first ordering).
+func getJSONArray(t *testing.T, url string) []map[string]interface{} {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Application", "prest")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status; body: %s", string(body))
+
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &rows), "body: %s", string(body))
+	return rows
+}
+
+// names extracts the "name" column in row order.
+func names(rows []map[string]interface{}) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if n, ok := r["name"].(string); ok {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// TestVectorKNNOrdering verifies the _korder pgvector nearest-neighbor ordering.
+// Seed distances from [1,0,0] (L2): alpha=0, delta≈0.14, beta≈1.41, gamma≈1.41.
+func TestVectorKNNOrdering(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// L2 nearest-first: alpha (exact match) then delta must lead the result set.
+	url := fmt.Sprintf("%s/prest-test/public/vector_items?_korder=embedding:l2:[1,0,0]", base)
+	rows := getJSONArray(t, url)
+	got := names(rows)
+	require.GreaterOrEqual(t, len(got), 4, "expected all seeded rows")
+	require.Equal(t, "alpha", got[0], "closest vector must be first")
+	require.Equal(t, "delta", got[1], "second closest vector must be second")
+
+	// Cosine distance ranks by direction; alpha ([1,0,0]) is the closest direction.
+	url = fmt.Sprintf("%s/prest-test/public/vector_items?_korder=embedding:cosine:[1,0,0]", base)
+	rows = getJSONArray(t, url)
+	require.Equal(t, "alpha", names(rows)[0], "cosine nearest must be alpha")
+}
+
+// TestVectorKNNCombinedWithOrder verifies _korder composes with a normal _order
+// term in a single ORDER BY without breaking either clause.
+func TestVectorKNNCombinedWithOrder(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// _order=name (tie-break) plus KNN distance ordering — request must succeed.
+	url := fmt.Sprintf("%s/prest-test/public/vector_items?_order=name&_korder=embedding:l2:[1,0,0]", base)
+	rows := getJSONArray(t, url)
+	require.GreaterOrEqual(t, len(rows), 4)
+}
+
+// TestVectorThresholdFilter verifies the :vecdist distance-threshold WHERE filter.
+func TestVectorThresholdFilter(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// Only alpha (0) and delta (≈0.14) are within L2 distance 0.5 of [1,0,0].
+	url := fmt.Sprintf("%s/prest-test/public/vector_items?embedding:vecdist=l2:lt:[1,0,0]:0.5", base)
+	rows := getJSONArray(t, url)
+	got := names(rows)
+	require.ElementsMatch(t, []string{"alpha", "delta"}, got,
+		"threshold must exclude far vectors beta and gamma")
+
+	// A tiny threshold keeps only the exact match.
+	url = fmt.Sprintf("%s/prest-test/public/vector_items?embedding:vecdist=l2:lte:[1,0,0]:0.0001", base)
+	rows = getJSONArray(t, url)
+	require.Equal(t, []string{"alpha"}, names(rows))
+}
+
+// TestVectorSecurity_RejectsInjection is the adversarial suite: every payload is
+// crafted to break out of the intended SQL context. All must fail closed with
+// 400 (never 200, never 500), and the vector_items table must remain intact
+// afterwards — proving no injected DDL/DML ever executed.
+func TestVectorSecurity_RejectsInjection(t *testing.T) {
+	base := helpers.ServerURL(t)
+	table := fmt.Sprintf("%s/prest-test/public/vector_items", base)
+
+	// %3B is an encoded ';' so it survives as a value byte instead of being
+	// stripped as a query-pair separator — the strongest injection vector.
+	cases := []struct {
+		description string
+		query       string
+	}{
+		{
+			description: "metric field carries encoded SQL — whitelist rejects it",
+			// _korder=embedding:l2; DROP TABLE vector_items:[1,0,0]
+			query: "?_korder=embedding:l2%3B%20DROP%20TABLE%20vector_items:[1,0,0]",
+		},
+		{
+			description: "column field attempts quote break-out — ident validation rejects it",
+			// _korder=embedding"); DROP TABLE vector_items; --:l2:[1,0,0]
+			query: "?_korder=embedding%22%29%3B%20DROP%20TABLE%20vector_items%3B%20--:l2:[1,0,0]",
+		},
+		{
+			description: "vector literal appends a statement — reconstruction rejects it",
+			// _korder=embedding:l2:[1,0,0]'; DROP TABLE vector_items; --
+			query: "?_korder=embedding:l2:%5B1%2C0%2C0%5D%27%3B%20DROP%20TABLE%20vector_items%3B%20--",
+		},
+		{
+			description: "vector element is not numeric — rejected before SQL",
+			query:       "?_korder=embedding:l2:[1,abc,0]",
+		},
+		{
+			description: "threshold carries encoded SQL — ParseFloat rejects it",
+			// embedding:vecdist=l2:lt:[1,0,0]:0.5; DROP TABLE vector_items
+			query: "?embedding:vecdist=l2:lt:[1,0,0]:0.5%3B%20DROP%20TABLE%20vector_items",
+		},
+		{
+			description: "vecdist comparison smuggles LIKE — non-comparison operator rejected",
+			query:       "?embedding:vecdist=l2:like:[1,0,0]:0.5",
+		},
+		{
+			description: "vecdist vector break-out attempt — reconstruction rejects it",
+			// embedding:vecdist=l2:lt:[1,0,0]'::text); DROP TABLE vector_items; --:0.5
+			query: "?embedding:vecdist=l2:lt:%5B1%2C0%2C0%5D%27%3A%3Atext%29%3B%20DROP%20TABLE%20vector_items%3B%20--:0.5",
+		},
+		{
+			description: "unknown vector metric is rejected",
+			query:       "?_korder=embedding:hamming:[1,0,0]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Log(tc.description)
+		// Every malicious request must fail closed with 400 Bad Request.
+		testutils.DoRequest(t, table+tc.query, nil, http.MethodGet,
+			http.StatusBadRequest, tc.description)
+	}
+
+	// Proof of no side effects: the table still exists with all 4 seeded rows.
+	// If any injection had executed a DROP, this GET would 404 or return fewer rows.
+	rows := getJSONArray(t, table+"?_order=id")
+	require.Equal(t, []string{"alpha", "beta", "gamma", "delta"}, names(rows),
+		"vector_items must be untouched after every injection attempt")
+}
+
+// TestVectorDimensionMismatch verifies a well-formed but wrong-dimension vector
+// fails safely at the database (400) rather than crashing or corrupting state.
+func TestVectorDimensionMismatch(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// Column is vector(3); a 2-dim query vector must be rejected by Postgres.
+	url := fmt.Sprintf("%s/prest-test/public/vector_items?_korder=embedding:l2:[1,0]", base)
+	testutils.DoRequest(t, url, nil, http.MethodGet,
+		http.StatusBadRequest, "dimension mismatch must fail safely")
+}

--- a/integration/postgres/controllers/vector_test.go
+++ b/integration/postgres/controllers/vector_test.go
@@ -1,9 +1,7 @@
 package controllers_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"testing"
 
@@ -17,20 +15,8 @@ import (
 // which cannot prove nearest-first ordering).
 func getJSONArray(t *testing.T, url string) []map[string]interface{} {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	require.NoError(t, err)
-	req.Header.Set("X-Application", "prest")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status; body: %s", string(body))
-
 	var rows []map[string]interface{}
-	require.NoError(t, json.Unmarshal(body, &rows), "body: %s", string(body))
+	testutils.DoRequestJSON(t, url, nil, http.MethodGet, http.StatusOK, url, &rows)
 	return rows
 }
 
@@ -69,10 +55,15 @@ func TestVectorKNNOrdering(t *testing.T) {
 func TestVectorKNNCombinedWithOrder(t *testing.T) {
 	base := helpers.ServerURL(t)
 
-	// _order=name (tie-break) plus KNN distance ordering — request must succeed.
-	url := fmt.Sprintf("%s/prest-test/public/vector_items?_order=name&_korder=embedding:l2:[1,0,0]", base)
+	// KNN leads the sort; _order=-name only breaks the beta/gamma distance tie.
+	// L2 from [1,0,0]: alpha=0, delta≈0.14, then beta≈1.41 == gamma≈1.41 (tied).
+	// Descending name pins the tie to gamma-before-beta — the reverse of both the
+	// fixture insertion order (alpha,beta,gamma,delta) and an ascending tie-break,
+	// so the exact sequence proves _korder AND _order each shaped the result.
+	url := fmt.Sprintf("%s/prest-test/public/vector_items?_order=-name&_korder=embedding:l2:[1,0,0]", base)
 	rows := getJSONArray(t, url)
-	require.GreaterOrEqual(t, len(rows), 4)
+	require.Equal(t, []string{"alpha", "delta", "gamma", "beta"}, names(rows),
+		"KNN distance orders alpha,delta first; -name tie-break orders gamma before beta")
 }
 
 // TestVectorThresholdFilter verifies the :vecdist distance-threshold WHERE filter.
@@ -86,10 +77,16 @@ func TestVectorThresholdFilter(t *testing.T) {
 	require.ElementsMatch(t, []string{"alpha", "delta"}, got,
 		"threshold must exclude far vectors beta and gamma")
 
-	// A tiny threshold keeps only the exact match.
-	url = fmt.Sprintf("%s/prest-test/public/vector_items?embedding:vecdist=l2:lte:[1,0,0]:0.0001", base)
+	// lte at an exact 0 threshold includes alpha at the equality boundary
+	// (distance == 0) and excludes every other row.
+	url = fmt.Sprintf("%s/prest-test/public/vector_items?embedding:vecdist=l2:lte:[1,0,0]:0", base)
 	rows = getJSONArray(t, url)
-	require.Equal(t, []string{"alpha"}, names(rows))
+	require.Equal(t, []string{"alpha"}, names(rows), "lte 0 must include the exact match")
+
+	// lt at 0 is strictly below the minimum distance, so no row qualifies.
+	url = fmt.Sprintf("%s/prest-test/public/vector_items?embedding:vecdist=l2:lt:[1,0,0]:0", base)
+	rows = getJSONArray(t, url)
+	require.Empty(t, names(rows), "lt 0 must exclude the exact match at the boundary")
 }
 
 // TestVectorSecurity_RejectsInjection is the adversarial suite: every payload is

--- a/integration/postgres/docker-compose.yml
+++ b/integration/postgres/docker-compose.yml
@@ -21,6 +21,17 @@ x-prestd-service: &prestd-service
 services:
   postgres:
     image: postgres:18
+    # Official image + PGDG pgvector package so `CREATE EXTENSION vector`
+    # (run by migration 002) has its binaries. The outer entrypoint passes the
+    # bash command through; the inner `exec docker-entrypoint.sh postgres` then
+    # performs the normal initdb/startup.
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        apt-get update
+        && apt-get install -y --no-install-recommends postgresql-18-pgvector
+        && exec docker-entrypoint.sh postgres
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres

--- a/integration/postgres/docker-compose.yml
+++ b/integration/postgres/docker-compose.yml
@@ -20,18 +20,10 @@ x-prestd-service: &prestd-service
 
 services:
   postgres:
-    image: postgres:18
-    # Official image + PGDG pgvector package so `CREATE EXTENSION vector`
-    # (run by migration 002) has its binaries. The outer entrypoint passes the
-    # bash command through; the inner `exec docker-entrypoint.sh postgres` then
-    # performs the normal initdb/startup.
-    entrypoint:
-      - bash
-      - -c
-      - >-
-        apt-get update
-        && apt-get install -y --no-install-recommends postgresql-18-pgvector
-        && exec docker-entrypoint.sh postgres
+    # Pinned pgvector image (official postgres:18 + prebuilt vector binaries) so
+    # `CREATE EXTENSION vector` (run by migration 002) has its binaries without
+    # an install step at container start. db-init still runs the migrations.
+    image: pgvector/pgvector:pg18
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres

--- a/integration/testutils/testutils.go
+++ b/integration/testutils/testutils.go
@@ -106,6 +106,9 @@ func DoRequestJSON(
 	if r != nil {
 		byt, err = json.Marshal(r)
 		assert.Nil(t, err, "error on json marshal")
+		if err != nil {
+			return
+		}
 	}
 
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(byt))
@@ -114,6 +117,9 @@ func DoRequestJSON(
 		return
 	}
 	req.Header.Add("X-Application", "prest")
+	if r != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/integration/testutils/testutils.go
+++ b/integration/testutils/testutils.go
@@ -89,6 +89,52 @@ func DoRequestWithHeaders(
 	}
 }
 
+// DoRequestJSON performs an HTTP request, asserts the response status, and
+// decodes the JSON body into target. Unlike DoRequest (substring checks only),
+// this exposes the parsed response so callers can assert on structure/order.
+func DoRequestJSON(
+	t *testing.T,
+	url string,
+	r interface{},
+	method string,
+	expectedStatus int,
+	where string,
+	target interface{},
+) {
+	var byt []byte
+	var err error
+	if r != nil {
+		byt, err = json.Marshal(r)
+		assert.Nil(t, err, "error on json marshal")
+	}
+
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(byt))
+	assert.Nil(t, err, "error on New Request")
+	if err != nil {
+		return
+	}
+	req.Header.Add("X-Application", "prest")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.Nil(t, err, "error on Do Request")
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	assert.Nil(t, err, "error on io ReadAll")
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, expectedStatus, resp.StatusCode,
+		"%s: unexpected status; body: %s", where, string(body))
+	assert.NoError(t, json.Unmarshal(body, target),
+		"%s: body: %s", where, string(body))
+}
+
 // DoRequestRaw sends a request with a raw body and optional headers.
 func DoRequestRaw(t *testing.T, url string, body []byte, method string, expectedStatus int, where string, headers map[string]string, expectedBody ...string) {
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))

--- a/testdata/migrations/002_pgvector.down.sql
+++ b/testdata/migrations/002_pgvector.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS vector_items;
+DROP EXTENSION IF EXISTS vector;

--- a/testdata/migrations/002_pgvector.up.sql
+++ b/testdata/migrations/002_pgvector.up.sql
@@ -1,0 +1,22 @@
+-- pgvector extension + deterministic 3-dim embeddings for KNN/threshold tests.
+-- Requires the pgvector binaries in the server image (installed via the
+-- postgres service entrypoint in integration/postgres/docker-compose.yml).
+--
+-- L2 distances from the query vector [1,0,0]:
+--   alpha [1,0,0]     -> 0
+--   delta [0.9,0.1,0] -> ~0.1414
+--   beta  [0,1,0]     -> ~1.4142
+--   gamma [0,0,1]     -> ~1.4142
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE vector_items(
+    id serial PRIMARY KEY,
+    name text,
+    embedding vector(3)
+);
+
+INSERT INTO vector_items (name, embedding) VALUES
+    ('alpha', '[1,0,0]'),
+    ('beta',  '[0,1,0]'),
+    ('gamma', '[0,0,1]'),
+    ('delta', '[0.9,0.1,0]');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pgvector nearest-neighbor ordering via `_korder`.
  * Added vector distance filtering via `:vecdist` (supports `lt`/`lte`) with correct composition alongside `_order`.
* **Bug Fixes**
  * Improved pgvector input validation: safer metric/operator parsing, canonicalized vector literals, stricter column identifier checks, and clear errors for invalid thresholds/metrics, malformed payloads, and vector dimension mismatches.
  * Expanded test coverage, including security scenarios where unsafe payloads reliably fail with `400` and do not alter data.
* **Chores**
  * Added pgvector test migration coverage for setup/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->