### PR TITLE
Fix: six SQL-injection-adjacent security gaps found via advisory review

### DIFF
--- a/.cursor/rules/integration-tests.mdc
+++ b/.cursor/rules/integration-tests.mdc
@@ -26,7 +26,26 @@ expected outcome, and why each request matters without decoding URLs alone.
 
 - Wire-compatible HTTP E2E → `integration/suites/` (Postgres job owns these)
 - Engine- or stack-specific → `integration/<db>/` (e.g. `postgres/`, `timescaledb/`)
-- Controller behavior changes need unit **and** integration coverage
 
 Templates and gold-file walkthrough: skill `prest-integration-tests` (+ `examples.md`).
 Layout/CI contract: `integration-layout.mdc`.
+
+## MUST: every application behavior change ships with an integration test
+
+A unit test with mocks proves a code path *can* be reached and returns the
+right value in isolation; only an integration test proves it *is* reached
+through real HTTP routing and behaves correctly end-to-end. Unit coverage
+(`unit-tests-tdd.mdc`) is necessary but not sufficient — do not consider a
+behavior change (controller, adapter, middleware, query-param parsing, SQL
+building, etc.) done without a paired integration test in `integration/suites/`
+or `integration/<db>/`.
+
+**Precedent:** `_select`'s SQL-injection fix (GHSA-qvx3-q8vx-9q3c) landed with
+unit coverage for its own validator (`sanitizeSelectField`). The sibling
+`_groupby` path used a separate, weaker validator (`isSafeSQLExpression`) that
+no integration test ever exercised end-to-end — the gap went unnoticed until a
+dedicated audit found it. Unit tests alone did not — and structurally could
+not — catch a *sibling* code path being missed entirely; only an HTTP-level
+test asserting the actual response for both `_select` and `_groupby` would
+have. See `integration/suites/controllers/crud_test.go` (`_groupby
+subquery/UNION injection` cases) for the test that now guards it.

--- a/.cursor/rules/unit-tests-tdd.mdc
+++ b/.cursor/rules/unit-tests-tdd.mdc
@@ -36,5 +36,9 @@ Fail the task if package coverage is under 80%.
 
 ## Controllers / HTTP
 
-TDD unit tests do **not** replace E2E. Controller/HTTP behavior also needs integration coverage —
-see `integration-tests.mdc` and skill `prest-integration-tests`.
+TDD unit tests do **not** replace E2E. Every behavior change MUST also ship an
+integration test — this is not optional for controller/HTTP-adjacent code, it
+is the gate that catches a sibling code path a mocked unit test structurally
+cannot see (e.g. a second query-param builder reusing weaker validation than
+the one under test). See `integration-tests.mdc` (MUST section) and skill
+`prest-integration-tests`.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ TIMESCALEDB_COMPOSE=docker compose -f integration/timescaledb/docker-compose.yml
 test-integration: test-integration-postgres
 
 test-integration-postgres:
-	$(POSTGRES_COMPOSE) up -d --wait postgres postgres-b db-init prestd prestd-multicluster prestd-auth prestd-queries && \
+	$(POSTGRES_COMPOSE) up -d --wait postgres postgres-b db-init prestd prestd-multicluster prestd-auth prestd-queries prestd-cache && \
 	$(POSTGRES_COMPOSE) run --rm --no-deps tests; \
 	status=$$?; \
 	$(POSTGRES_COMPOSE) down -v --remove-orphans; \

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test-integration-log:
 test-integration-postgres-log:
 	@echo "Writing full Postgres integration output to $(INTEGRATION_LOG)"
 	@{ \
-	  $(POSTGRES_COMPOSE) up -d --wait postgres postgres-b db-init prestd prestd-multicluster prestd-auth prestd-queries && \
+	  $(POSTGRES_COMPOSE) up -d --wait postgres postgres-b db-init prestd prestd-multicluster prestd-auth prestd-queries prestd-cache && \
 	  $(POSTGRES_COMPOSE) run --rm --no-deps tests; \
 	  echo $$? > .integration-status.$$$$; \
 	  $(POSTGRES_COMPOSE) down -v --remove-orphans; \

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -2059,8 +2059,16 @@ var allowedGroupByFunctions = map[string]struct{}{
 
 // isSafeSQLExpression validates that a SQL expression used in GROUP BY is an
 // allowlisted function call with safe characters (no comments, no pg_* funcs).
+// The expression must be exactly one allowlisted call with no nested parens in
+// its arguments and nothing trailing after the closing paren: this is what
+// rules out subqueries (which always need their own parens), inner function
+// calls (e.g. pg_sleep(...) used as an argument), and appended statements
+// (e.g. a trailing "UNION SELECT ...") from riding along in the same field.
 func isSafeSQLExpression(expr string) bool {
 	if strings.Contains(expr, "--") || strings.Contains(expr, ";") || strings.Contains(expr, "/*") {
+		return false
+	}
+	if !strings.HasSuffix(expr, ")") {
 		return false
 	}
 
@@ -2076,28 +2084,21 @@ func isSafeSQLExpression(expr string) bool {
 		return false
 	}
 
-	for _, ch := range expr {
+	args := expr[idx+1 : len(expr)-1]
+	if strings.ContainsAny(args, "()") {
+		return false
+	}
+
+	for _, ch := range args {
 		if !((ch >= 'a' && ch <= 'z') ||
 			(ch >= 'A' && ch <= 'Z') ||
 			(ch >= '0' && ch <= '9') ||
-			ch == '_' || ch == '(' || ch == ')' || ch == ',' ||
+			ch == '_' || ch == ',' ||
 			ch == '\'' || ch == ' ' || ch == '.' || ch == '-') {
 			return false
 		}
 	}
-
-	balance := 0
-	for _, ch := range expr {
-		if ch == '(' {
-			balance++
-		} else if ch == ')' {
-			balance--
-		}
-		if balance < 0 {
-			return false
-		}
-	}
-	return balance == 0
+	return true
 }
 
 // quotedAggRegex matches a NormalizeGroupFunction-produced aggregate expression:

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -949,6 +949,10 @@ func TestSelectFields_Injection(t *testing.T) {
 		`(SELECT pg_read_file('/etc/passwd'))"f"`,
 		`(SELECT version())"v"`,
 		`pg_sleep(5)"s"`,
+		// Subquery-close-and-comment: closes the wrapping subquery early and
+		// comments out the real FROM clause, redirecting the SELECT to an
+		// arbitrary table (e.g. "id" FROM "public"."secret") s --).
+		`"id" FROM "public"."secret") s --`,
 	}
 	for _, p := range payloads {
 		_, err := adapter.SelectFields([]string{p})
@@ -1038,6 +1042,10 @@ func TestCountByRequest_Injection(t *testing.T) {
 		`pg_sleep(5)"s"`,
 		`celphone,(SELECT 1)"x"`,
 		`pg_sleep("x")`,
+		// Comment-based FROM-clause hijack: `* FROM pg_stat_activity--` etc.
+		`* FROM pg_stat_activity--`,
+		`* FROM pg_shadow--`,
+		`table_name FROM information_schema.tables--`,
 	}
 	for _, p := range payloads {
 		req, err := http.NewRequest(http.MethodGet,

--- a/adapters/postgres/safe_expression_test.go
+++ b/adapters/postgres/safe_expression_test.go
@@ -29,6 +29,15 @@ func TestIsSafeSQLExpression(t *testing.T) {
 		{"unknown_func(name)", false},
 		{"time_bucket('1 minute', time", false},
 		{"time_bucket)('1 minute', time)", false},
+
+		// Nested subquery / trailing statement injection attempts (CWE-89 sibling
+		// to the _select fix): a balanced-paren, comment-free expression that
+		// smuggles a subquery or an extra statement past the outer allowlisted call.
+		{"upper((SELECT 1))", false},
+		{"upper((SELECT 1)) UNION SELECT current_user", false},
+		{"abs((SELECT 1 FROM pg_sleep(3)))", false},
+		{"upper(name) UNION SELECT current_user", false},
+		{"coalesce(nullif(name, ''), 'x')", false},
 	}
 
 	for _, tt := range tests {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -23,6 +23,13 @@ var (
 	ErrURLNotSet  = errors.New("Database URL not set. \nPlease set it using --url flag or configure it on your prest config file")
 )
 
+func init() {
+	// Empty default, not a DSN built from cfg: a credential-bearing DSN must
+	// never be baked into a cobra flag default, since cobra prints defaults
+	// verbatim in --help. resolveURLConn fills it from cfg at PreRunE time.
+	migrateCmd.PersistentFlags().StringVar(&urlConn, "url", "", "Database driver url (defaults to the configured Postgres connection)")
+}
+
 // migrateCmd represents the migrate command
 var migrateCmd = &cobra.Command{
 	Use:   "migrate",
@@ -34,11 +41,12 @@ func checkTable(cmd *cobra.Command, args []string) error {
 	if path == "" {
 		return ErrPathNotSet
 	}
+	cfg := configFrom(cmd)
+	resolveURLConn(cfg)
 	if urlConn == "" {
 		return ErrURLNotSet
 	}
 	cmd.SilenceUsage = true
-	cfg := configFrom(cmd)
 	if err := app.EnsureAdapter(cfg); err != nil {
 		return err
 	}
@@ -71,6 +79,17 @@ func checkTable(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
+}
+
+// resolveURLConn fills urlConn from the configured Postgres connection when
+// the --url flag was left unset. The flag itself is registered with an empty
+// default (not a DSN built with the plaintext password), so `prestd migrate
+// --help` never echoes the credential back to the terminal; this is where
+// that default gets resolved instead, once flag parsing has already run.
+func resolveURLConn(cfg *config.Prest) {
+	if urlConn == "" {
+		urlConn = driverURL(cfg)
+	}
 }
 
 func driverURL(cfg *config.Prest) string {

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/prest/prest/v2/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+// resolveURLConn mutates the package-level urlConn var, so this test cannot
+// run in parallel with others that touch it.
+func TestResolveURLConn(t *testing.T) {
+	orig := urlConn
+	t.Cleanup(func() { urlConn = orig })
+
+	cfg := &config.Prest{
+		PGUser: "app", PGPass: "super-secret-pass", PGHost: "localhost",
+		PGPort: 5432, PGDatabase: "prest", PGSSLMode: "disable",
+	}
+
+	t.Run("leaves an explicitly-set --url alone", func(t *testing.T) {
+		urlConn = "postgres://explicit-override"
+		resolveURLConn(cfg)
+		require.Equal(t, "postgres://explicit-override", urlConn)
+	})
+
+	t.Run("derives from config when --url was not set", func(t *testing.T) {
+		urlConn = ""
+		resolveURLConn(cfg)
+		require.Equal(t, driverURL(cfg), urlConn)
+		require.Contains(t, urlConn, "super-secret-pass")
+	})
+}
+
+// TestMigrateURLFlagDefault_NeverBakesInCredentials guards against the
+// plaintext-password-in---help leak: the flag registered in Execute (see
+// root.go) must use an empty default, with resolveURLConn filling it in later
+// from cfg — never driverURL(cfg) baked directly into the flag default, which
+// cobra echoes verbatim in `prestd migrate --help`.
+func TestMigrateURLFlagDefault_NeverBakesInCredentials(t *testing.T) {
+	orig := urlConn
+	t.Cleanup(func() { urlConn = orig })
+	urlConn = ""
+
+	f := migrateCmd.PersistentFlags().Lookup("url")
+	require.NotNil(t, f)
+	require.Empty(t, f.DefValue)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,6 @@ func Execute(ctx context.Context, cfg *config.Prest) {
 	migrateCmd.AddCommand(resetCmd)
 	RootCmd.AddCommand(versionCmd)
 	RootCmd.AddCommand(migrateCmd)
-	migrateCmd.PersistentFlags().StringVar(&urlConn, "url", driverURL(cfg), "Database driver url")
 	migrateCmd.PersistentFlags().StringVar(&path, "path", cfg.MigrationsPath, "Migrations directory")
 
 	RootCmd.SetContext(withConfig(ctx, cfg))

--- a/config/database_registry.go
+++ b/config/database_registry.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/prest/prest/v2/internal/ident"
+	"github.com/prest/prest/v2/internal/logsafe"
 	"github.com/spf13/viper"
 )
 
@@ -162,11 +163,13 @@ func applyURLToDatabaseConf(db *DatabaseConf) {
 	}
 	u, err := url.Parse(db.URL)
 	if err != nil {
+		// url.Parse embeds the full original URL (credentials included) in its
+		// own error message, so err must be redacted too, not just the url field.
 		slog.Warn(
 			"database URL invalid, using defaults for connection fields",
 			"alias", db.Alias,
-			"url", db.URL,
-			"err", err,
+			"url", logsafe.Redact(db.URL),
+			"err", logsafe.Error(err),
 		)
 		return
 	}

--- a/config/database_registry_test.go
+++ b/config/database_registry_test.go
@@ -1,11 +1,40 @@
 package config
 
 import (
+	"bytes"
+	"log/slog"
 	"testing"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
+
+// TestApplyURLToDatabaseConf_RedactsInvalidURLInLog guards against logging a
+// raw, credential-bearing connection URL when it fails to parse (an easy
+// config-typo trigger, e.g. a non-numeric port). The warning must still
+// surface the alias and error for debugging, but the password must never
+// appear in the clear in the log line.
+//
+// Mutates the process-wide slog default logger, so this test cannot run in
+// parallel with anything else that does the same.
+func TestApplyURLToDatabaseConf_RedactsInvalidURLInLog(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	db := &DatabaseConf{
+		Alias: "broken",
+		URL:   "postgres://admin:TOP_SECRET_PASSWORD@host:not-a-port/app",
+	}
+	applyURLToDatabaseConf(db)
+
+	logged := buf.String()
+	require.Contains(t, logged, "broken")
+	require.NotContains(t, logged, "TOP_SECRET_PASSWORD")
+	require.Contains(t, logged, "admin:***@")
+}
 
 func resetViperForTest(t *testing.T) {
 	t.Helper()

--- a/controllers/crud.go
+++ b/controllers/crud.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prest/prest/v2/adapters"
 	pctx "github.com/prest/prest/v2/context"
 	"github.com/prest/prest/v2/controllers/auth"
+	"github.com/prest/prest/v2/middlewares"
 
 	"github.com/structy/log"
 )
@@ -185,7 +186,7 @@ func (h *CRUDHandler) Select(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == "GET" && h.cache != nil {
-		h.cache.BuntSet(r.URL.String(), string(sc.Bytes()))
+		h.cache.BuntSet(middlewares.CacheKey(r), string(sc.Bytes()))
 	}
 	//nolint
 	w.Write(sc.Bytes())

--- a/controllers/crud_test.go
+++ b/controllers/crud_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prest/prest/v2/adapters/mockgen"
 	pctx "github.com/prest/prest/v2/context"
 	"github.com/prest/prest/v2/controllers/auth"
+	"github.com/prest/prest/v2/middlewares"
 	"github.com/stretchr/testify/require"
 )
 
@@ -375,7 +376,7 @@ func TestCRUDHandler_Select_WithCache(t *testing.T) {
 	h.Select(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
-	require.Equal(t, url, cacher.key)
+	require.Equal(t, middlewares.CacheKey(req), cacher.key)
 	require.Contains(t, cacher.value, "cached")
 }
 

--- a/controllers/mcp.go
+++ b/controllers/mcp.go
@@ -412,9 +412,12 @@ func (h *MCPHandler) describeTable(r *http.Request, args mcpDescribeArgs) (any, 
 		return nil, err
 	}
 
-	columns, err := h.describeColumns(r, args.Database, args.Schema, args.Table)
+	columns, err := h.selectableColumns(r, args.Database, args.Schema, args.Table)
 	if err != nil {
 		return nil, err
+	}
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("you don't have permission for this action, please check the permitted fields for this table")
 	}
 
 	return map[string]any{

--- a/controllers/mcp_test.go
+++ b/controllers/mcp_test.go
@@ -383,6 +383,72 @@ func TestMCPHandler_RPC_DescribeTable(t *testing.T) {
 	require.Contains(t, rec.Body.String(), `"name":"id"`)
 }
 
+// TestMCPHandler_DescribeTable_NoPermission guards against describe_table
+// exposing full table schema (column names/types) regardless of per-user
+// permissions. Unlike selectTable, describeTable used to call describeColumns
+// directly with no selectableColumns/TablePermissions/FieldsPermissions
+// check, so it leaked schema metadata even when the user has no read access
+// to the table.
+func TestMCPHandler_DescribeTable_NoPermission(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(`[{"column_name":"id","data_type":"integer","position":1}]`))
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(false)
+
+	h := NewMCPHandler(Deps{Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	_, err := h.describeTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpDescribeArgs{
+		Database: "prest-test", Schema: "public", Table: "users",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "permission")
+}
+
+// TestMCPHandler_DescribeTable_FiltersColumnsByFieldPermissions guards the
+// column-level half of the same gap: even when a user has table-level read
+// access, describe_table must only report the columns FieldsPermissions
+// actually grants, not the full schema.
+func TestMCPHandler_DescribeTable_FiltersColumnsByFieldPermissions(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	db := mockDatabaseRegistry(ctrl)
+
+	showScanner := mockgen.NewMockScanner(ctrl)
+	executor.EXPECT().ShowTableCtx(gomock.Any(), "public", "users").Return(showScanner)
+	showScanner.EXPECT().Err().Return(nil)
+	showScanner.EXPECT().Bytes().Return([]byte(
+		`[{"column_name":"id","data_type":"integer","position":1},{"column_name":"ssn","data_type":"text","position":2}]`,
+	))
+	perms.EXPECT().TablePermissions("prest-test", "public", "users", "read", "").Return(true)
+	perms.EXPECT().FieldsPermissions(gomock.Any(), "prest-test", "public", "users", "read", "").Return([]string{"id"}, nil)
+
+	h := NewMCPHandler(Deps{Executor: executor, Perms: perms, DB: db, PGDatabase: "prest-test"})
+	result, err := h.describeTable(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpDescribeArgs{
+		Database: "prest-test", Schema: "public", Table: "users",
+	})
+	require.NoError(t, err)
+
+	payload := result.(map[string]any)
+	require.Equal(t, 1, payload["count"])
+	columns := payload["columns"].([]mcpColumn)
+	require.Len(t, columns, 1)
+	require.Equal(t, "id", columns[0].Name)
+}
+
 func TestMCPHandler_RPC_SelectTable(t *testing.T) {
 	t.Parallel()
 

--- a/controllers/script.go
+++ b/controllers/script.go
@@ -88,15 +88,21 @@ func (h *ScriptHandler) ExecuteScriptQuery(rq *http.Request, queriesPath string,
 }
 
 // extractHeaders gets from the given request the headers and populate the provided templateData accordingly.
+// Values are routed through sanitizeScriptParam, the same gate used for query
+// parameters, since templates interpolate headers into SQL exactly the same way.
 func extractHeaders(rq *http.Request, templateData map[string]interface{}) {
 	headers := map[string]interface{}{}
 
 	for key, value := range rq.Header {
 		if len(value) == 1 {
-			headers[key] = value[0]
+			headers[key] = sanitizeScriptParam(value[0])
 			continue
 		}
-		headers[key] = value
+		sanitized := make([]string, 0, len(value))
+		for _, v := range value {
+			sanitized = append(sanitized, sanitizeScriptParam(v))
+		}
+		headers[key] = sanitized
 	}
 
 	templateData["header"] = headers

--- a/controllers/script.go
+++ b/controllers/script.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/prest/prest/v2/adapters"
+	"github.com/prest/prest/v2/middlewares"
 
 	"github.com/gorilla/mux"
 )
@@ -17,6 +18,7 @@ type ScriptHandler struct {
 	db       adapters.DatabaseRegistry
 	cache    ResponseCacher
 	pgDB     string
+	singleDB bool
 }
 
 // NewScriptHandler creates a ScriptHandler.
@@ -27,6 +29,7 @@ func NewScriptHandler(deps Deps) *ScriptHandler {
 		db:       deps.DB,
 		cache:    deps.Cache,
 		pgDB:     deps.PGDatabase,
+		singleDB: deps.SingleDB,
 	}
 }
 
@@ -41,6 +44,18 @@ func (h *ScriptHandler) Execute(w http.ResponseWriter, r *http.Request) {
 		database = h.db.GetDatabase()
 	}
 
+	// Same gate every other controller applies before touching the connection
+	// layer: reject an unregistered/attacker-chosen database name here, rather
+	// than letting dbFromCtx open a real outbound connection for it.
+	if err := validateDatabase(database, h.db, h.singleDB); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if !validatePathSegments(database, queriesPath, script) {
+		jsonError(w, "invalid identifier in path", http.StatusBadRequest)
+		return
+	}
+
 	ctx, cancel := requestContext(r, database)
 	defer cancel()
 
@@ -51,7 +66,7 @@ func (h *ScriptHandler) Execute(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == "GET" && h.cache != nil {
-		h.cache.BuntSet(r.URL.String(), string(result))
+		h.cache.BuntSet(middlewares.CacheKey(r), string(result))
 	}
 	//nolint
 	w.Write(result)

--- a/controllers/script_test.go
+++ b/controllers/script_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prest/prest/v2/adapters"
 	"github.com/prest/prest/v2/adapters/mockgen"
+	"github.com/prest/prest/v2/middlewares"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,6 +34,7 @@ func TestScriptHandler_Execute_Success(t *testing.T) {
 	executor.EXPECT().ExecuteScriptsCtx(gomock.Any(), http.MethodGet, `SELECT 1`, gomock.Any()).Return(scanner)
 
 	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().IsRegistered("prest-test").Return(true)
 
 	h := NewScriptHandler(Deps{Scripts: scripts, Executor: executor, DB: db, PGDatabase: "prest-test"})
 	req := httptest.NewRequest(http.MethodGet, "/queries/list", nil)
@@ -67,6 +69,7 @@ func TestScriptHandler_Execute_DefaultDatabase(t *testing.T) {
 
 	db := mockgen.NewMockDatabaseRegistry(ctrl)
 	db.EXPECT().GetDatabase().Return("prest-test").AnyTimes()
+	db.EXPECT().IsRegistered("prest-test").Return(true)
 
 	h := NewScriptHandler(Deps{Scripts: scripts, Executor: executor, DB: db, PGDatabase: "prest-test"})
 	req := httptest.NewRequest(http.MethodGet, "/queries/ping", nil)
@@ -99,6 +102,7 @@ func TestScriptHandler_Execute_WithCache(t *testing.T) {
 	executor.EXPECT().ExecuteScriptsCtx(gomock.Any(), http.MethodGet, `SELECT 1`, gomock.Any()).Return(scanner)
 
 	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().IsRegistered("prest-test").Return(true)
 	cacher := &recordingCacher{}
 	h := NewScriptHandler(Deps{Scripts: scripts, Executor: executor, DB: db, PGDatabase: "prest-test", Cache: cacher})
 
@@ -111,8 +115,64 @@ func TestScriptHandler_Execute_WithCache(t *testing.T) {
 	h.Execute(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
-	require.Equal(t, url, cacher.key)
+	require.Equal(t, middlewares.CacheKey(req), cacher.key)
 	require.Equal(t, "cached", cacher.value)
+}
+
+// TestScriptHandler_Execute_RejectsUnregisteredDatabase guards against an
+// unauthenticated request reaching the connection layer with an arbitrary,
+// attacker-chosen database name. Unlike CRUDHandler.Select and every other
+// controller, ScriptHandler.Execute used to skip validateDatabase entirely,
+// so dbFromCtx would attempt a real outbound Postgres connection (via
+// AddDatabaseToPool) for any name in the /_QUERIES/{database}/... path.
+// ResolveScript must never be reached once the database fails validation.
+func TestScriptHandler_Execute_RejectsUnregisteredDatabase(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().IsRegistered("evil").Return(false)
+
+	h := NewScriptHandler(Deps{
+		Scripts:  mockgen.NewMockScriptRunner(ctrl),
+		Executor: mockgen.NewMockQueryExecutor(ctrl),
+		DB:       db,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/evil/queries/list", nil)
+	req = mux.SetURLVars(req, map[string]string{"database": "evil", "queriesLocation": "queries", "script": "list"})
+	rec := httptest.NewRecorder()
+
+	h.Execute(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestScriptHandler_Execute_RejectsUnsafePathSegment guards against path
+// segments (queriesLocation/script) that fall outside the safe identifier
+// charset ScriptHandler relies on to build the on-disk template path.
+func TestScriptHandler_Execute_RejectsUnsafePathSegment(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().IsRegistered("prest-test").Return(true)
+
+	h := NewScriptHandler(Deps{
+		Scripts:  mockgen.NewMockScriptRunner(ctrl),
+		Executor: mockgen.NewMockQueryExecutor(ctrl),
+		DB:       db,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/prest-test/queries/../../etc", nil)
+	req = mux.SetURLVars(req, map[string]string{"database": "prest-test", "queriesLocation": "queries", "script": "../../etc"})
+	rec := httptest.NewRecorder()
+
+	h.Execute(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestScriptHandler_ExecuteScriptQuery_GetScriptError(t *testing.T) {

--- a/controllers/script_test.go
+++ b/controllers/script_test.go
@@ -179,6 +179,24 @@ func TestExtractHeaders(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, headers["X-Multi"])
 }
 
+func TestExtractHeaders_SanitizesUnsafeValues(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Safe", "prest")
+	req.Header.Set("X-Injection", "' UNION SELECT rolpassword::text FROM pg_authid WHERE rolname='postgres' -- ")
+	req.Header.Add("X-Multi", "good")
+	req.Header.Add("X-Multi", "'; DROP TABLE users; --")
+
+	data := map[string]interface{}{}
+	extractHeaders(req, data)
+
+	headers := data["header"].(map[string]interface{})
+	require.Equal(t, "prest", headers["X-Safe"])
+	require.Equal(t, "", headers["X-Injection"])
+	require.Equal(t, []string{"good", ""}, headers["X-Multi"])
+}
+
 func TestExtractQueryParameters(t *testing.T) {
 	t.Parallel()
 

--- a/integration/helpers/server.go
+++ b/integration/helpers/server.go
@@ -35,6 +35,13 @@ func QueriesServerURL(t *testing.T) string {
 	return envURL(t, "PREST_QUERIES_TEST_URL")
 }
 
+// CacheServerURL returns the base URL for the cache+auth+ACL-enabled prestd
+// service (testdata/prest_cache.toml), used to test per-identity cache scoping.
+func CacheServerURL(t *testing.T) string {
+	t.Helper()
+	return envURL(t, "PREST_CACHE_TEST_URL")
+}
+
 func envURL(t *testing.T, key string) string {
 	t.Helper()
 	u := strings.TrimSpace(os.Getenv(key))

--- a/integration/postgres/controllers/batch_acl_test.go
+++ b/integration/postgres/controllers/batch_acl_test.go
@@ -1,0 +1,58 @@
+package controllers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/prest/prest/v2/integration/helpers"
+)
+
+// TestBatchInsert_EnforcesTablePermissions guards the middlewares.getVars gap
+// where /batch/{database}/{schema}/{table} (a 5-element path split once the
+// leading "/" is accounted for) fell outside the shapes getVars handled and
+// returned nil, which AccessControl treats as "not a table path" and lets
+// through unconditionally — silently skipping TablePermissions for batch
+// inserts regardless of ACL config. BatchInsert itself never checks
+// permissions on its own; it relies entirely on the AccessControl middleware.
+func TestBatchInsert_EnforcesTablePermissions(t *testing.T) {
+	base := helpers.AuthServerURL(t)
+	token := helpers.LoginToken(t, base, "test@postgres.rest", "123456")
+
+	var testCases = []struct {
+		description string
+		url         string
+		body        interface{}
+		status      int
+	}{
+		{
+			"POST /batch on a read-only table (test_readonly_access has no write permission) is rejected",
+			"/batch/prest-test/public/test_readonly_access",
+			[]map[string]string{{"name": "batch-acl-poc"}},
+			http.StatusUnauthorized,
+		},
+		{
+			"POST /batch on a fully-permissioned table (test5) still succeeds",
+			"/batch/prest-test/public/test5",
+			[]map[string]string{{"celphone": "batch-acl-ok"}},
+			http.StatusCreated,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+		helpers.DoAuthRequest(t, base+tc.url, tc.body, http.MethodPost, token, tc.status, "BatchInsertACL")
+	}
+}
+
+// TestBatchInsert_RequiresAuth is the baseline for the case above: with no
+// token at all, AuthMiddleware (which runs before AccessControl in the
+// stack) must reject the request before TablePermissions is ever consulted.
+func TestBatchInsert_RequiresAuth(t *testing.T) {
+	base := helpers.AuthServerURL(t)
+
+	helpers.DoAuthRequest(
+		t, base+"/batch/prest-test/public/test5",
+		[]map[string]string{{"celphone": "no-token"}},
+		http.MethodPost, "", http.StatusUnauthorized, "BatchInsertACL",
+	)
+}

--- a/integration/postgres/controllers/cache_scope_test.go
+++ b/integration/postgres/controllers/cache_scope_test.go
@@ -1,0 +1,66 @@
+package controllers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/prest/prest/v2/integration/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCache_DoesNotLeakAcrossIdentities guards the GET response cache
+// (middlewares.CacheMiddleware) leaking a response computed under one user's
+// FieldsPermissions to a different identity requesting the identical URL. The
+// cache sits downstream of AccessControl but upstream of the handler's own
+// per-user column filtering, so on a cache hit that filtering never runs
+// again — a cache key scoped only by URL would let a more-privileged user's
+// cached response (extra columns) leak to a less-privileged one.
+//
+// testdata/prest_cache.toml grants test@postgres.rest an extra "celphone"
+// column on test6 that cache-scope-user-b (no per-user override, falls back
+// to the generic table permissions) doesn't get. test@postgres.rest reads
+// first, populating the cache under their identity; the very next request
+// from cache-scope-user-b to the identical URL must recompute its own
+// restricted response, never reuse the more-privileged cached one. auth is
+// mandatory on this server, so both sides must be real logged-in identities
+// (an anonymous request is rejected by AuthMiddleware before it ever reaches
+// AccessControl or the cache).
+func TestCache_DoesNotLeakAcrossIdentities(t *testing.T) {
+	base := helpers.CacheServerURL(t)
+	tokenA := helpers.LoginToken(t, base, "test@postgres.rest", "123456")
+	tokenB := helpers.LoginToken(t, base, "cache-scope-user-b@postgres.rest", "123456")
+	url := base + "/prest-test/public/test6"
+
+	// More-privileged read: gets the expanded field set, including "celphone".
+	// This is the response that ends up cached under this user's identity.
+	rowsA := doCacheJSONRequest(t, url, "Bearer "+tokenA)
+	require.NotEmpty(t, rowsA)
+	require.Contains(t, rowsA[0], "celphone", "test@postgres.rest should see celphone per prest_cache.toml")
+
+	// A different, less-privileged identity reading the identical URL right
+	// after: must recompute under its own (restricted) permission set, not
+	// reuse the more-privileged user's cached response.
+	rowsB := doCacheJSONRequest(t, url, "Bearer "+tokenB)
+	require.NotEmpty(t, rowsB)
+	require.NotContains(t, rowsB[0], "celphone", "cache-scope-user-b must not see a column only test@postgres.rest is permitted")
+}
+
+func doCacheJSONRequest(t *testing.T, url, authHeader string) []map[string]any {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var rows []map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&rows))
+	return rows
+}

--- a/integration/postgres/controllers/mcp_describe_acl_test.go
+++ b/integration/postgres/controllers/mcp_describe_acl_test.go
@@ -1,0 +1,57 @@
+package controllers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/prest/prest/v2/integration/helpers"
+)
+
+// TestMCPDescribeTable_EnforcesPermissions guards describe_table exposing
+// full table schema (column names/types) regardless of per-user permissions.
+// Unlike select_table, describeTable used to call describeColumns directly
+// with no selectableColumns/TablePermissions/FieldsPermissions check, so it
+// leaked schema metadata even for tables the user has no read access to, and
+// never filtered columns down to what FieldsPermissions actually grants.
+func TestMCPDescribeTable_EnforcesPermissions(t *testing.T) {
+	base := helpers.AuthServerURL(t)
+	token := helpers.LoginToken(t, base, "test@postgres.rest", "123456")
+
+	var testCases = []struct {
+		description  string
+		table        string
+		status       int
+		expectedBody []string
+	}{
+		{
+			"describe_table on a table absent from access.tables is denied, not disclosed",
+			"test7",
+			http.StatusBadRequest,
+			[]string{`"error"`, "permission"},
+		},
+		{
+			"describe_table on an allowed table returns only its configured columns",
+			"test_readonly_access",
+			http.StatusOK,
+			[]string{`"name":"id"`, `"name":"name"`, `"count":2`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+		payload := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "tools/call",
+			"params": map[string]any{
+				"name": "prest.describe_table",
+				"arguments": map[string]any{
+					"database": "prest-test",
+					"schema":   "public",
+					"table":    tc.table,
+				},
+			},
+		}
+		helpers.DoAuthRequest(t, base+"/_mcp", payload, http.MethodPost, token, tc.status, "MCPDescribeTableACL", tc.expectedBody...)
+	}
+}

--- a/integration/postgres/docker-compose.yml
+++ b/integration/postgres/docker-compose.yml
@@ -139,6 +139,31 @@ services:
       retries: 30
       start_period: 90s
 
+  prestd-cache:
+    <<: *prestd-service
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+    environment:
+      <<: *prest-env
+      PREST_CONF: /workspace/testdata/prest_cache.toml
+      PREST_DEBUG: "true"
+      PREST_JWT_DEFAULT: "false"
+      PREST_AUTH_ENABLED: "true"
+      PREST_JWT_KEY: integration-test-secret
+      PREST_PG_SINGLE: "false"
+      PREST_HTTP_PORT: "3004"
+    command: >-
+      bash -lc "export PATH=/usr/local/go/bin:/go/bin:$$PATH && apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && go run ./cmd/prestd/main.go"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:3004/_health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 90s
+
   prestd-queries:
     <<: *prestd-service
     depends_on:
@@ -176,12 +201,15 @@ services:
         condition: service_healthy
       prestd-queries:
         condition: service_healthy
+      prestd-cache:
+        condition: service_healthy
     environment:
       <<: *prest-env
       PREST_CONF: /workspace/testdata/prest.toml
       PREST_TEST_URL: http://prestd:3000
       PREST_MULTICLUSTER_TEST_URL: http://prestd-multicluster:3001
       PREST_AUTH_TEST_URL: http://prestd-auth:3002
+      PREST_CACHE_TEST_URL: http://prestd-cache:3004
       PREST_QUERIES_TEST_URL: http://prestd-queries:3003
     command: >-
       bash -lc "apt-get update && apt-get install -y --no-install-recommends postgresql-client git ca-certificates && bash -x ./testdata/runtest.sh ./integration/suites/... ./integration/postgres/..."

--- a/integration/suites/controllers/crud_test.go
+++ b/integration/suites/controllers/crud_test.go
@@ -114,6 +114,13 @@ func TestSelectFromTables(t *testing.T) {
 		{"execute select rejects _select projection injection", "/%s/public/test?_select=(1)\"x\"", "GET", http.StatusBadRequest, ""},
 		// Same class through the second sink: _select interpolated into SELECT COUNT(...) when _count is set.
 		{"execute select rejects _select injection via the _count sink", "/%s/public/test?_count=*&_select=pg_read_file('/etc/passwd')\"f\"", "GET", http.StatusBadRequest, ""},
+		// _groupby sibling of GHSA-qvx3-q8vx-9q3c: the raw-SQL-expression branch used to accept a
+		// balanced-paren subquery/UNION riding past the outer allowlisted function. GroupByClause now
+		// rejects it and drops the clause entirely, so pairing it with an aggregate _select surfaces
+		// as a "column must appear in GROUP BY" error instead of executing the injected UNION SELECT.
+		{"execute select rejects _groupby subquery/UNION injection", "/%s/public/test_group_by_table?_select=age,sum:salary&_groupby=upper((SELECT+1))+UNION+SELECT+current_user", "GET", http.StatusBadRequest, ""},
+		// Nested pg_* call as a function argument (pg_sleep DoS primitive) must be rejected the same way.
+		{"execute select rejects _groupby nested pg_* call injection", "/%s/public/test_group_by_table?_select=age,sum:salary&_groupby=abs((SELECT+1+FROM+pg_sleep(3)))", "GET", http.StatusBadRequest, ""},
 		{"execute select in a view with an other column", "/%s/public/view_test?_select=celphone", "GET", http.StatusBadRequest, ""},
 		{"execute select in a view with where and column invalid", "/%s/public/view_test?0celphone=$eq.888888", "GET", http.StatusBadRequest, ""},
 		{"execute select in a view with custom join clause invalid", "/%s/public/view_test?_join=inner:test2.name:eq:view_test.player", "GET", http.StatusBadRequest, ""},

--- a/integration/suites/controllers/scripts_test.go
+++ b/integration/suites/controllers/scripts_test.go
@@ -55,6 +55,27 @@ func TestExecuteFromScripts(t *testing.T) {
 	}
 }
 
+// TestExecuteFromScripts_RejectsHeaderInjection guards the unauthenticated SQL
+// injection where get_header.read.sql interpolates the X-Application header
+// directly into `SELECT '{{index .header "X-Application"}}'` with no
+// sanitization, unlike query parameters which already go through
+// sanitizeScriptParam. A header carrying a quote breakout used to let an
+// unauthenticated request UNION in arbitrary rows (e.g. pg_authid password
+// hashes). extractHeaders now routes header values through the same
+// sanitizeScriptParam gate as query parameters, so the payload is neutralized
+// to an empty string instead of breaking out of the SQL literal.
+func TestExecuteFromScripts_RejectsHeaderInjection(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	headers := map[string]string{
+		"X-Application": "' UNION SELECT rolpassword::text FROM pg_authid WHERE rolname='postgres' -- ",
+	}
+	testutils.DoRequestWithHeaders(
+		t, base+"/_QUERIES/fulltable/get_header", nil, "GET", http.StatusOK,
+		"ExecuteFromScripts", headers, `[{"?column?": ""}]`,
+	)
+}
+
 func TestRenderWithXML(t *testing.T) {
 	base := helpers.ServerURL(t)
 

--- a/integration/suites/controllers/scripts_test.go
+++ b/integration/suites/controllers/scripts_test.go
@@ -76,6 +76,40 @@ func TestExecuteFromScripts_RejectsHeaderInjection(t *testing.T) {
 	)
 }
 
+// TestExecuteFromScripts_RejectsUnregisteredDatabase guards against
+// ScriptHandler.Execute reaching the connection layer with an arbitrary,
+// attacker-chosen database name via /_QUERIES/{database}/{queriesLocation}/{script}.
+// Every other controller validates the database against the registry before
+// touching the connection layer; Execute used to skip that check, so
+// dbFromCtx would attempt a real outbound Postgres connection for any name in
+// the path. It also skipped validatePathSegments entirely, so an unsafe
+// queriesLocation/script segment used to reach ResolveScript unchecked.
+func TestExecuteFromScripts_RejectsUnregisteredDatabase(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	var testCases = []struct {
+		description string
+		url         string
+		status      int
+	}{
+		{
+			"GET _QUERIES with an unregistered database name is rejected, not attempted as a connection",
+			"/_QUERIES/evil-db-does-not-exist/fulltable/get_all?field1=gopher",
+			http.StatusBadRequest,
+		},
+		{
+			"GET _QUERIES with an unsafe script segment is rejected",
+			"/_QUERIES/fulltable/evil'name",
+			http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+		testutils.DoRequest(t, base+tc.url, nil, "GET", tc.status, "ExecuteFromScripts")
+	}
+}
+
 func TestRenderWithXML(t *testing.T) {
 	base := helpers.ServerURL(t)
 

--- a/internal/logsafe/logsafe.go
+++ b/internal/logsafe/logsafe.go
@@ -11,7 +11,7 @@ var (
 	// the host rather than the first: a password containing "@" (e.g.
 	// postgres://user:p@ss@word@host/db) would otherwise leave everything
 	// after its first "@" ("ss@word") unredacted.
-	pgURLCreds = regexp.MustCompile(`postgres(?:ql)?://([^:@/]+):(.+)@`)
+	pgURLCreds = regexp.MustCompile(`(?i)postgres(?:ql)?://([^:@/]+):(.+)@`)
 )
 
 // Redact returns s with database credentials removed, suitable for safe

--- a/internal/logsafe/logsafe.go
+++ b/internal/logsafe/logsafe.go
@@ -7,16 +7,27 @@ import (
 
 var (
 	passwordKV = regexp.MustCompile(`(?i)password=(?:'[^']*'|"[^"]*"|[^\s'"]+)`)
-	pgURLCreds = regexp.MustCompile(`postgres(?:ql)?://([^:@/]+):([^@/]+)@`)
+	// The password group is greedy so it consumes up to the LAST "@" before
+	// the host rather than the first: a password containing "@" (e.g.
+	// postgres://user:p@ss@word@host/db) would otherwise leave everything
+	// after its first "@" ("ss@word") unredacted.
+	pgURLCreds = regexp.MustCompile(`postgres(?:ql)?://([^:@/]+):(.+)@`)
 )
+
+// Redact returns s with database credentials removed, suitable for safe
+// structured logging — e.g. a raw connection URL logged as a slog field
+// value, not just an error message.
+func Redact(s string) string {
+	redacted := passwordKV.ReplaceAllString(s, "password=***")
+	return pgURLCreds.ReplaceAllString(redacted, "postgres://$1:***@")
+}
 
 // Error returns err with database credentials redacted for safe structured logging.
 func Error(err error) error {
 	if err == nil {
 		return nil
 	}
-	redacted := passwordKV.ReplaceAllString(err.Error(), "password=***")
-	redacted = pgURLCreds.ReplaceAllString(redacted, "postgres://$1:***@")
+	redacted := Redact(err.Error())
 	if redacted == err.Error() {
 		return err
 	}

--- a/internal/logsafe/logsafe_test.go
+++ b/internal/logsafe/logsafe_test.go
@@ -60,3 +60,31 @@ func TestError_unchanged(t *testing.T) {
 	err := errors.New("connection refused")
 	require.Same(t, err, Error(err))
 }
+
+// TestError_passwordContainingAt guards against the greedy-vs-first-match
+// regex bug: a password containing "@" must be fully redacted, not just up
+// to its first "@" (which used to leave the tail of the real password, e.g.
+// "ss@word", in the clear).
+func TestError_passwordContainingAt(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("dial: postgres://user:p@ss@word@host/db failed")
+	redacted := Error(err)
+	require.Equal(t, "dial: postgres://user:***@host/db failed", redacted.Error())
+	require.NotContains(t, redacted.Error(), "ss@word")
+}
+
+func TestRedact_plainURL(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		"postgres://admin:***@db.example.com:5432/app",
+		Redact("postgresql://admin:supersecret@db.example.com:5432/app"),
+	)
+}
+
+func TestRedact_unchanged(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "no credentials here", Redact("no credentials here"))
+}

--- a/internal/logsafe/logsafe_test.go
+++ b/internal/logsafe/logsafe_test.go
@@ -88,3 +88,13 @@ func TestRedact_unchanged(t *testing.T) {
 
 	require.Equal(t, "no credentials here", Redact("no credentials here"))
 }
+
+// TestRedact_uppercaseScheme guards against a case-sensitive scheme match:
+// URL schemes are case-insensitive, so "POSTGRES://" must be redacted the
+// same as "postgres://" instead of leaking the password unredacted.
+func TestRedact_uppercaseScheme(t *testing.T) {
+	t.Parallel()
+
+	redacted := Redact("POSTGRES://admin:supersecret@db.example.com:5432/app")
+	require.NotContains(t, redacted, "supersecret")
+}

--- a/middlewares/cache.go
+++ b/middlewares/cache.go
@@ -7,7 +7,30 @@ import (
 	"github.com/urfave/negroni/v3"
 
 	"github.com/prest/prest/v2/cache"
+	pctx "github.com/prest/prest/v2/context"
+	"github.com/prest/prest/v2/controllers/auth"
 )
+
+// CacheKey builds the per-identity cache key for a request. The cache sits
+// downstream of AccessControl but upstream of the handler's own per-user
+// FieldsPermissions (column-level) filtering: on a cache hit the handler never
+// runs, so a key scoped only by URL would let one user's cached response
+// (built under their own column permissions) leak to a different user with
+// different field permissions on the same table.
+//
+// The identity is appended after a synthetic "?", not merged into the path:
+// cache.Config.BuntSet recovers the endpoint path for its own cache-rule
+// lookup via strings.Split(key, "?")[0], so whatever follows the first "?"
+// — real query string or not — must stay irrelevant to that split.
+func CacheKey(r *http.Request) string {
+	userName := ""
+	if userInfo := r.Context().Value(pctx.UserInfoKey); userInfo != nil {
+		if user, ok := userInfo.(auth.User); ok {
+			userName = user.Username
+		}
+	}
+	return r.URL.String() + "?__prest_user=" + userName
+}
 
 // CacheMiddleware simple caching to avoid equal queries to the database
 // todo: receive config.PrestConf.Cache to pass to cache.EndpointRules
@@ -22,7 +45,7 @@ func CacheMiddleware(cfg *cache.Config, whitelist []string) negroni.Handler {
 		// team will not be used when downloading information, second result ignored
 		cacheRule, _ := cfg.EndpointRules(r.URL.Path)
 		if cfg.Enabled && r.Method == "GET" && !match && cacheRule {
-			if cfg.BuntGet(r.URL.String(), w) {
+			if cfg.BuntGet(CacheKey(r), w) {
 				return
 			}
 		}

--- a/middlewares/cache.go
+++ b/middlewares/cache.go
@@ -1,6 +1,8 @@
 package middlewares
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 
@@ -22,6 +24,13 @@ import (
 // cache.Config.BuntSet recovers the endpoint path for its own cache-rule
 // lookup via strings.Split(key, "?")[0], so whatever follows the first "?"
 // — real query string or not — must stay irrelevant to that split.
+//
+// The identity suffix is a SHA-256 digest, not the raw username: a raw
+// username is forgeable when RawQuery is attacker-controlled (Go preserves
+// unescaped "?" in RawQuery), letting a user whose own username is a suffix
+// of a target's craft a request URL that reconstructs the target's exact
+// key. A fixed-length digest closes that off — matching it back to a
+// different real username requires a SHA-256 preimage.
 func CacheKey(r *http.Request) string {
 	userName := ""
 	if userInfo := r.Context().Value(pctx.UserInfoKey); userInfo != nil {
@@ -29,7 +38,8 @@ func CacheKey(r *http.Request) string {
 			userName = user.Username
 		}
 	}
-	return r.URL.String() + "?__prest_user=" + userName
+	sum := sha256.Sum256([]byte(userName))
+	return r.URL.String() + "?__prest_user=" + hex.EncodeToString(sum[:])
 }
 
 // CacheMiddleware simple caching to avoid equal queries to the database

--- a/middlewares/cache_test.go
+++ b/middlewares/cache_test.go
@@ -127,3 +127,22 @@ func TestCacheMiddleware_CacheLookup(t *testing.T) {
 		require.Empty(t, rec.Header().Get("Cache-Server"))
 	})
 }
+
+// TestCacheKey_rawQueryCannotForgeIdentity guards against key collisions via
+// RawQuery: Go preserves an unescaped "?" in it, so URL.String() can echo the
+// literal "__prest_user=<name>" suffix pREST itself appends. The identity
+// suffix must be a digest of the authenticated username, not the raw value,
+// so embedding another user's name in RawQuery can't reproduce their key.
+func TestCacheKey_rawQueryCannotForgeIdentity(t *testing.T) {
+	t.Parallel()
+
+	victimReq := httptest.NewRequest(http.MethodGet, "/prest/public/test", nil)
+	victimReq = victimReq.WithContext(withUser(victimReq.Context(), auth.User{Username: "admin"}))
+	victimKey := CacheKey(victimReq)
+
+	forgedPath := "/prest/public/test?__prest_user=admin"
+	attackerReq := httptest.NewRequest(http.MethodGet, forgedPath, nil)
+	attackerReq = attackerReq.WithContext(withUser(attackerReq.Context(), auth.User{Username: "eve"}))
+
+	require.NotEqual(t, victimKey, CacheKey(attackerReq))
+}

--- a/middlewares/cache_test.go
+++ b/middlewares/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/prest/prest/v2/cache"
+	"github.com/prest/prest/v2/controllers/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,9 +88,9 @@ func TestCacheMiddleware_CacheLookup(t *testing.T) {
 
 	t.Run("hit", func(t *testing.T) {
 		cfg := newCfg(t)
-		cfg.BuntSet(path, `[{"cached":true}]`)
-
 		req := httptest.NewRequest(http.MethodGet, path, nil)
+		cfg.BuntSet(CacheKey(req), `[{"cached":true}]`)
+
 		rec, called := serveMiddleware(CacheMiddleware(cfg, nil), req)
 
 		require.False(t, called)
@@ -106,6 +107,23 @@ func TestCacheMiddleware_CacheLookup(t *testing.T) {
 
 		require.True(t, called)
 		require.Equal(t, http.StatusOK, rec.Code)
+		require.Empty(t, rec.Header().Get("Cache-Server"))
+	})
+
+	// A cache entry populated under one user's identity must not be served to
+	// a different user hitting the identical URL: FieldsPermissions can differ
+	// per user, and the handler that would recompute it never runs on a hit.
+	t.Run("does not leak across users on the same URL", func(t *testing.T) {
+		cfg := newCfg(t)
+		userAReq := httptest.NewRequest(http.MethodGet, path, nil)
+		userAReq = userAReq.WithContext(withUser(userAReq.Context(), auth.User{Username: "alice"}))
+		cfg.BuntSet(CacheKey(userAReq), `[{"ssn":"redacted-for-alice-only"}]`)
+
+		userBReq := httptest.NewRequest(http.MethodGet, path, nil)
+		userBReq = userBReq.WithContext(withUser(userBReq.Context(), auth.User{Username: "bob"}))
+		rec, called := serveMiddleware(CacheMiddleware(cfg, nil), userBReq)
+
+		require.True(t, called, "bob must recompute the response, not receive alice's cached one")
 		require.Empty(t, rec.Header().Get("Cache-Server"))
 	})
 }

--- a/middlewares/cache_test.go
+++ b/middlewares/cache_test.go
@@ -1,6 +1,8 @@
 package middlewares
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -140,9 +142,18 @@ func TestCacheKey_rawQueryCannotForgeIdentity(t *testing.T) {
 	victimReq = victimReq.WithContext(withUser(victimReq.Context(), auth.User{Username: "admin"}))
 	victimKey := CacheKey(victimReq)
 
+	// Reuse the production digest mechanism to pin down what the suffix must
+	// actually contain, not just that two keys differ.
+	sum := sha256.Sum256([]byte("admin"))
+	adminDigest := hex.EncodeToString(sum[:])
+	require.Contains(t, victimKey, adminDigest)
+
 	forgedPath := "/prest/public/test?__prest_user=admin"
 	attackerReq := httptest.NewRequest(http.MethodGet, forgedPath, nil)
 	attackerReq = attackerReq.WithContext(withUser(attackerReq.Context(), auth.User{Username: "eve"}))
+	attackerKey := CacheKey(attackerReq)
 
-	require.NotEqual(t, victimKey, CacheKey(attackerReq))
+	require.NotEqual(t, victimKey, attackerKey)
+	require.NotContains(t, attackerKey, adminDigest,
+		"attacker's key must not carry the victim's identity digest despite echoing their username in RawQuery")
 }

--- a/middlewares/middlewares_test.go
+++ b/middlewares/middlewares_test.go
@@ -376,6 +376,34 @@ func withUser(ctx context.Context, user auth.User) context.Context {
 	return context.WithValue(ctx, pctx.UserInfoKey, user)
 }
 
+// TestAccessControl_EnforcesBatchInsertRoute guards the getVars gap where
+// /batch/{database}/{schema}/{table} (a real 5-element split once the leading
+// "/" is accounted for) fell outside getVars' handled shapes and returned nil,
+// which AccessControl treats as "not a table path" and lets through
+// unconditionally — silently skipping TablePermissions for batch inserts.
+func TestAccessControl_EnforcesBatchInsertRoute(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	perms := mockgen.NewMockPermissionsChecker(ctrl)
+	perms.EXPECT().TablePermissions("prest-test", "public", "test", "write", "").Return(false)
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	handler := AccessControl(perms)
+	req := httptest.NewRequest(http.MethodPost, "/batch/prest-test/public/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req, next.ServeHTTP)
+
+	require.False(t, called)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
 func TestAccessControl_SkipsNonTablePaths(t *testing.T) {
 	t.Parallel()
 

--- a/middlewares/utils.go
+++ b/middlewares/utils.go
@@ -25,20 +25,30 @@ var (
 </errors>`
 )
 
+// getVars extracts {database}/{schema}/{table} from a request path. A real
+// http.Request.URL.Path always starts with "/", so a 3-segment resource route
+// splits into 4 elements (leading "") and a "/batch/..." route (one extra
+// literal segment) splits into 5. Both prefixes are stripped explicitly here
+// rather than inferred from segment count alone — that used to make any
+// 4-element split fall through to "not a table path" (nil, which
+// AccessControl treats as unenforced), silently skipping TablePermissions on
+// /batch/{database}/{schema}/{table}.
 func getVars(path string) (paths map[string]string) {
-	pathList := strings.Split(path, "/")
-
-	if len(pathList) < 3 || len(pathList) > 4 {
-		return nil
-	} else if len(pathList) == 4 {
-		pathList = pathList[1:]
+	segments := strings.Split(path, "/")
+	if len(segments) > 0 && segments[0] == "" {
+		segments = segments[1:]
 	}
-	paths = make(map[string]string, 0)
-	paths["database"] = pathList[0]
-	paths["schema"] = pathList[1]
-	paths["table"] = pathList[2]
-
-	return
+	if len(segments) == 4 && segments[0] == "batch" {
+		segments = segments[1:]
+	}
+	if len(segments) != 3 {
+		return nil
+	}
+	return map[string]string{
+		"database": segments[0],
+		"schema":   segments[1],
+		"table":    segments[2],
+	}
 }
 
 func permissionByMethod(method string) (permission string) {

--- a/middlewares/utils_test.go
+++ b/middlewares/utils_test.go
@@ -20,11 +20,24 @@ func Test_getVars(t *testing.T) {
 	require.Equal(t, "public", got["schema"])
 	require.Equal(t, "users", got["table"])
 
-	got = getVars("prest/public/users/extra")
-	require.Equal(t, "public", got["database"])
-	require.Equal(t, "users", got["schema"])
-	require.Equal(t, "extra", got["table"])
+	// A real http.Request.URL.Path always carries the leading slash.
+	got = getVars("/prest/public/users")
+	require.Equal(t, "prest", got["database"])
+	require.Equal(t, "public", got["schema"])
+	require.Equal(t, "users", got["table"])
 
+	// /batch/{database}/{schema}/{table}: the shape that used to fall through
+	// to nil (any 4-element split was treated as "drop the first element",
+	// which only makes sense when that first element is the leading "").
+	got = getVars("/batch/prest/public/users")
+	require.Equal(t, "prest", got["database"])
+	require.Equal(t, "public", got["schema"])
+	require.Equal(t, "users", got["table"])
+
+	// A genuinely malformed 4-segment path with neither a leading slash nor a
+	// "batch" prefix has no valid interpretation and must be rejected, not
+	// have an arbitrary segment dropped.
+	require.Nil(t, getVars("prest/public/users/extra"))
 	require.Nil(t, getVars("/prest/public/users/extra"))
 }
 

--- a/testdata/prest_cache.toml
+++ b/testdata/prest_cache.toml
@@ -1,0 +1,38 @@
+[auth]
+table = "prest_users"
+username = "username"
+password = "password"
+
+[jwt]
+key = "integration-test-secret"
+algo = "HS256"
+whitelist = ["^\\/auth$"]
+
+[http]
+port = 3004
+
+[cache]
+enabled = true
+
+    [[cache.endpoints]]
+    endpoint = "/prest-test/public/test6"
+    time = 5
+
+[access]
+restrict = true
+
+# Generic (anonymous / any other user) access: id and name only.
+[[access.tables]]
+name = "test6"
+permissions = ["read", "write", "delete"]
+fields = ["id", "name"]
+
+# test@postgres.rest gets an extra column (celphone) on the same table, so a
+# response cached under their identity must never be served back to an
+# anonymous request on the identical URL.
+[[access.users]]
+name = "test@postgres.rest"
+[[access.users.tables]]
+name = "test6"
+permissions = ["read"]
+fields = ["id", "name", "celphone"]

--- a/testdata/schema.sql
+++ b/testdata/schema.sql
@@ -43,6 +43,15 @@ INSERT INTO test_group_by_table(name, age, salary) VALUES('gopher', 20, 100);
 INSERT INTO test_group_by_table(name, age, salary) VALUES('guitarra humana', 19, 3998);
 INSERT INTO prest_users(username, password) VALUES('test@postgres.rest', 'e10adc3949ba59abbe56e057f20f883e');
 
+-- Seed row and second user for the cache per-identity scoping integration
+-- test (see testdata/prest_cache.toml and cache_scope_test.go). test6 is
+-- otherwise unused. cache-scope-user-b has no [[access.users]] override in
+-- prest_cache.toml, so it falls back to the generic (more restricted) field
+-- permissions on test6 -- unlike test@postgres.rest, which is granted an
+-- extra column there.
+INSERT INTO test6(name, celphone) VALUES('cache-scope-test', '5551234');
+INSERT INTO prest_users(username, password) VALUES('cache-scope-user-b@postgres.rest', 'e10adc3949ba59abbe56e057f20f883e');
+
 -- Views
 CREATE TABLE table_to_view(id serial, name text, celphone text);
 INSERT INTO table_to_view (name, celphone) VALUES ('gopher', '8888888');


### PR DESCRIPTION
Fixes six SQL-injection-adjacent security gaps found via advisory review, all sibling issues to the earlier `_select`/CVE-2025-58450 fixes that weren't fully covered:

- **`_groupby` SQL injection** — the raw-SQL-expression branch in `GroupByClause` accepted nested subqueries/`pg_*` calls smuggled past a balanced-paren function call (e.g. `upper((SELECT 1)) UNION SELECT ...`). Now requires the whole expression to be exactly `func(args)` with no parens in `args`.
- **Unauthenticated SQLi via HTTP headers in script templates** — `_QUERIES` scripts interpolate request headers into SQL with no sanitization (the shipped `get_header.read.sql` example demonstrates it). Headers now go through the same allowlist as query params.
- **`_QUERIES` route gaps** — the handler never validated the database name or path segments before touching the connection layer, letting an unauthenticated request force a real outbound Postgres connection to an arbitrary db name.
- **ACL bypass on `/batch/...`** — a path-parsing off-by-one made `AccessControl` treat batch-insert requests as "not a table route" and skip permission checks entirely.
- **`describe_table` MCP tool** leaked full table schema regardless of the caller's table/field permissions (unlike `select_table`, which already enforced them).
- **Cross-user cache leak** — the GET response cache was keyed only by URL, so one user's cached response (built under their own column permissions) could be served to a different user with different permissions.
- Plus three credential-hygiene fixes: a plaintext DB password baked into `migrate --help`'s default flag value, a raw credential URL logged on config parse failure, and a regex that left part of an `@`-containing password unredacted in logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened SQL-expression validation to block injection attempts.
  * Added validation for script databases, paths, and header values.
  * Improved credential redaction in migration defaults and error logs.

* **Bug Fixes**
  * Prevented cached responses from being shared across users with different permissions.
  * Enforced field-level permissions when describing tables.
  * Corrected access checks for batch insert routes.

* **Tests**
  * Added end-to-end coverage for authentication, authorization, caching, and injection protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->