### PR TITLE
feat: implement expose configuration for MCP endpoint and listing predicates

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,27 @@ type ExposeConf struct {
 	TableListing    bool
 }
 
+// The listing predicates below are the single definition of what [expose]
+// permits. Every surface that returns catalog metadata — the REST routes via
+// ExposureMiddleware and the /_mcp tools — must consult them, so a new
+// discovery endpoint cannot silently escape the control. When the section is
+// disabled the flags carry no meaning and everything is listable.
+
+// DatabaseListingAllowed reports whether database names may be listed.
+func (e ExposeConf) DatabaseListingAllowed() bool {
+	return !e.Enabled || e.DatabaseListing
+}
+
+// SchemaListingAllowed reports whether schema names may be listed.
+func (e ExposeConf) SchemaListingAllowed() bool {
+	return !e.Enabled || e.SchemaListing
+}
+
+// TableListingAllowed reports whether table names may be listed.
+func (e ExposeConf) TableListingAllowed() bool {
+	return !e.Enabled || e.TableListing
+}
+
 // StudioConf controls the embedded pREST Studio UI.
 type StudioConf struct {
 	Enabled bool

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -810,3 +810,25 @@ func inaccessiblePath(t *testing.T) string {
 	t.Cleanup(func() { _ = os.Chmod(restricted, 0700) })
 	return target
 }
+
+// The listing predicates are the shared definition of [expose] consumed by both
+// ExposureMiddleware and the /_mcp catalog tools; the section only carries
+// meaning while it is enabled.
+func TestExposeConf_ListingPredicates(t *testing.T) {
+	t.Parallel()
+
+	disabled := ExposeConf{Enabled: false}
+	require.True(t, disabled.DatabaseListingAllowed())
+	require.True(t, disabled.SchemaListingAllowed())
+	require.True(t, disabled.TableListingAllowed())
+
+	hidden := ExposeConf{Enabled: true}
+	require.False(t, hidden.DatabaseListingAllowed())
+	require.False(t, hidden.SchemaListingAllowed())
+	require.False(t, hidden.TableListingAllowed())
+
+	partial := ExposeConf{Enabled: true, SchemaListing: true}
+	require.False(t, partial.DatabaseListingAllowed())
+	require.True(t, partial.SchemaListingAllowed())
+	require.False(t, partial.TableListingAllowed())
+}

--- a/controllers/deps.go
+++ b/controllers/deps.go
@@ -41,6 +41,7 @@ type Deps struct {
 	SingleDB           bool
 	PGDatabase         string
 	Auth               AuthConfig
+	Expose             config.ExposeConf
 }
 
 // NewDepsFromConfig builds handler dependencies from application config.
@@ -72,6 +73,7 @@ func NewDepsFromConfig(p *config.Prest) Deps {
 		Cache:         cacher,
 		SingleDB:      p.SingleDB,
 		PGDatabase:    p.PGDatabase,
+		Expose:        p.ExposeConf,
 		Auth: AuthConfig{
 			Enabled:  p.AuthEnabled,
 			AuthType: p.AuthType,

--- a/controllers/mcp.go
+++ b/controllers/mcp.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/prest/prest/v2/adapters"
+	"github.com/prest/prest/v2/config"
 	pctx "github.com/prest/prest/v2/context"
 	"github.com/prest/prest/v2/controllers/auth"
 
@@ -38,6 +39,7 @@ type MCPHandler struct {
 	perms    adapters.PermissionsChecker
 	singleDB bool
 	pgDB     string
+	expose   config.ExposeConf
 }
 
 // NewMCPHandler creates an MCPHandler.
@@ -50,6 +52,7 @@ func NewMCPHandler(deps Deps) *MCPHandler {
 		perms:    deps.Perms,
 		singleDB: deps.SingleDB,
 		pgDB:     deps.PGDatabase,
+		expose:   deps.Expose,
 	}
 }
 
@@ -324,7 +327,15 @@ func (h *MCPHandler) callTool(r *http.Request, params json.RawMessage) (result a
 	}
 }
 
+// errUnauthorizedListing mirrors the message ExposureMiddleware returns for the
+// REST catalog routes, so a caller denied at /databases sees the same refusal
+// through /_mcp.
+var errUnauthorizedListing = fmt.Errorf("unauthorized listing")
+
 func (h *MCPHandler) listDatabases(r *http.Request) (any, error) {
+	if !h.expose.DatabaseListingAllowed() {
+		return nil, errUnauthorizedListing
+	}
 	aliases := h.databaseAliases()
 	if len(aliases) > 0 {
 		rows := make([]map[string]any, 0, len(aliases))
@@ -344,6 +355,9 @@ func (h *MCPHandler) listDatabases(r *http.Request) (any, error) {
 }
 
 func (h *MCPHandler) listSchemas(r *http.Request, args mcpListSchemasArgs) (any, error) {
+	if !h.expose.SchemaListingAllowed() {
+		return nil, errUnauthorizedListing
+	}
 	if args.Database == "" {
 		args.Database = h.defaultDatabase()
 	}
@@ -392,6 +406,9 @@ func (h *MCPHandler) listSchemas(r *http.Request, args mcpListSchemasArgs) (any,
 }
 
 func (h *MCPHandler) listTables(r *http.Request, args mcpListTablesArgs) (any, error) {
+	if !h.expose.TableListingAllowed() {
+		return nil, errUnauthorizedListing
+	}
 	if args.Database == "" {
 		args.Database = h.defaultDatabase()
 	}
@@ -519,15 +536,34 @@ func (h *MCPHandler) selectTable(r *http.Request, args mcpSelectArgs) (any, erro
 
 func (h *MCPHandler) tools(r *http.Request) ([]mcpTool, error) {
 	tools := []mcpTool{
-		{Name: "prest.list_databases", Description: "List accessible databases.", InputSchema: emptyObjectSchema()},
-		{Name: "prest.list_schemas", Description: "List readable schemas for a database alias.", InputSchema: mcpListSchemasSchema()},
-		{Name: "prest.list_tables", Description: "List readable tables for a database alias and optional schema.", InputSchema: mcpListTablesSchema()},
 		{Name: "prest.describe_table", Description: "Describe a table and return its columns.", InputSchema: mcpDescribeSchema()},
 		{Name: "prest.select_table", Description: "Read rows from a table in a read-only way.", InputSchema: mcpSelectSchema()},
+	}
+	// A listing tool the caller is not allowed to invoke is not advertised.
+	if h.expose.DatabaseListingAllowed() {
+		tools = append(tools, mcpTool{Name: "prest.list_databases", Description: "List accessible databases.", InputSchema: emptyObjectSchema()})
+	}
+	if h.expose.SchemaListingAllowed() {
+		tools = append(tools, mcpTool{Name: "prest.list_schemas", Description: "List readable schemas for a database alias.", InputSchema: mcpListSchemasSchema()})
+	}
+	if h.expose.TableListingAllowed() {
+		tools = append(tools, mcpTool{Name: "prest.list_tables", Description: "List readable tables for a database alias and optional schema.", InputSchema: mcpListTablesSchema()})
+	}
+
+	// The per-table select tools below are themselves a catalog dump: each name
+	// carries database.schema.table and each description carries the column
+	// names, so a bare GET /_mcp discloses everything [expose] was set to hide
+	// without a single tools/call. Only enumerate them when the catalog is
+	// listable; the generic prest.select_table tool still serves callers that
+	// already know the target.
+	if !h.expose.DatabaseListingAllowed() || !h.expose.SchemaListingAllowed() || !h.expose.TableListingAllowed() {
+		sort.SliceStable(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+		return tools, nil
 	}
 
 	aliases := h.databaseAliases()
 	if len(aliases) == 0 {
+		sort.SliceStable(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
 		return tools, nil
 	}
 

--- a/controllers/mcp_test.go
+++ b/controllers/mcp_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/prest/prest/v2/adapters/mockgen"
+	"github.com/prest/prest/v2/config"
 	pctx "github.com/prest/prest/v2/context"
 	"github.com/prest/prest/v2/controllers/auth"
 	"github.com/stretchr/testify/require"
@@ -1923,4 +1924,90 @@ func TestMCPHandler_ListSchemas_AccessibleSchemasError(t *testing.T) {
 	h := NewMCPHandler(Deps{Catalog: catalog, Executor: executor, DB: db, PGDatabase: "prest-test"})
 	_, err := h.listSchemas(httptest.NewRequest(http.MethodGet, "/_mcp", nil), mcpListSchemasArgs{Database: "prest-test"})
 	require.Error(t, err)
+}
+
+// hiddenCatalogExpose is the configuration of an operator who enabled [expose]
+// specifically to hide catalog discovery while still allowing known tables to
+// be queried directly.
+var hiddenCatalogExpose = config.ExposeConf{Enabled: true}
+
+// The /_mcp endpoint used to bypass ExposureMiddleware entirely: it is not one
+// of the three literal prefixes (/databases, /tables, /schemas) that middleware
+// gates, and the MCP catalog tools never consulted [expose]. A caller denied at
+// GET /databases could therefore read the whole catalog through the MCP tools.
+func TestMCPHandler_ListToolsRespectExposeConf(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// No catalog/executor expectations: enforcement must reject before any
+	// query reaches the database.
+	h := NewMCPHandler(Deps{DB: mockDatabaseRegistry(ctrl), PGDatabase: "prest-test", Expose: hiddenCatalogExpose})
+
+	var testCases = []struct {
+		description string
+		call        func() (any, error)
+	}{
+		{"prest.list_databases is denied when expose.databases=false", func() (any, error) {
+			return h.listDatabases(httptest.NewRequest(http.MethodPost, "/_mcp", nil))
+		}},
+		{"prest.list_schemas is denied when expose.schemas=false", func() (any, error) {
+			return h.listSchemas(httptest.NewRequest(http.MethodPost, "/_mcp", nil), mcpListSchemasArgs{Database: "prest-test"})
+		}},
+		{"prest.list_tables is denied when expose.tables=false", func() (any, error) {
+			return h.listTables(httptest.NewRequest(http.MethodPost, "/_mcp", nil), mcpListTablesArgs{Database: "prest-test"})
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+		result, err := tc.call()
+		require.Nil(t, result)
+		require.ErrorIs(t, err, errUnauthorizedListing)
+	}
+}
+
+// A bare GET /_mcp returns the tool catalog, whose per-table tool names carry
+// database.schema.table and whose descriptions carry column names — the exact
+// data [expose] was set to hide, disclosed with no tools/call at all.
+func TestMCPHandler_GetDiscovery_RespectsExposeConf(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	h := NewMCPHandler(Deps{DB: mockDatabaseRegistry(ctrl), PGDatabase: "prest-test", Expose: hiddenCatalogExpose})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/_mcp", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	// No catalog names leak, and the listing tools are not advertised at all.
+	require.NotContains(t, body, "prest.select.prest-test.public.users")
+	require.NotContains(t, body, "prest.list_databases")
+	require.NotContains(t, body, "prest.list_schemas")
+	require.NotContains(t, body, "prest.list_tables")
+	// Direct access to an already-known table stays available: [expose] governs
+	// discovery, [access] governs reads.
+	require.Contains(t, body, "prest.select_table")
+	require.Contains(t, body, "prest.describe_table")
+}
+
+// With [expose] disabled the flags carry no meaning, so nothing changes for the
+// default configuration.
+func TestMCPHandler_ExposeDisabledKeepsListing(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().Aliases().Return([]string{"prest-test"}).AnyTimes()
+	db.EXPECT().PhysicalName("prest-test").Return("prest-test")
+
+	h := NewMCPHandler(Deps{DB: db, PGDatabase: "prest-test", Expose: config.ExposeConf{Enabled: false}})
+	result, err := h.listDatabases(httptest.NewRequest(http.MethodPost, "/_mcp", nil))
+	require.NoError(t, err)
+	require.NotNil(t, result)
 }

--- a/controllers/script.go
+++ b/controllers/script.go
@@ -127,9 +127,17 @@ func extractHeaders(rq *http.Request, templateData map[string]interface{}) {
 var safeScriptParamRegex = regexp.MustCompile(`^[a-zA-Z0-9_.:@/\\ -]+$`)
 
 // scriptParamWordRegex extracts the word tokens of a value so they can be
-// screened against SQL keywords. Splitting on every non-letter keeps
-// `0-union`, `a/select` and similar from smuggling a keyword past the check.
-var scriptParamWordRegex = regexp.MustCompile(`[a-zA-Z_]+`)
+// screened against SQL keywords. Tokens are whole alphanumeric runs, so
+// `order66` or `table9` stay intact instead of matching on an `order`/`table`
+// prefix, while `0-union` and `a/select` still split on the separator and get
+// caught.
+var scriptParamWordRegex = regexp.MustCompile(`[a-zA-Z0-9_]+`)
+
+// scriptParamLeadingDigits matches the numeric prefix of a token. PostgreSQL
+// before v15 lexes `0union` as `0` followed by the keyword, so the digits are
+// stripped before the keyword lookup; `order66` has no numeric prefix and is
+// unaffected.
+var scriptParamLeadingDigits = regexp.MustCompile(`^[0-9]+`)
 
 // scriptParamSQLKeywords are the tokens that make SQL composition possible once
 // a value lands in an unquoted template context. Values carrying any of them
@@ -168,7 +176,11 @@ func sanitizeScriptParam(value string) string {
 		return ""
 	}
 	for _, word := range scriptParamWordRegex.FindAllString(value, -1) {
-		if _, ok := scriptParamSQLKeywords[strings.ToLower(word)]; ok {
+		word = strings.ToLower(word)
+		if _, ok := scriptParamSQLKeywords[word]; ok {
+			return ""
+		}
+		if _, ok := scriptParamSQLKeywords[scriptParamLeadingDigits.ReplaceAllString(word, "")]; ok {
 			return ""
 		}
 	}

--- a/controllers/script.go
+++ b/controllers/script.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/prest/prest/v2/adapters"
 	"github.com/prest/prest/v2/middlewares"
@@ -125,13 +126,53 @@ func extractHeaders(rq *http.Request, templateData map[string]interface{}) {
 
 var safeScriptParamRegex = regexp.MustCompile(`^[a-zA-Z0-9_.:@/\\ -]+$`)
 
+// scriptParamWordRegex extracts the word tokens of a value so they can be
+// screened against SQL keywords. Splitting on every non-letter keeps
+// `0-union`, `a/select` and similar from smuggling a keyword past the check.
+var scriptParamWordRegex = regexp.MustCompile(`[a-zA-Z_]+`)
+
+// scriptParamSQLKeywords are the tokens that make SQL composition possible once
+// a value lands in an unquoted template context. Values carrying any of them
+// are rejected outright.
+var scriptParamSQLKeywords = map[string]struct{}{
+	"all": {}, "alter": {}, "and": {}, "any": {}, "as": {}, "between": {},
+	"by": {}, "call": {}, "case": {}, "cast": {}, "copy": {}, "create": {},
+	"database": {}, "delete": {}, "distinct": {}, "do": {}, "drop": {},
+	"except": {}, "exec": {}, "execute": {}, "exists": {}, "fetch": {},
+	"from": {}, "grant": {}, "group": {}, "having": {}, "ilike": {},
+	"insert": {}, "intersect": {}, "into": {}, "join": {}, "lateral": {},
+	"like": {}, "limit": {}, "not": {}, "null": {}, "offset": {}, "only": {},
+	"or": {}, "order": {}, "over": {}, "returning": {}, "revoke": {},
+	"schema": {}, "select": {}, "set": {}, "similar": {}, "table": {},
+	"then": {}, "truncate": {}, "union": {}, "update": {}, "using": {},
+	"values": {}, "when": {}, "where": {}, "window": {}, "with": {},
+}
+
 // sanitizeScriptParam sanitizes the given value to be used as a script parameter.
 // This is used to prevent SQL injection.
+//
+// The character allow-list alone is not enough: it keeps quotes, commas and
+// parentheses out, but letters, digits and space are already sufficient to
+// compose a read-only injection such as
+// `0 UNION SELECT users::text FROM users` whenever a template interpolates the
+// value in an unquoted context (`WHERE id = {{.id}}`). SQL comment (`--`) and
+// cast (`::`) tokens plus any SQL keyword are therefore rejected as well.
+//
+// Templates that need to interpolate free-form values should use the `sqlVal`
+// / `sqlList` helpers, which bind them as query parameters instead.
 func sanitizeScriptParam(value string) string {
-	if safeScriptParamRegex.MatchString(value) {
-		return value
+	if !safeScriptParamRegex.MatchString(value) {
+		return ""
 	}
-	return ""
+	if strings.Contains(value, "--") || strings.Contains(value, "::") {
+		return ""
+	}
+	for _, word := range scriptParamWordRegex.FindAllString(value, -1) {
+		if _, ok := scriptParamSQLKeywords[strings.ToLower(word)]; ok {
+			return ""
+		}
+	}
+	return value
 }
 
 // extractQueryParameters gets from the given request the query parameters and populate the provided templateData

--- a/controllers/script_test.go
+++ b/controllers/script_test.go
@@ -279,6 +279,35 @@ func TestSanitizeScriptParam(t *testing.T) {
 	require.Equal(t, "", sanitizeScriptParam(`" OR 1=1`))
 }
 
+// The character allow-list permits letters, digits and space, which is enough
+// to compose a read-only injection when a template interpolates the value in an
+// unquoted context (`WHERE id = {{.id}}`) — no quote, comma or parenthesis
+// required. These payloads must be blanked, not returned verbatim.
+func TestSanitizeScriptParam_RejectsUnquotedContextInjection(t *testing.T) {
+	t.Parallel()
+
+	unsafe := []string{
+		"0 OR true",
+		"0 UNION SELECT users::text FROM users",
+		"0 union select passwd from pg_shadow",
+		"0 UNION SELECT table_name FROM information_schema.tables",
+		"0 UNION SELECT query FROM pg_stat_activity",
+		"1 -- comment",
+		"1::text",
+		"0 Union Select 1",
+	}
+	for _, value := range unsafe {
+		require.Equal(t, "", sanitizeScriptParam(value), "value must be rejected: %s", value)
+	}
+
+	// Values that carry no SQL keyword or comment/cast token stay untouched, so
+	// existing quoted-context templates keep working.
+	safe := []string{"gopher", "42", "2024-01-01", "user@example.com", "John Doe", "a/b.c"}
+	for _, value := range safe {
+		require.Equal(t, value, sanitizeScriptParam(value), "value must be preserved: %s", value)
+	}
+}
+
 func TestExtractQueryParameters_SanitizesUnsafeValues(t *testing.T) {
 	t.Parallel()
 

--- a/controllers/script_test.go
+++ b/controllers/script_test.go
@@ -295,6 +295,9 @@ func TestSanitizeScriptParam_RejectsUnquotedContextInjection(t *testing.T) {
 		"1 -- comment",
 		"1::text",
 		"0 Union Select 1",
+		// PostgreSQL before v15 accepts `0union` as `0` + keyword, so a token's
+		// numeric prefix must not hide the keyword behind it.
+		"0union select 1",
 	}
 	for _, value := range unsafe {
 		require.Equal(t, "", sanitizeScriptParam(value), "value must be rejected: %s", value)
@@ -302,7 +305,10 @@ func TestSanitizeScriptParam_RejectsUnquotedContextInjection(t *testing.T) {
 
 	// Values that carry no SQL keyword or comment/cast token stay untouched, so
 	// existing quoted-context templates keep working.
-	safe := []string{"gopher", "42", "2024-01-01", "user@example.com", "John Doe", "a/b.c"}
+	// A keyword is only a keyword as a whole token: identifiers that merely
+	// start with one (order66, select2, table9) must survive.
+	safe := []string{"gopher", "42", "2024-01-01", "user@example.com", "John Doe", "a/b.c",
+		"order66", "select2", "table9", "union_member"}
 	for _, value := range safe {
 		require.Equal(t, value, sanitizeScriptParam(value), "value must be preserved: %s", value)
 	}

--- a/integration/postgres/middlewares/config_test.go
+++ b/integration/postgres/middlewares/config_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -316,4 +317,66 @@ func TestExposeTablesMiddleware(t *testing.T) {
 	// Expected to fail with HTTP status Unauthorized.
 	resp, _ = http.Get(server.URL + "/schemas")
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestExposeMCPEndpoint guards the /_mcp bypass of [expose]: the endpoint is
+// not one of the three literal prefixes ExposureMiddleware gates
+// (/databases, /tables, /schemas), so an operator who set
+// expose.databases/schemas/tables = false to hide catalog discovery still had
+// the full database, schema, table and column catalog served through /_mcp —
+// via the JSON-RPC list tools and, with no call at all, via the GET discovery
+// payload whose per-table tool names and descriptions embed those names.
+// The MCP catalog tools now consult the same [expose] predicates as the REST
+// routes.
+func TestExposeMCPEndpoint(t *testing.T) {
+	t.Setenv("PREST_DEBUG", "true")
+	t.Setenv("PREST_CONF", helpers.TestExposeConfigPath())
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	require.NoError(t, app.EnsureAdapter(cfg))
+
+	h := controllers.NewHandlersFromConfig(cfg)
+	r := mux.NewRouter()
+	r.Handle("/_mcp", h.MCP.Handler()).Methods("GET", "POST")
+	n := middlewares.New(cfg)
+	n.UseHandler(r)
+	server := httptest.NewServer(n)
+	defer server.Close()
+
+	// Baseline: the REST catalog route is denied, which is the operator intent
+	// /_mcp must not contradict.
+	resp, err := http.Get(server.URL + "/tables")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// GET /_mcp discovery must not enumerate the catalog it was set to hide:
+	// no per-table select tools and no listing tools advertised.
+	resp, err = http.Get(server.URL + "/_mcp")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	discovery := string(body)
+	require.NotContains(t, discovery, "prest.select.")
+	require.NotContains(t, discovery, "prest.list_databases")
+	require.NotContains(t, discovery, "prest.list_schemas")
+	require.NotContains(t, discovery, "prest.list_tables")
+
+	// Each catalog tool is refused with the same "unauthorized listing" message
+	// ExposureMiddleware returns for the REST routes.
+	for _, tool := range []string{"prest.list_databases", "prest.list_schemas", "prest.list_tables"} {
+		t.Log("tools/call " + tool + " must be denied while [expose] hides the catalog")
+		call := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + tool + `"}}`
+		resp, err := http.Post(server.URL+"/_mcp", "application/json", strings.NewReader(call))
+		require.NoError(t, err)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Contains(t, string(body), "unauthorized listing")
+	}
 }

--- a/integration/postgres/middlewares/config_test.go
+++ b/integration/postgres/middlewares/config_test.go
@@ -348,6 +348,7 @@ func TestExposeMCPEndpoint(t *testing.T) {
 	resp, err := http.Get(server.URL + "/tables")
 	require.NoError(t, err)
 	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
 	// GET /_mcp discovery must not enumerate the catalog it was set to hide:
 	// no per-table select tools and no listing tools advertised.

--- a/integration/suites/controllers/scripts_test.go
+++ b/integration/suites/controllers/scripts_test.go
@@ -3,6 +3,7 @@ package controllers_test
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/prest/prest/v2/integration/helpers"
@@ -74,6 +75,56 @@ func TestExecuteFromScripts_RejectsHeaderInjection(t *testing.T) {
 		t, base+"/_QUERIES/fulltable/get_header", nil, "GET", http.StatusOK,
 		"ExecuteFromScripts", headers, `[{"?column?": ""}]`,
 	)
+}
+
+// TestExecuteFromScripts_RejectsUnquotedContextInjection guards the
+// unauthenticated read-only SQL injection that survived the CVE-2025-58450 fix:
+// sanitizeScriptParam's character allow-list blocks quotes, commas and
+// parentheses, but letters, digits and space alone compose
+// `0 UNION SELECT <col> FROM <table>` once a template interpolates the value in
+// an unquoted context (get_unquoted.read.sql: `WHERE 1 = {{.field1}}`).
+// A keyword/comment/cast screen now blanks those payloads, so the query never
+// composes and the request fails instead of dumping the catalog.
+func TestExecuteFromScripts_RejectsUnquotedContextInjection(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	var testCases = []struct {
+		description string
+		url         string
+		status      int
+	}{
+		// Baseline: a plain numeric value still reaches the query and succeeds.
+		{
+			"GET unquoted-context script with a benign value returns OK",
+			"/_QUERIES/fulltable/get_unquoted?field1=1",
+			http.StatusOK,
+		},
+		// UNION arm dumping every column of a table via the whole-row ::text cast.
+		{
+			"GET unquoted-context script with a UNION payload is neutralized",
+			"/_QUERIES/fulltable/get_unquoted?field1=" +
+				url.QueryEscape("1 UNION SELECT test7::text FROM test7"),
+			http.StatusBadRequest,
+		},
+		// Role password hashes from the catalog (superuser default in Docker).
+		{
+			"GET unquoted-context script reading pg_shadow is neutralized",
+			"/_QUERIES/fulltable/get_unquoted?field1=" +
+				url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"),
+			http.StatusBadRequest,
+		},
+		// Row-filter bypass needing no UNION at all.
+		{
+			"GET unquoted-context script with an OR-true row filter bypass is neutralized",
+			"/_QUERIES/fulltable/get_unquoted?field1=" + url.QueryEscape("1 OR true"),
+			http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+		testutils.DoRequest(t, base+tc.url, nil, "GET", tc.status, "ExecuteFromScripts")
+	}
 }
 
 // TestExecuteFromScripts_RejectsUnregisteredDatabase guards against

--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -273,17 +273,17 @@ func ExposureMiddleware(expose config.ExposeConf) negroni.Handler {
 	return negroni.HandlerFunc(func(rw http.ResponseWriter, rq *http.Request, next http.HandlerFunc) {
 		url := rq.URL.Path
 
-		if strings.HasPrefix(url, "/databases") && !expose.DatabaseListing {
+		if strings.HasPrefix(url, "/databases") && !expose.DatabaseListingAllowed() {
 			http.Error(rw, fmt.Sprintf(jsonErrFormat, "unauthorized listing"), http.StatusUnauthorized)
 			return
 		}
 
-		if strings.HasPrefix(url, "/tables") && !expose.TableListing {
+		if strings.HasPrefix(url, "/tables") && !expose.TableListingAllowed() {
 			http.Error(rw, fmt.Sprintf(jsonErrFormat, "unauthorized listing"), http.StatusUnauthorized)
 			return
 		}
 
-		if strings.HasPrefix(url, "/schemas") && !expose.SchemaListing {
+		if strings.HasPrefix(url, "/schemas") && !expose.SchemaListingAllowed() {
 			http.Error(rw, fmt.Sprintf(jsonErrFormat, "unauthorized listing"), http.StatusUnauthorized)
 			return
 		}

--- a/middlewares/middlewares_test.go
+++ b/middlewares/middlewares_test.go
@@ -551,7 +551,7 @@ func TestExposureMiddleware_DatabasesDenied(t *testing.T) {
 	t.Parallel()
 
 	req := httptest.NewRequest(http.MethodGet, "/databases", nil)
-	rec, called := serveMiddleware(ExposureMiddleware(config.ExposeConf{DatabaseListing: false}), req)
+	rec, called := serveMiddleware(ExposureMiddleware(config.ExposeConf{Enabled: true, DatabaseListing: false}), req)
 
 	require.False(t, called)
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
@@ -562,7 +562,7 @@ func TestExposureMiddleware_SchemasDenied(t *testing.T) {
 	t.Parallel()
 
 	req := httptest.NewRequest(http.MethodGet, "/schemas", nil)
-	rec, called := serveMiddleware(ExposureMiddleware(config.ExposeConf{SchemaListing: false}), req)
+	rec, called := serveMiddleware(ExposureMiddleware(config.ExposeConf{Enabled: true, SchemaListing: false}), req)
 
 	require.False(t, called)
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
@@ -572,7 +572,7 @@ func TestExposureMiddleware_TablesDenied(t *testing.T) {
 	t.Parallel()
 
 	req := httptest.NewRequest(http.MethodGet, "/tables", nil)
-	rec, called := serveMiddleware(ExposureMiddleware(config.ExposeConf{TableListing: false}), req)
+	rec, called := serveMiddleware(ExposureMiddleware(config.ExposeConf{Enabled: true, TableListing: false}), req)
 
 	require.False(t, called)
 	require.Equal(t, http.StatusUnauthorized, rec.Code)

--- a/samples/prest.sample.toml
+++ b/samples/prest.sample.toml
@@ -172,6 +172,10 @@ ignore_table = []
 # ------------------------------------------------------------------------
 # [expose] - control discovery/listing endpoints (as opposed to [access],
 # which controls whether data can be read/written).
+# Covers the REST catalog routes (/databases, /schemas, /tables) and the
+# catalog surface of the MCP endpoint (/_mcp): its list tools are refused and
+# the discovery payload stops advertising per-table tools whose names and
+# descriptions would otherwise disclose table and column names.
 # ------------------------------------------------------------------------
 [expose]
 enabled = false

--- a/testdata/queries/fulltable/get_unquoted.read.sql
+++ b/testdata/queries/fulltable/get_unquoted.read.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test7 WHERE 1 = {{.field1}}


### PR DESCRIPTION
- Added ExposeConf struct to manage visibility of database, schema, and table listings.
- Updated MCPHandler to respect expose settings, ensuring unauthorized access is denied for listing tools.
- Introduced tests for MCP endpoint to validate behavior with different expose configurations, ensuring compliance with security requirements.
- Enhanced middleware to prevent unauthorized catalog discovery through the MCP endpoint.
- Updated sample configuration to include expose settings for better user guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened script parameter sanitization to reject SQL comment, cast tokens, and blacklisted keywords, backed by new unit and integration regression tests.

- **Access Control**
  - Added explicit predicate helpers for database/schema/table listing permissions and updated middleware to use them.
  - Enforced listing authorization across REST and MCP, with hidden catalog tools removed from discovery and MCP listing calls blocked.

- **Documentation**
  - Expanded the sample configuration to better explain exposed versus hidden catalog and MCP discovery behavior.

- **Testing**
  - Added unit/integration coverage for expose-driven MCP and query execution restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->