### PR TITLE
chore: update GitHub Actions workflows and enhance SQL logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,21 @@ on:
     tags:
       - 'v*'
 
+# Nothing is writable by default; the one job that needs write declares it below.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     environment: build
+    # GoReleaser reads GITHUB_TOKEN (the job token) to create the GitHub release
+    # on tag pushes, so contents must be writable here — `contents: read` alone
+    # would break releases. Registry pushes authenticate with
+    # GORELEASER_GITHUB_TOKEN / DOCKER_PASSWORD via docker/login-action rather
+    # than the job token, so no packages permission is needed.
+    permissions:
+      contents: write
     defaults:
       run:
         shell: bash

--- a/.github/workflows/duplicate-issue-detector.yml
+++ b/.github/workflows/duplicate-issue-detector.yml
@@ -2,6 +2,9 @@ name: Potential Duplicate Issues
 on:
   issues:
     types: [opened, edited]
+permissions:
+  issues: write
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint

--- a/README.md
+++ b/README.md
@@ -38,6 +38,37 @@ GET /{database}/{schema}/{table}
 
 See [Configuring pREST](https://docs.prestd.com/get-started/configuring-prest) for auth, ACL, custom queries, and MCP.
 
+## Passing values to query scripts
+
+Values a `_QUERIES` script template interpolates become part of the SQL text, so
+pREST screens them: anything carrying quotes, `--`, `::`, or — for multi-word
+values — a SQL keyword is refused, and a refused value that is interpolated fails
+the request with `400`.
+
+Bind free-form values instead, and the screen does not apply at all. A bound value
+travels to Postgres out of band, where it can never be parsed as SQL:
+
+```sql
+-- interpolated: screened, and rejected for values like 'compra do mes'
+SELECT * FROM articles WHERE slug = '{{.slug}}'
+
+-- bound: the caller's value arrives verbatim, whatever it contains
+SELECT * FROM articles WHERE slug = {{sqlVal "slug"}}
+```
+
+| Helper | Use for | Renders |
+|--------|---------|---------|
+| `{{sqlVal "key"}}` | a single value | `$1` |
+| `{{sqlList "key"}}` | a repeated query parameter (`?tag=a&tag=b`) | `($1,$2)` |
+| `{{ident "key"}}` | a table/column name, which cannot be bound | `"public"."users"` |
+
+`sqlVal` and `sqlList` also reach headers as `{{sqlVal "header.X-Application"}}`.
+Credential headers (`Authorization`, `Cookie`, …) are always withheld.
+
+Prefer binding for anything user-supplied — search phrases especially, since a
+phrase containing a common word such as `do`, `as` or `or` is exactly what the
+interpolation screen refuses.
+
 ## 1-Click Deploy
 
 ### Heroku

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -1054,7 +1054,12 @@ func (adapter *postgres) QueryCtx(ctx context.Context, SQL string, params ...int
 		return &scanner.PrestScanner{Error: err}
 	}
 	SQL = fmt.Sprintf("SELECT %s(s) FROM (%s) s", adapter.cfg.JSONAggType, SQL)
-	slog.Debug("generated SQL", "sql", SQL, "parameter_count", len(params)) // codeql[go/clear-text-logging]
+	// The statement itself is deliberately not logged here. Script templates render
+	// request headers and query parameters directly into the SQL text before it
+	// reaches this function, so the string is caller-controlled data rather than a
+	// fixed pREST-built statement. INSERT/UPDATE/DELETE, which scripts cannot reach
+	// through this path, still log their SQL at debug level.
+	slog.Debug("generated SQL", "parameter_count", len(params))
 	p, err := adapter.Prepare(db, SQL)
 	if err != nil {
 		slog.Error("log details", "err", err)
@@ -1079,11 +1084,9 @@ func (adapter *postgres) Query(SQL string, params ...interface{}) (sc adapters.S
 		return &scanner.PrestScanner{Error: err}
 	}
 	SQL = fmt.Sprintf("SELECT %s(s) FROM (%s) s", adapter.cfg.JSONAggType, SQL)
-	// Flagged sources here are not secrets: AuthConfig.Password is the password
-	// *column name*, and extractHeaders blanks credential headers before a script
-	// template can interpolate one. Bound parameter values are not logged.
-	// codeql[go/clear-text-logging]
-	slog.Debug("generated SQL", "sql", SQL, "parameter_count", len(params))
+	// Not logged, for the same reason as QueryCtx above: scripts render request
+	// data into this statement before it arrives.
+	slog.Debug("generated SQL", "parameter_count", len(params))
 	p, err := adapter.Prepare(db, SQL)
 	if err != nil {
 		return &scanner.PrestScanner{Error: err}

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -1054,7 +1054,7 @@ func (adapter *postgres) QueryCtx(ctx context.Context, SQL string, params ...int
 		return &scanner.PrestScanner{Error: err}
 	}
 	SQL = fmt.Sprintf("SELECT %s(s) FROM (%s) s", adapter.cfg.JSONAggType, SQL)
-	slog.Debug("generated SQL", "sql", SQL, "parameters", params)
+	slog.Debug("generated SQL", "sql", SQL, "parameter_count", len(params)) // codeql[go/clear-text-logging]
 	p, err := adapter.Prepare(db, SQL)
 	if err != nil {
 		slog.Error("log details", "err", err)
@@ -1079,7 +1079,11 @@ func (adapter *postgres) Query(SQL string, params ...interface{}) (sc adapters.S
 		return &scanner.PrestScanner{Error: err}
 	}
 	SQL = fmt.Sprintf("SELECT %s(s) FROM (%s) s", adapter.cfg.JSONAggType, SQL)
-	slog.Debug("generated SQL", "sql", SQL, "parameters", params)
+	// Flagged sources here are not secrets: AuthConfig.Password is the password
+	// *column name*, and extractHeaders blanks credential headers before a script
+	// template can interpolate one. Bound parameter values are not logged.
+	// codeql[go/clear-text-logging]
+	slog.Debug("generated SQL", "sql", SQL, "parameter_count", len(params))
 	p, err := adapter.Prepare(db, SQL)
 	if err != nil {
 		return &scanner.PrestScanner{Error: err}
@@ -1103,7 +1107,7 @@ func (adapter *postgres) QueryCount(SQL string, params ...interface{}) (sc adapt
 		return &scanner.PrestScanner{Error: err}
 	}
 
-	slog.Debug("generated SQL", "sql", SQL, "parameters", params)
+	slog.Debug("generated SQL", "sql", SQL, "parameter_count", len(params))
 	p, err := adapter.Prepare(db, SQL)
 	if err != nil {
 		return &scanner.PrestScanner{Error: err}
@@ -1132,7 +1136,7 @@ func (adapter *postgres) QueryCountCtx(ctx context.Context, SQL string, params .
 		slog.Error("log details", "err", logsafe.Error(err))
 		return &scanner.PrestScanner{Error: err}
 	}
-	slog.Debug("generated SQL", "sql", SQL, "parameters", params)
+	slog.Debug("generated SQL", "sql", SQL, "parameter_count", len(params))
 	p, err := adapter.Prepare(db, SQL)
 	if err != nil {
 		slog.Error("log details", "err", err)
@@ -1448,7 +1452,7 @@ func (adapter *postgres) insert(ctx context.Context, db *sqlx.DB, tx *sql.Tx, SQ
 		slog.Error("log details", "err", err)
 		return &scanner.PrestScanner{Error: err}
 	}
-	slog.Debug("log details", "sql", SQL, "parameters", params)
+	slog.Debug("log details", "sql", SQL, "parameter_count", len(params))
 	var jsonData []byte
 	if ctx != nil {
 		err = stmt.QueryRowContext(ctx, params...).Scan(&jsonData)
@@ -1487,7 +1491,7 @@ func (adapter *postgres) DeleteWithTransaction(tx *sql.Tx, SQL string, params ..
 }
 
 func (adapter *postgres) delete(ctx context.Context, db *sqlx.DB, tx *sql.Tx, SQL string, params ...interface{}) (sc adapters.Scanner) {
-	slog.Debug("generated SQL", "sql", SQL, "parameters", params)
+	slog.Debug("generated SQL", "sql", SQL, "parameter_count", len(params))
 	var stmt *sql.Stmt
 	var err error
 	if tx != nil {
@@ -1611,7 +1615,7 @@ func (adapter *postgres) update(ctx context.Context, db *sqlx.DB, tx *sql.Tx, SQ
 		slog.Error("could not prepare sql", "sql", SQL, "err", err)
 		return &scanner.PrestScanner{Error: err}
 	}
-	slog.Debug("generated SQL", "sql", SQL, "parameters", params)
+	slog.Debug("generated SQL", "sql", SQL, "parameter_count", len(params))
 	if strings.Contains(SQL, "RETURNING") {
 		var rows *sql.Rows
 		if ctx != nil {

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -1506,7 +1506,8 @@ func (adapter *postgres) delete(ctx context.Context, db *sqlx.DB, tx *sql.Tx, SQ
 		stmt, err = adapter.Prepare(db, SQL)
 	}
 	if err != nil {
-		slog.Error("could not prepare sql", "sql", SQL, "err", err)
+		slog.Error("could not prepare sql", "err", logsafe.Error(err))
+		logFailedSQL(SQL)
 		return &scanner.PrestScanner{Error: err}
 	}
 	if strings.Contains(SQL, "RETURNING") {
@@ -1612,7 +1613,8 @@ func (adapter *postgres) update(ctx context.Context, db *sqlx.DB, tx *sql.Tx, SQ
 		stmt, err = adapter.Prepare(db, SQL)
 	}
 	if err != nil {
-		slog.Error("could not prepare sql", "sql", SQL, "err", err)
+		slog.Error("could not prepare sql", "err", logsafe.Error(err))
+		logFailedSQL(SQL)
 		return &scanner.PrestScanner{Error: err}
 	}
 	slog.Debug("generated SQL", "sql", SQL, "parameter_count", len(params))
@@ -1661,12 +1663,14 @@ func (adapter *postgres) update(ctx context.Context, db *sqlx.DB, tx *sql.Tx, SQ
 		result, err = stmt.Exec(params...)
 	}
 	if err != nil {
-		slog.Error("could not execute sql", "sql", SQL, "err", err)
+		slog.Error("could not execute sql", "err", logsafe.Error(err))
+		logFailedSQL(SQL)
 		return &scanner.PrestScanner{Error: err}
 	}
 	rowsAffected, err = result.RowsAffected()
 	if err != nil {
-		slog.Error("could not get rows affected", "sql", SQL, "err", err)
+		slog.Error("could not get rows affected", "err", logsafe.Error(err))
+		logFailedSQL(SQL)
 		return &scanner.PrestScanner{Error: err}
 	}
 	data := make(map[string]interface{})

--- a/adapters/postgres/queries.go
+++ b/adapters/postgres/queries.go
@@ -13,11 +13,13 @@ import (
 	"log/slog"
 )
 
-// logFailedSQL emits the statement that failed at debug level only. Script
-// templates interpolate request headers and query parameters straight into the
-// SQL text, so a rendered statement carries caller-supplied data; keeping it off
-// the always-on error path means an operator opts in to seeing it.
-// codeql[go/clear-text-logging]
+// logFailedSQL emits the statement that failed at debug level only.
+//
+// Call it solely from paths a script template cannot reach — the CRUD
+// insert/update/delete builders. WriteSQL and WriteSQLCtx are excluded: scripts
+// render request headers and query parameters straight into the statements those
+// two execute, so the SQL text there is caller-controlled data, not a fixed
+// pREST-built statement.
 func logFailedSQL(sql string) {
 	slog.Debug("failed sql", "sql", sql)
 }
@@ -33,7 +35,6 @@ func (adapter *postgres) WriteSQL(sql string, values []interface{}) (sc adapters
 	stmt, err := adapter.Prepare(db, sql)
 	if err != nil {
 		slog.Error("could not prepare sql", "err", logsafe.Error(err))
-		logFailedSQL(sql)
 		sc = &scanner.PrestScanner{Error: fmt.Errorf("could not prepare sql: %w", err)}
 		return
 	}
@@ -46,7 +47,6 @@ func (adapter *postgres) WriteSQL(sql string, values []interface{}) (sc adapters
 	result, err := stmt.Exec(valuesAux...)
 	if err != nil {
 		slog.Error("could not execute sql", "err", logsafe.Error(err))
-		logFailedSQL(sql)
 		err = fmt.Errorf("could not peform sql: %w", err)
 		sc = &scanner.PrestScanner{Error: err}
 		return
@@ -81,7 +81,6 @@ func (adapter *postgres) WriteSQLCtx(ctx context.Context, sql string, values []i
 	stmt, err := adapter.PrepareContext(ctx, db, sql)
 	if err != nil {
 		slog.Error("could not prepare sql", "err", logsafe.Error(err))
-		logFailedSQL(sql)
 		sc = &scanner.PrestScanner{Error: fmt.Errorf("could not prepare sql: %w", err)}
 		return
 	}
@@ -94,7 +93,6 @@ func (adapter *postgres) WriteSQLCtx(ctx context.Context, sql string, values []i
 	result, err := stmt.ExecContext(ctx, valuesAux...)
 	if err != nil {
 		slog.Error("could not execute sql", "err", logsafe.Error(err))
-		logFailedSQL(sql)
 		err = fmt.Errorf("could not peform sql: %w", err)
 		sc = &scanner.PrestScanner{Error: err}
 		return

--- a/adapters/postgres/queries.go
+++ b/adapters/postgres/queries.go
@@ -32,7 +32,7 @@ func (adapter *postgres) WriteSQL(sql string, values []interface{}) (sc adapters
 	}
 	stmt, err := adapter.Prepare(db, sql)
 	if err != nil {
-		slog.Error("could not prepare sql", "err", err)
+		slog.Error("could not prepare sql", "err", logsafe.Error(err))
 		logFailedSQL(sql)
 		sc = &scanner.PrestScanner{Error: fmt.Errorf("could not prepare sql: %w", err)}
 		return
@@ -47,7 +47,7 @@ func (adapter *postgres) WriteSQL(sql string, values []interface{}) (sc adapters
 	if err != nil {
 		slog.Error("could not execute sql", "err", logsafe.Error(err))
 		logFailedSQL(sql)
-		err = fmt.Errorf("could not peform sql: %v", err)
+		err = fmt.Errorf("could not peform sql: %w", err)
 		sc = &scanner.PrestScanner{Error: err}
 		return
 	}
@@ -95,7 +95,7 @@ func (adapter *postgres) WriteSQLCtx(ctx context.Context, sql string, values []i
 	if err != nil {
 		slog.Error("could not execute sql", "err", logsafe.Error(err))
 		logFailedSQL(sql)
-		err = fmt.Errorf("could not peform sql: %v", err)
+		err = fmt.Errorf("could not peform sql: %w", err)
 		sc = &scanner.PrestScanner{Error: err}
 		return
 	}

--- a/adapters/postgres/queries.go
+++ b/adapters/postgres/queries.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/prest/prest/v2/adapters"
 	"github.com/prest/prest/v2/adapters/scanner"
@@ -13,6 +12,15 @@ import (
 
 	"log/slog"
 )
+
+// logFailedSQL emits the statement that failed at debug level only. Script
+// templates interpolate request headers and query parameters straight into the
+// SQL text, so a rendered statement carries caller-supplied data; keeping it off
+// the always-on error path means an operator opts in to seeing it.
+// codeql[go/clear-text-logging]
+func logFailedSQL(sql string) {
+	slog.Debug("failed sql", "sql", sql)
+}
 
 // WriteSQL perform INSERT's, UPDATE's, DELETE's operations
 func (adapter *postgres) WriteSQL(sql string, values []interface{}) (sc adapters.Scanner) {
@@ -24,7 +32,8 @@ func (adapter *postgres) WriteSQL(sql string, values []interface{}) (sc adapters
 	}
 	stmt, err := adapter.Prepare(db, sql)
 	if err != nil {
-		slog.Error("could not prepare sql", "sql", sql, "err", err)
+		slog.Error("could not prepare sql", "err", err)
+		logFailedSQL(sql)
 		sc = &scanner.PrestScanner{Error: fmt.Errorf("could not prepare sql: %w", err)}
 		return
 	}
@@ -36,7 +45,8 @@ func (adapter *postgres) WriteSQL(sql string, values []interface{}) (sc adapters
 
 	result, err := stmt.Exec(valuesAux...)
 	if err != nil {
-		log.Printf("sql = %v\n", sql)
+		slog.Error("could not execute sql", "err", logsafe.Error(err))
+		logFailedSQL(sql)
 		err = fmt.Errorf("could not peform sql: %v", err)
 		sc = &scanner.PrestScanner{Error: err}
 		return
@@ -70,7 +80,8 @@ func (adapter *postgres) WriteSQLCtx(ctx context.Context, sql string, values []i
 	}
 	stmt, err := adapter.PrepareContext(ctx, db, sql)
 	if err != nil {
-		slog.Error("could not prepare sql", "sql", sql, "err", logsafe.Error(err))
+		slog.Error("could not prepare sql", "err", logsafe.Error(err))
+		logFailedSQL(sql)
 		sc = &scanner.PrestScanner{Error: fmt.Errorf("could not prepare sql: %w", err)}
 		return
 	}
@@ -82,7 +93,8 @@ func (adapter *postgres) WriteSQLCtx(ctx context.Context, sql string, values []i
 
 	result, err := stmt.ExecContext(ctx, valuesAux...)
 	if err != nil {
-		log.Printf("sql = %v\n", sql)
+		slog.Error("could not execute sql", "err", logsafe.Error(err))
+		logFailedSQL(sql)
 		err = fmt.Errorf("could not peform sql: %v", err)
 		sc = &scanner.PrestScanner{Error: err}
 		return

--- a/adapters/postgres/queries_test.go
+++ b/adapters/postgres/queries_test.go
@@ -53,6 +53,51 @@ func TestGetScript_Success(t *testing.T) {
 	require.Equal(t, scriptPath, got)
 }
 
+// TestGetScript_RejectsTraversal keeps the path barrier inside the adapter
+// rather than relying on the controller's validatePathSegments gate: getScriptPath
+// joins caller-supplied folder and name onto the queries directory, so any caller
+// that skips that gate could otherwise read arbitrary files (CodeQL go/path-injection).
+func TestGetScript_RejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// A readable file one level above the queries directory: the target an
+	// escaping path would reach if the join were unchecked.
+	outside := filepath.Join(dir, "secret.read.sql")
+	require.NoError(t, os.WriteFile(outside, []byte("SELECT 'pwned'"), 0o644))
+
+	queries := filepath.Join(dir, "queries")
+	require.NoError(t, os.MkdirAll(queries, 0o755))
+
+	cfg := defaultTestConf()
+	cfg.QueriesPath = queries
+	adapter := testAdapter(cfg)
+
+	var testCases = []struct {
+		description string
+		folder      string
+		script      string
+	}{
+		{"parent traversal in the folder segment", "..", "secret"},
+		{"parent traversal in the script segment", ".", "../secret"},
+		{"nested traversal that normalizes above the base", "sub/../..", "secret"},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+		_, err := adapter.GetScript("GET", tc.folder, tc.script)
+		require.Error(t, err, tc.description)
+		require.Contains(t, err.Error(), "invalid script path", tc.description)
+	}
+
+	// An absolute folder segment is not an escape: filepath.Join drops the leading
+	// separator, re-rooting it under the queries directory. It fails as a missing
+	// file rather than as a rejected path, and must not reach the outside file.
+	_, err := adapter.GetScript("GET", dir, "secret")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "could not load script")
+}
+
 func TestParseScript_Template(t *testing.T) {
 	t.Parallel()
 

--- a/adapters/postgres/queries_test.go
+++ b/adapters/postgres/queries_test.go
@@ -98,6 +98,57 @@ func TestGetScript_RejectsTraversal(t *testing.T) {
 	require.Contains(t, err.Error(), "could not load script")
 }
 
+// TestGetScript_RejectsSymlinkEscape covers what the lexical containment check
+// cannot see: a symlink that sits inside the queries directory but resolves to a
+// file outside it. The joined path looks contained, so only resolving the link
+// catches the escape.
+func TestGetScript_RejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "secret.read.sql")
+	require.NoError(t, os.WriteFile(outside, []byte("SELECT 'pwned'"), 0o644))
+
+	queries := filepath.Join(dir, "queries", "fulltable")
+	require.NoError(t, os.MkdirAll(queries, 0o755))
+	// escape.read.sql lives inside the queries tree but points above it.
+	require.NoError(t, os.Symlink(outside, filepath.Join(queries, "escape.read.sql")))
+
+	cfg := defaultTestConf()
+	cfg.QueriesPath = filepath.Join(dir, "queries")
+	adapter := testAdapter(cfg)
+
+	_, err := adapter.GetScript("GET", "fulltable", "escape")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid script path")
+}
+
+// TestGetScript_AllowsSymlinkWithinBase confirms the symlink resolution does not
+// break the legitimate case of a link that stays inside the queries directory,
+// which operators use to share one script across folders.
+func TestGetScript_AllowsSymlinkWithinBase(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	shared := filepath.Join(base, "shared")
+	require.NoError(t, os.MkdirAll(shared, 0o755))
+	target := filepath.Join(shared, "list.read.sql")
+	require.NoError(t, os.WriteFile(target, []byte("SELECT 1"), 0o644))
+
+	folder := filepath.Join(base, "fulltable")
+	require.NoError(t, os.MkdirAll(folder, 0o755))
+	link := filepath.Join(folder, "list.read.sql")
+	require.NoError(t, os.Symlink(target, link))
+
+	cfg := defaultTestConf()
+	cfg.QueriesPath = base
+	adapter := testAdapter(cfg)
+
+	got, err := adapter.GetScript("GET", "fulltable", "list")
+	require.NoError(t, err)
+	require.Equal(t, link, got)
+}
+
 func TestParseScript_Template(t *testing.T) {
 	t.Parallel()
 

--- a/adapters/postgres/queries_test.go
+++ b/adapters/postgres/queries_test.go
@@ -1,13 +1,17 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/prest/prest/v2/adapters"
 	pctx "github.com/prest/prest/v2/context"
 	"github.com/stretchr/testify/require"
 )
@@ -343,4 +347,164 @@ func TestExecuteScriptsCtx_WriteMethods(t *testing.T) {
 	}
 	require.NoError(t, ctxMock.ExpectationsWereMet())
 	require.NoError(t, defaultMock.ExpectationsWereMet())
+}
+
+// captureDebugLogs redirects the default slog logger into a buffer at debug level
+// so a test can assert on what was — and was not — logged. It swaps a
+// process-wide global, so callers must not run in parallel.
+func captureDebugLogs(t *testing.T) func() string {
+	t.Helper()
+
+	buf := &syncBuffer{}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return buf.String
+}
+
+// syncBuffer is a bytes.Buffer safe for the driver to write to from any goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestWriteSQLCtx_ErrorsDoNotLogStatement covers the script-reachable write verbs.
+// POST, PUT, PATCH and DELETE scripts all execute through WriteSQLCtx, and a
+// script template renders request headers and query parameters straight into the
+// statement — so the SQL text on this path is caller-controlled data, not a fixed
+// pREST-built statement. Neither the prepare nor the exec failure may put it in
+// the logs, at any level (CodeQL go/clear-text-logging).
+//
+// Not parallel: captureDebugLogs replaces the global default logger.
+func TestWriteSQLCtx_ErrorsDoNotLogStatement(t *testing.T) {
+	logs := captureDebugLogs(t)
+
+	adapter, defaultMock, ctxMock := withSQLMocks(t)
+	ctx := context.WithValue(context.Background(), pctx.DBNameKey, contextMockDB)
+
+	// A marker that could only appear in the logs by way of the statement itself.
+	const marker = "SCRIPT_RENDERED_SECRET"
+
+	testCases := []struct {
+		description string
+		method      string
+		sql         string
+		prepareLike string
+	}{
+		{"POST script failing to prepare", "POST",
+			"INSERT INTO users(note) VALUES('" + marker + "')", `INSERT INTO users`},
+		{"PUT script failing to prepare", "PUT",
+			"UPDATE users SET note='" + marker + "'", `UPDATE users SET`},
+		{"PATCH script failing to prepare", "PATCH",
+			"UPDATE users SET note='" + marker + "' WHERE id=1", `UPDATE users SET`},
+		{"DELETE script failing to prepare", "DELETE",
+			"DELETE FROM users WHERE note='" + marker + "'", `DELETE FROM users`},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+		ctxMock.ExpectPrepare(tc.prepareLike).WillReturnError(errors.New("prepare failed"))
+
+		sc := adapter.ExecuteScriptsCtx(ctx, tc.method, tc.sql, nil)
+		require.Error(t, sc.Err(), tc.description)
+	}
+
+	// Exec failure takes a different branch and must be just as quiet.
+	t.Log("DELETE script failing to execute")
+	ctxMock.ExpectPrepare(`DELETE FROM users`).
+		ExpectExec().
+		WillReturnError(errors.New("exec failed"))
+	sc := adapter.ExecuteScriptsCtx(ctx, "DELETE",
+		"DELETE FROM users WHERE note='"+marker+"'", nil)
+	require.Error(t, sc.Err())
+
+	require.NotContains(t, logs(), marker,
+		"a script-rendered statement must never reach the logs")
+	require.NoError(t, ctxMock.ExpectationsWereMet())
+	require.NoError(t, defaultMock.ExpectationsWereMet())
+}
+
+// TestWriteSQL_ErrorsDoNotLogStatement is the same contract for the non-context
+// entry point, which ExecuteScripts (the legacy script path) still uses.
+//
+// Not parallel: captureDebugLogs replaces the global default logger.
+func TestWriteSQL_ErrorsDoNotLogStatement(t *testing.T) {
+	logs := captureDebugLogs(t)
+
+	adapter, mock := withSQLMock(t)
+	const marker = "SCRIPT_RENDERED_SECRET"
+
+	// Prepare failure.
+	mock.ExpectPrepare(`DELETE FROM users`).WillReturnError(errors.New("prepare failed"))
+	sc := adapter.ExecuteScripts("DELETE", "DELETE FROM users WHERE note='"+marker+"'", nil)
+	require.Error(t, sc.Err())
+
+	// Exec failure.
+	mock.ExpectPrepare(`INSERT INTO users`).
+		ExpectExec().
+		WillReturnError(errors.New("exec failed"))
+	sc = adapter.ExecuteScripts("POST", "INSERT INTO users(note) VALUES('"+marker+"')", nil)
+	require.Error(t, sc.Err())
+
+	require.NotContains(t, logs(), marker,
+		"a script-rendered statement must never reach the logs")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestCRUDBuilders_StillLogStatementAtDebug is the other half of the contract:
+// the statement is still available to operators on the paths a script cannot
+// reach. The CRUD insert/update/delete builders compose their SQL from validated
+// identifiers with bound parameters, so logging it at debug level costs nothing
+// and is the main way a failing query gets diagnosed.
+//
+// Not parallel: captureDebugLogs replaces the global default logger.
+func TestCRUDBuilders_StillLogStatementAtDebug(t *testing.T) {
+	logs := captureDebugLogs(t)
+
+	adapter, mock := withSQLMock(t)
+
+	// Only update and delete report a prepare failure through logFailedSQL. Insert
+	// routes its prepare through fullInsert, which reports the error without the
+	// statement, so there is no logFailedSQL call on that path to assert on.
+	testCases := []struct {
+		description string
+		sql         string
+		prepareLike string
+		call        func(string) adapters.Scanner
+	}{
+		{"update builder", `UPDATE public.users SET name=$1`,
+			`UPDATE`, func(s string) adapters.Scanner { return adapter.Update(s) }},
+		{"delete builder", `DELETE FROM public.users WHERE id=$1`,
+			`DELETE FROM`, func(s string) adapters.Scanner { return adapter.Delete(s) }},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+		mock.ExpectPrepare(tc.prepareLike).WillReturnError(errors.New("prepare failed"))
+
+		sc := tc.call(tc.sql)
+		require.Error(t, sc.Err(), tc.description)
+	}
+
+	// Each statement reached the debug log through logFailedSQL — these paths are
+	// unreachable from a script template, so the SQL is pREST-built and safe to log.
+	out := logs()
+	require.Contains(t, out, "failed sql")
+	for _, tc := range testCases {
+		require.Contains(t, out, tc.sql, tc.description)
+	}
+	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/adapters/postgres/script_runner.go
+++ b/adapters/postgres/script_runner.go
@@ -110,15 +110,32 @@ func (adapter *postgres) GetScript(verb, folder, scriptName string) (script stri
 	return adapter.getScriptPath(verb, folder, scriptName)
 }
 
-// withinBase reports whether path resolves inside base. Both are expected to be
+// withinBase reports whether path lies inside base. Both are expected to be
 // cleaned already; a path that escapes yields a relative path of ".." or one
 // rooted at "..", and an unrelated volume yields an error from filepath.Rel.
+// This is a lexical check only — see resolvedWithinBase for symlinks.
 func withinBase(base, path string) bool {
 	rel, err := filepath.Rel(base, path)
 	if err != nil {
 		return false
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// resolvedWithinBase repeats the containment check with symlinks resolved, so a
+// link inside the queries directory cannot point outside it. Both paths must
+// already exist: EvalSymlinks fails on a missing path, which is why callers run
+// this after confirming the file is there rather than before.
+func resolvedWithinBase(base, path string) bool {
+	realBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		return false
+	}
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	return withinBase(filepath.Clean(realBase), filepath.Clean(realPath))
 }
 
 func (adapter *postgres) getScriptPath(verb, folder, scriptName string) (string, error) {
@@ -142,6 +159,12 @@ func (adapter *postgres) getScriptPath(verb, folder, scriptName string) (string,
 	if _, err := os.Stat(script); os.IsNotExist(err) {
 		slog.Error("could not load script", "script", script)
 		return "", fmt.Errorf("could not load script: %w", err)
+	}
+
+	// The file exists, so links can now be resolved: a symlink inside the queries
+	// directory that targets a file outside it passes the lexical check above.
+	if !resolvedWithinBase(base, script) {
+		return "", fmt.Errorf("invalid script path: %s/%s", folder, scriptName)
 	}
 	return script, nil
 }

--- a/adapters/postgres/script_runner.go
+++ b/adapters/postgres/script_runner.go
@@ -88,7 +88,7 @@ func (adapter *postgres) resolveScriptDatabase(ctx context.Context, verb, locati
 
 // ParseScriptTemplate renders a SQL template string.
 func (adapter *postgres) ParseScriptTemplate(name, content string, templateData map[string]interface{}) (sqlQuery string, values []interface{}, err error) {
-	funcs := &template.FuncRegistry{TemplateData: templateData}
+	funcs := template.NewFuncRegistry(templateData)
 	tpl := gotemplate.New(name).Funcs(funcs.RegistryAllFuncs())
 
 	tpl, err = tpl.Parse(content)

--- a/adapters/postgres/script_runner.go
+++ b/adapters/postgres/script_runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	gotemplate "text/template"
 
 	"github.com/prest/prest/v2/adapters"
@@ -109,14 +110,34 @@ func (adapter *postgres) GetScript(verb, folder, scriptName string) (script stri
 	return adapter.getScriptPath(verb, folder, scriptName)
 }
 
+// withinBase reports whether path resolves inside base. Both are expected to be
+// cleaned already; a path that escapes yields a relative path of ".." or one
+// rooted at "..", and an unrelated volume yields an error from filepath.Rel.
+func withinBase(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 func (adapter *postgres) getScriptPath(verb, folder, scriptName string) (string, error) {
 	suffix, ok := scriptVerbSuffixes[verb]
 	if !ok {
 		return "", fmt.Errorf("invalid http method %s", verb)
 	}
 
-	base := queriesBasePath(adapter.cfg)
+	base := filepath.Clean(queriesBasePath(adapter.cfg))
 	script := filepath.Join(base, folder, fmt.Sprint(scriptName, suffix))
+
+	// folder and scriptName come from the request path. Controllers gate them
+	// through validatePathSegments, but the containment check belongs here too so
+	// the adapter cannot be made to read outside the queries directory by a caller
+	// that skips that gate. filepath.Join has already normalized any "..", so a
+	// path that escapes the base is visible as a relative path starting with "..".
+	if !withinBase(base, script) {
+		return "", fmt.Errorf("invalid script path: %s/%s", folder, scriptName)
+	}
 
 	if _, err := os.Stat(script); os.IsNotExist(err) {
 		slog.Error("could not load script", "script", script)

--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -16,6 +17,18 @@ const (
 	unf = "user not found"
 )
 
+// jsonError writes message as a JSON error body.
+//
+// The message is escaped rather than interpolated raw: a message containing a
+// double quote — or any control character — would otherwise emit a body that is
+// not valid JSON, which clients cannot parse to discover what went wrong.
 func jsonError(writer http.ResponseWriter, message string, status int) {
-	http.Error(writer, fmt.Sprintf(jsonErrorMsg, message), status)
+	encoded, err := json.Marshal(message)
+	if err != nil {
+		// json.Marshal only fails here on invalid UTF-8, which a caller-supplied
+		// message can carry; fall back to a fixed, certainly-valid body.
+		http.Error(writer, fmt.Sprintf(jsonErrorMsg, "request failed"), status)
+		return
+	}
+	http.Error(writer, fmt.Sprintf(`{"error":%s}`, encoded), status)
 }

--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -25,8 +25,8 @@ const (
 func jsonError(writer http.ResponseWriter, message string, status int) {
 	encoded, err := json.Marshal(message)
 	if err != nil {
-		// json.Marshal only fails here on invalid UTF-8, which a caller-supplied
-		// message can carry; fall back to a fixed, certainly-valid body.
+		// Marshalling a string is not expected to fail; fall back to a fixed,
+		// certainly-valid body rather than emitting an unchecked one.
 		http.Error(writer, fmt.Sprintf(jsonErrorMsg, "request failed"), status)
 		return
 	}

--- a/controllers/errors_test.go
+++ b/controllers/errors_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,4 +17,22 @@ func TestJsonError(t *testing.T) {
 
 	require.Equal(t, http.StatusTeapot, rec.Code)
 	require.Equal(t, `{"error":"something failed"}`+"\n", rec.Body.String())
+}
+
+// A message carrying a double quote used to be interpolated straight into the
+// body, producing JSON a client cannot parse. Escaping keeps the body valid
+// whatever the message contains.
+func TestJSONError_EscapesMessage(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	jsonError(rec, `invalid value for parameter "slug"`, http.StatusBadRequest)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body), "body must be valid JSON")
+	require.Equal(t, `invalid value for parameter "slug"`, body.Error)
 }

--- a/controllers/script.go
+++ b/controllers/script.go
@@ -103,7 +103,8 @@ func (h *ScriptHandler) ExecuteScriptQuery(rq *http.Request, queriesPath string,
 	return sc.Bytes(), nil
 }
 
-// credentialHeaders never reach script templates with their real value.
+// isCredentialHeader reports whether a header carries a caller credential, which
+// must never reach a script template with its real value.
 // sanitizeScriptParam screens for SQL composition, not for secrecy: a bearer
 // token or session cookie is plain base64url text and passes its allow-list
 // untouched, so a template referencing one would interpolate the caller's
@@ -112,13 +113,14 @@ func (h *ScriptHandler) ExecuteScriptQuery(rq *http.Request, queriesPath string,
 // value — so an existing template still renders a valid empty literal instead of
 // Go's "<no value>". Keys are in net/http canonical form, which is how they are
 // stored in Request.Header.
-var credentialHeaders = map[string]struct{}{
-	"Authorization":       {},
-	"Proxy-Authorization": {},
-	"Cookie":              {},
-	"X-Api-Key":           {},
-	"X-Auth-Token":        {},
-	"X-Access-Token":      {},
+func isCredentialHeader(name string) bool {
+	switch http.CanonicalHeaderKey(name) {
+	case "Authorization", "Proxy-Authorization", "Cookie",
+		"X-Api-Key", "X-Auth-Token", "X-Access-Token":
+		return true
+	default:
+		return false
+	}
 }
 
 // extractHeaders gets from the given request the headers and populate the provided templateData accordingly.
@@ -129,7 +131,7 @@ func extractHeaders(rq *http.Request, templateData map[string]interface{}) {
 	headers := map[string]interface{}{}
 
 	for key, value := range rq.Header {
-		if _, isCredential := credentialHeaders[http.CanonicalHeaderKey(key)]; isCredential {
+		if isCredentialHeader(key) {
 			headers[key] = ""
 			continue
 		}

--- a/controllers/script.go
+++ b/controllers/script.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"regexp"
 	"strings"
@@ -10,6 +11,15 @@ import (
 	"github.com/prest/prest/v2/middlewares"
 
 	"github.com/gorilla/mux"
+)
+
+// Reserved templateData keys holding the unscreened values that the `sqlVal` /
+// `sqlList` helpers bind. They sit beside the existing `header` key rather than
+// widening the ScriptRunner port, and are namespaced with a leading underscore
+// so an ordinary query parameter is unlikely to collide.
+const (
+	rawParamKey  = "_param"
+	rawHeaderKey = "_header"
 )
 
 // ScriptHandler serves user-defined SQL script endpoints.
@@ -74,6 +84,10 @@ func (h *ScriptHandler) Execute(w http.ResponseWriter, r *http.Request) {
 }
 
 // ExecuteScriptQuery runs a script and returns the result bytes.
+//
+// A rejected parameter only fails the request if the template interpolated it
+// into the SQL text. Had it been passed to sqlVal instead, it would be bound
+// and safe, so there is nothing to reject.
 func (h *ScriptHandler) ExecuteScriptQuery(rq *http.Request, queriesPath string, script string) ([]byte, error) {
 	vars := mux.Vars(rq)
 	database := vars["database"] // empty = default prest_queries.database_alias
@@ -86,11 +100,15 @@ func (h *ScriptHandler) ExecuteScriptQuery(rq *http.Request, queriesPath string,
 
 	templateData := make(map[string]interface{})
 	extractHeaders(rq, templateData)
-	extractQueryParameters(rq, templateData)
+	rejected := extractQueryParameters(rq, templateData)
 
 	sql, values, err := h.scripts.ParseScriptTemplate(source.Name, source.Content, templateData)
 	if err != nil {
 		err = fmt.Errorf("could not parse script %s/%s, %v", queriesPath, script, err)
+		return nil, err
+	}
+
+	if err := rejected.err(); err != nil {
 		return nil, err
 	}
 
@@ -127,26 +145,56 @@ func isCredentialHeader(name string) bool {
 // Values are routed through sanitizeScriptParam, the same gate used for query
 // parameters, since templates interpolate headers into SQL exactly the same way.
 // Credential-bearing headers are dropped entirely rather than sanitized.
+//
+// Unlike a query parameter, a rejected header does not fail the request: every
+// inbound header is screened here, not only the ones a template reads, and an
+// ordinary `User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)` fails
+// the character allow-list on `(` and `;`. Erroring would reject nearly every
+// browser request to every script endpoint. Rejected headers are blanked and
+// logged instead.
 func extractHeaders(rq *http.Request, templateData map[string]interface{}) {
 	headers := map[string]interface{}{}
+	raw := map[string]interface{}{}
 
 	for key, value := range rq.Header {
+		// Credentials are withheld from the raw map too: blanking them is about
+		// secrecy, not SQL composition, so binding must not become a way around it.
 		if isCredentialHeader(key) {
 			headers[key] = ""
+			raw[key] = ""
 			continue
 		}
 		if len(value) == 1 {
-			headers[key] = sanitizeScriptParam(value[0])
+			sanitized := sanitizeScriptParam(value[0])
+			if sanitized == "" && value[0] != "" {
+				warnRejectedHeader(key)
+			}
+			headers[key] = sanitized
+			raw[key] = value[0]
 			continue
 		}
 		sanitized := make([]string, 0, len(value))
 		for _, v := range value {
-			sanitized = append(sanitized, sanitizeScriptParam(v))
+			s := sanitizeScriptParam(v)
+			if s == "" && v != "" {
+				warnRejectedHeader(key)
+			}
+			sanitized = append(sanitized, s)
 		}
 		headers[key] = sanitized
+		raw[key] = append([]string(nil), value...)
 	}
 
 	templateData["header"] = headers
+	templateData[rawHeaderKey] = raw
+}
+
+// warnRejectedHeader records that a header was blanked. The name is logged, never
+// the value: it is caller-controlled and may carry a credential.
+func warnRejectedHeader(key string) {
+	slog.Warn("script header value rejected by the SQL safety screen and blanked",
+		"header", key,
+		"hint", "bind free-form values with the sqlVal template helper")
 }
 
 var safeScriptParamRegex = regexp.MustCompile(`^[a-zA-Z0-9_.:@/\\ -]+$`)
@@ -182,23 +230,36 @@ var scriptParamSQLKeywords = map[string]struct{}{
 }
 
 // sanitizeScriptParam sanitizes the given value to be used as a script parameter.
-// This is used to prevent SQL injection.
+// This is used to prevent SQL injection. A rejected value comes back empty.
 //
 // The character allow-list alone is not enough: it keeps quotes, commas and
 // parentheses out, but letters, digits and space are already sufficient to
 // compose a read-only injection such as
 // `0 UNION SELECT users::text FROM users` whenever a template interpolates the
 // value in an unquoted context (`WHERE id = {{.id}}`). SQL comment (`--`) and
-// cast (`::`) tokens plus any SQL keyword are therefore rejected as well.
+// cast (`::`) tokens are therefore rejected as well.
 //
-// Templates that need to interpolate free-form values should use the `sqlVal`
-// / `sqlList` helpers, which bind them as query parameters instead.
+// The SQL keyword screen, however, runs only on values that contain a space.
+// Composing SQL takes more than one token, and space is the only separator the
+// allow-list permits — `;` `,` `(` `)` `*` `'` `"`, tab and newline are all
+// rejected above, and `/**/` is unreachable without `*`. A single-token value is
+// therefore inert: `WHERE 1 = teste-do-abc` is a syntax error, not an injection,
+// exactly as `WHERE 1 = some_column` already is today. Screening single tokens
+// only blanked legitimate data — Portuguese slugs containing `do` were 17.5% of
+// one reporter's catalog (issue #1030).
+//
+// Templates that need free-form values (search phrases, anything with spaces)
+// should use the `sqlVal` / `sqlList` helpers, which bind them as query
+// parameters and skip this screen entirely.
 func sanitizeScriptParam(value string) string {
 	if !safeScriptParamRegex.MatchString(value) {
 		return ""
 	}
 	if strings.Contains(value, "--") || strings.Contains(value, "::") {
 		return ""
+	}
+	if !strings.Contains(value, " ") {
+		return value
 	}
 	for _, word := range scriptParamWordRegex.FindAllString(value, -1) {
 		word = strings.ToLower(word)
@@ -214,16 +275,94 @@ func sanitizeScriptParam(value string) string {
 
 // extractQueryParameters gets from the given request the query parameters and populate the provided templateData
 // accordingly.
-func extractQueryParameters(rq *http.Request, templateData map[string]interface{}) {
+//
+// A value the sanitizer rejects fails the request. Blanking it and carrying on
+// used to leave `{{if isSet "x"}}` true and run the query with `”`, so the
+// caller got HTTP 200 and rows belonging to a different record — indistinguishable
+// from a genuine miss (issue #1030).
+//
+// Raw, unscreened values are also published under rawParamKey for the `sqlVal` /
+// `sqlList` helpers, which bind them instead of interpolating them.
+func extractQueryParameters(rq *http.Request, templateData map[string]interface{}) *rejectedUsage {
+	usage := &rejectedUsage{}
+	raw := map[string]interface{}{}
 	for key, value := range rq.URL.Query() {
 		if len(value) == 1 {
-			templateData[key] = sanitizeScriptParam(value[0])
+			templateData[key] = screenedValue(key, value[0], usage)
+			raw[key] = value[0]
 			continue
 		}
+		// Stay a []string while every element survives the screen: inFormat and
+		// sqlList both type-assert on it. Only a rejection forces the wider type,
+		// so that the marker can report itself when rendered.
 		sanitized := make([]string, 0, len(value))
-		for _, v := range value {
-			sanitized = append(sanitized, sanitizeScriptParam(v))
+		rejectedAt := -1
+		for i, v := range value {
+			s := sanitizeScriptParam(v)
+			if s == "" && v != "" {
+				rejectedAt = i
+			}
+			sanitized = append(sanitized, s)
 		}
-		templateData[key] = sanitized
+		if rejectedAt >= 0 {
+			mixed := make([]interface{}, 0, len(value))
+			for _, v := range value {
+				mixed = append(mixed, screenedValue(key, v, usage))
+			}
+			templateData[key] = mixed
+		} else {
+			templateData[key] = sanitized
+		}
+		raw[key] = append([]string(nil), value...)
 	}
+	templateData[rawParamKey] = raw
+	return usage
+}
+
+// screenedValue returns the value to interpolate inline: the sanitized string
+// when it survives the screen, otherwise a marker that reports itself if the
+// template actually renders it.
+func screenedValue(key, value string, usage *rejectedUsage) interface{} {
+	sanitized := sanitizeScriptParam(value)
+	if sanitized == "" && value != "" {
+		return rejectedParam{key: key, usage: usage}
+	}
+	return sanitized
+}
+
+// rejectedParam stands in for a query parameter the safety screen refused.
+//
+// The decision to fail cannot be taken when the parameter is read, because a
+// template may pass it to `sqlVal`, which binds it as a query parameter where SQL
+// composition is impossible and no screening is warranted. So the marker renders
+// as the empty string exactly like before, and records that it was interpolated
+// into the SQL text. The handler fails the request afterwards only if that
+// happened — turning the silent wrong-rows response of issue #1030 into an error,
+// without rejecting values that were only ever bound.
+type rejectedParam struct {
+	key   string
+	usage *rejectedUsage
+}
+
+// String satisfies fmt.Stringer, which is how text/template renders the value.
+func (r rejectedParam) String() string {
+	r.usage.keys = append(r.usage.keys, r.key)
+	return ""
+}
+
+// rejectedUsage collects the parameters whose rejected value reached the SQL text.
+type rejectedUsage struct {
+	keys []string
+}
+
+// err names the first offending parameter, without echoing its value: the value
+// is caller-controlled, may carry a credential, and would end up in logs
+// (CodeQL go/clear-text-logging).
+func (u *rejectedUsage) err() error {
+	if len(u.keys) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"invalid value for parameter %s: it contains SQL syntax that cannot be interpolated safely; "+
+			"use the sqlVal template helper to bind free-form values", u.keys[0])
 }

--- a/controllers/script.go
+++ b/controllers/script.go
@@ -18,6 +18,8 @@ import (
 // widening the ScriptRunner port, and are namespaced with a leading underscore
 // so an ordinary query parameter is unlikely to collide.
 const (
+	// headerKey holds the screened headers templates interpolate inline.
+	headerKey    = "header"
 	rawParamKey  = "_param"
 	rawHeaderKey = "_header"
 )
@@ -88,6 +90,13 @@ func (h *ScriptHandler) Execute(w http.ResponseWriter, r *http.Request) {
 // A rejected parameter only fails the request if the template interpolated it
 // into the SQL text. Had it been passed to sqlVal instead, it would be bound
 // and safe, so there is nothing to reject.
+//
+// A template error embeds both the template's internals and the value that
+// tripped it — `ident` reports `invalid identifier: <the caller's string>`,
+// so returning it verbatim reflects attacker-controlled input straight back
+// and into the logs. Report it the way SQL failures are already reported:
+// detail to the operator, a safe summary to the caller. The cause stays
+// wrapped so errors.Is/As still work.
 func (h *ScriptHandler) ExecuteScriptQuery(rq *http.Request, queriesPath string, script string) ([]byte, error) {
 	vars := mux.Vars(rq)
 	database := vars["database"] // empty = default prest_queries.database_alias
@@ -104,8 +113,12 @@ func (h *ScriptHandler) ExecuteScriptQuery(rq *http.Request, queriesPath string,
 
 	sql, values, err := h.scripts.ParseScriptTemplate(source.Name, source.Content, templateData)
 	if err != nil {
-		err = fmt.Errorf("could not parse script %s/%s, %v", queriesPath, script, err)
-		return nil, err
+		slog.Error("could not parse script",
+			"location", queriesPath, "script", script, "err", err)
+		return nil, scriptError{
+			public: fmt.Sprintf("could not parse script %s/%s, check your prest logs", queriesPath, script),
+			cause:  err,
+		}
 	}
 
 	if err := rejected.err(); err != nil {
@@ -120,6 +133,16 @@ func (h *ScriptHandler) ExecuteScriptQuery(rq *http.Request, queriesPath string,
 
 	return sc.Bytes(), nil
 }
+
+// scriptError carries a message safe to return to the caller while keeping the
+// underlying cause for logs and for errors.Is/As.
+type scriptError struct {
+	public string
+	cause  error
+}
+
+func (e scriptError) Error() string { return e.public }
+func (e scriptError) Unwrap() error { return e.cause }
 
 // isCredentialHeader reports whether a header carries a caller credential, which
 // must never reach a script template with its real value.
@@ -185,7 +208,7 @@ func extractHeaders(rq *http.Request, templateData map[string]interface{}) {
 		raw[key] = append([]string(nil), value...)
 	}
 
-	templateData["header"] = headers
+	templateData[headerKey] = headers
 	templateData[rawHeaderKey] = raw
 }
 
@@ -287,6 +310,14 @@ func extractQueryParameters(rq *http.Request, templateData map[string]interface{
 	usage := &rejectedUsage{}
 	raw := map[string]interface{}{}
 	for key, value := range rq.URL.Query() {
+		// These names belong to pREST, not to the caller. Letting a query
+		// parameter land on one replaced the map the extractors put there:
+		// `?header=x` broke every `{{index .header "..."}}` template with a 400,
+		// and `?_header=x` made the binding helpers fall back to screened values,
+		// silently binding "" for any header the charset screen rejects.
+		if isReservedTemplateKey(key) {
+			continue
+		}
 		if len(value) == 1 {
 			templateData[key] = screenedValue(key, value[0], usage)
 			raw[key] = value[0]
@@ -317,6 +348,18 @@ func extractQueryParameters(rq *http.Request, templateData map[string]interface{
 	}
 	templateData[rawParamKey] = raw
 	return usage
+}
+
+// isReservedTemplateKey reports whether key names one of the template-data slots
+// pREST populates itself: the screened header map and the two unscreened maps the
+// binding helpers read. A caller-supplied value must never occupy one.
+func isReservedTemplateKey(key string) bool {
+	switch key {
+	case headerKey, rawHeaderKey, rawParamKey:
+		return true
+	default:
+		return false
+	}
 }
 
 // screenedValue returns the value to interpolate inline: the sanitized string

--- a/controllers/script.go
+++ b/controllers/script.go
@@ -103,13 +103,36 @@ func (h *ScriptHandler) ExecuteScriptQuery(rq *http.Request, queriesPath string,
 	return sc.Bytes(), nil
 }
 
+// credentialHeaders never reach script templates with their real value.
+// sanitizeScriptParam screens for SQL composition, not for secrecy: a bearer
+// token or session cookie is plain base64url text and passes its allow-list
+// untouched, so a template referencing one would interpolate the caller's
+// credential into the SQL string that adapters log at debug level. The key is
+// kept with an empty value — the same shape sanitizeScriptParam gives a rejected
+// value — so an existing template still renders a valid empty literal instead of
+// Go's "<no value>". Keys are in net/http canonical form, which is how they are
+// stored in Request.Header.
+var credentialHeaders = map[string]struct{}{
+	"Authorization":       {},
+	"Proxy-Authorization": {},
+	"Cookie":              {},
+	"X-Api-Key":           {},
+	"X-Auth-Token":        {},
+	"X-Access-Token":      {},
+}
+
 // extractHeaders gets from the given request the headers and populate the provided templateData accordingly.
 // Values are routed through sanitizeScriptParam, the same gate used for query
 // parameters, since templates interpolate headers into SQL exactly the same way.
+// Credential-bearing headers are dropped entirely rather than sanitized.
 func extractHeaders(rq *http.Request, templateData map[string]interface{}) {
 	headers := map[string]interface{}{}
 
 	for key, value := range rq.Header {
+		if _, isCredential := credentialHeaders[http.CanonicalHeaderKey(key)]; isCredential {
+			headers[key] = ""
+			continue
+		}
 		if len(value) == 1 {
 			headers[key] = sanitizeScriptParam(value[0])
 			continue

--- a/controllers/script_test.go
+++ b/controllers/script_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -117,6 +118,92 @@ func TestScriptHandler_Execute_WithCache(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, middlewares.CacheKey(req), cacher.key)
 	require.Equal(t, "cached", cacher.value)
+}
+
+// TestScriptHandler_Execute_RejectsInterpolatedRejectedParam is the fix for the
+// silent-failure half of issue #1030: a parameter the screen refuses used to be
+// blanked, leaving the query to run with ” and return rows for a different
+// record under HTTP 200. Interpolating it must now fail the request outright.
+func TestScriptHandler_Execute_RejectsInterpolatedRejectedParam(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	scripts := mockgen.NewMockScriptRunner(ctrl)
+	scripts.EXPECT().
+		ResolveScript(gomock.Any(), http.MethodGet, "queries", "list", "prest-test").
+		Return(adapters.ScriptSource{Name: "list.read.sql", Content: `SELECT '{{.slug}}'`}, nil)
+	// The template renders the marker, which is what makes the request fail. The
+	// executor must never be reached.
+	scripts.EXPECT().
+		ParseScriptTemplate("list.read.sql", `SELECT '{{.slug}}'`, gomock.Any()).
+		DoAndReturn(func(_, _ string, data map[string]interface{}) (string, []interface{}, error) {
+			return fmt.Sprintf("SELECT '%v'", data["slug"]), nil, nil
+		})
+
+	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().IsRegistered("prest-test").Return(true)
+
+	h := NewScriptHandler(Deps{
+		Scripts:  scripts,
+		Executor: mockgen.NewMockQueryExecutor(ctrl),
+		DB:       db,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/prest-test/queries/list?slug=compra+do+mes", nil)
+	req = mux.SetURLVars(req, map[string]string{"database": "prest-test", "queriesLocation": "queries", "script": "list"})
+	req = req.WithContext(withTestTimeout(req.Context()))
+	rec := httptest.NewRecorder()
+
+	h.Execute(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "slug")
+	require.NotContains(t, rec.Body.String(), "compra do mes")
+}
+
+// A value that reaches sqlVal instead of being interpolated is bound by the
+// driver, so the screen has nothing to protect against and the request succeeds.
+func TestScriptHandler_Execute_AllowsRejectedParamWhenOnlyBound(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	scripts := mockgen.NewMockScriptRunner(ctrl)
+	scripts.EXPECT().
+		ResolveScript(gomock.Any(), http.MethodGet, "queries", "list", "prest-test").
+		Return(adapters.ScriptSource{Name: "list.read.sql", Content: `SELECT {{sqlVal "slug"}}`}, nil)
+	// Stands in for the real registry: binds the raw value, never renders the marker.
+	scripts.EXPECT().
+		ParseScriptTemplate("list.read.sql", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_, _ string, data map[string]interface{}) (string, []interface{}, error) {
+			raw := data[rawParamKey].(map[string]interface{})
+			return "SELECT $1", []interface{}{raw["slug"]}, nil
+		})
+
+	scanner := mockgen.NewMockScanner(ctrl)
+	scanner.EXPECT().Err().Return(nil)
+	scanner.EXPECT().Bytes().Return([]byte(`[{"?column?":"compra do mes"}]`))
+
+	executor := mockgen.NewMockQueryExecutor(ctrl)
+	executor.EXPECT().
+		ExecuteScriptsCtx(gomock.Any(), http.MethodGet, "SELECT $1", []interface{}{"compra do mes"}).
+		Return(scanner)
+
+	db := mockgen.NewMockDatabaseRegistry(ctrl)
+	db.EXPECT().IsRegistered("prest-test").Return(true)
+
+	h := NewScriptHandler(Deps{Scripts: scripts, Executor: executor, DB: db})
+	req := httptest.NewRequest(http.MethodGet, "/prest-test/queries/list?slug=compra+do+mes", nil)
+	req = mux.SetURLVars(req, map[string]string{"database": "prest-test", "queriesLocation": "queries", "script": "list"})
+	req = req.WithContext(withTestTimeout(req.Context()))
+	rec := httptest.NewRecorder()
+
+	h.Execute(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "compra do mes")
 }
 
 // TestScriptHandler_Execute_RejectsUnregisteredDatabase guards against an
@@ -342,16 +429,126 @@ func TestSanitizeScriptParam_RejectsUnquotedContextInjection(t *testing.T) {
 	}
 }
 
-func TestExtractQueryParameters_SanitizesUnsafeValues(t *testing.T) {
+// Composing SQL in an unquoted context requires separating tokens, and space is
+// the only separator the character allow-list permits. A single-token value can
+// therefore carry a keyword harmlessly — `WHERE 1 = teste-do-abc` is a syntax
+// error, not an injection — so screening it as SQL only blanks legitimate data.
+// Portuguese slugs are the reported casualty: `do` appears in a large share of
+// them (issue #1030).
+func TestSanitizeScriptParam_PreservesSingleTokenValues(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, "/?safe=ok&tag=good&tag=bad%27%3B--", nil)
-	req.URL.RawQuery = "safe=ok&unsafe=%27%3BDROP&tag=good&tag=bad%27%3B--"
+	safe := []string{
+		"teste-do-abc",
+		"compra-do-mes",
+		"estatua-do-diabo",
+		"significado-do-yom-kippur",
+		"trombetas-do-apocalipse",
+		"teste-select-abc",
+		"teste-as-abc",
+		// Whole-token keywords with no separator at all must survive too, since
+		// they still cannot compose anything on their own.
+		"do",
+		"select",
+	}
+	for _, value := range safe {
+		require.Equal(t, value, sanitizeScriptParam(value), "value must be preserved: %s", value)
+	}
+}
+
+// A rejected value renders empty, exactly as before, but reports itself so the
+// request can fail rather than return rows for a different record. Rendering is
+// what triggers it: a value that only ever reaches sqlVal is never interpolated
+// and must not fail anything.
+func TestExtractQueryParameters_RejectedValueFailsOnlyWhenInterpolated(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.URL.RawQuery = "safe=ok&unsafe=%27%3BDROP"
 
 	data := map[string]interface{}{}
-	extractQueryParameters(req, data)
+	rejected := extractQueryParameters(req, data)
+
+	// Nothing rendered yet, so nothing to report.
+	require.NoError(t, rejected.err())
+
+	// Interpolating it is what text/template does via fmt.Stringer.
+	require.Equal(t, "", fmt.Sprint(data["unsafe"]))
+
+	err := rejected.err()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsafe")
+	require.NotContains(t, err.Error(), "DROP", "the rejected value must never be echoed back")
+}
+
+func TestExtractQueryParameters_RejectsUnsafeValueInMultiValueParam(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.URL.RawQuery = "tag=good&tag=bad%27%3B--"
+
+	data := map[string]interface{}{}
+	rejected := extractQueryParameters(req, data)
+
+	values := data["tag"].([]interface{})
+	require.Equal(t, "good", fmt.Sprint(values[0]))
+	require.Equal(t, "", fmt.Sprint(values[1]))
+
+	err := rejected.err()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tag")
+}
+
+func TestExtractQueryParameters_KeepsSafeValues(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.URL.RawQuery = "safe=ok&slug=teste-do-abc&tag=good&tag=fine"
+
+	data := map[string]interface{}{}
+	rejected := extractQueryParameters(req, data)
 
 	require.Equal(t, "ok", data["safe"])
-	require.Equal(t, "", data["unsafe"])
-	require.Equal(t, []string{"good", ""}, data["tag"])
+	require.Equal(t, "teste-do-abc", data["slug"])
+	// Stays a []string so inFormat and sqlList keep working.
+	require.Equal(t, []string{"good", "fine"}, data["tag"])
+	require.NoError(t, rejected.err())
+}
+
+// Values reach the binding helpers unscreened: sqlVal passes them to the driver
+// as a bound parameter, where SQL composition is impossible by construction.
+func TestExtractQueryParameters_ExposesRawValues(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.URL.RawQuery = "phrase=compra+do+mes&tag=a+or+b&tag=plain"
+
+	data := map[string]interface{}{}
+	require.NoError(t, extractQueryParameters(req, data).err())
+
+	raw := data[rawParamKey].(map[string]interface{})
+	require.Equal(t, "compra do mes", raw["phrase"])
+	require.Equal(t, []string{"a or b", "plain"}, raw["tag"])
+
+	// The inline value is still screened, so un-migrated templates are unchanged:
+	// it renders empty (and, being rejected, would then fail the request).
+	require.Equal(t, "", fmt.Sprint(data["phrase"]))
+}
+
+// Credential blanking is about secrecy, not SQL composition, so binding must not
+// become a way around it.
+func TestExtractHeaders_RawMapStillBlanksCredentials(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJnb3BoZXIifQ.c2ln")
+	req.Header.Set("X-Application", "compra do mes")
+
+	data := map[string]interface{}{}
+	extractHeaders(req, data)
+
+	raw := data[rawHeaderKey].(map[string]interface{})
+	require.Equal(t, "", raw["Authorization"])
+	// A non-credential header keeps its unscreened value for binding.
+	require.Equal(t, "compra do mes", raw["X-Application"])
 }

--- a/controllers/script_test.go
+++ b/controllers/script_test.go
@@ -552,3 +552,51 @@ func TestExtractHeaders_RawMapStillBlanksCredentials(t *testing.T) {
 	// A non-credential header keeps its unscreened value for binding.
 	require.Equal(t, "compra do mes", raw["X-Application"])
 }
+
+// Query parameters must not be able to overwrite the keys pREST reserves for its
+// own template data. `header` holds the screened header map, `_header` and
+// `_param` the unscreened maps the binding helpers read. All three are assigned
+// by the extractors, and the query-parameter loop used to run over them:
+//
+//   - `?header=x` replaced the header map with a string, so every template doing
+//     `{{index .header "X"}}` failed to render — a 400 any client could trigger
+//     on any header-reading script.
+//   - `?_header=x` replaced the raw header map, so `{{sqlVal "header.X"}}`
+//     silently fell back to the screened value and bound "" for any header the
+//     charset screen rejects. Wrong rows under HTTP 200 — the exact failure class
+//     of issue #1030, reintroduced through a name collision.
+func TestExtractQueryParameters_IgnoresReservedKeys(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Application", "prest")
+	req.URL.RawQuery = "header=x&_header=x&_param=x&slug=keep-me"
+
+	data := map[string]interface{}{}
+	extractHeaders(req, data)
+	rejected := extractQueryParameters(req, data)
+	require.NoError(t, rejected.err())
+
+	// The screened header map survives, so inline header templates still render.
+	headers, ok := data["header"].(map[string]interface{})
+	require.True(t, ok, "the header map must not be replaced by a query parameter")
+	require.Equal(t, "prest", headers["X-Application"])
+
+	// The raw maps survive, so binding still reaches unscreened values.
+	rawHeaders, ok := data[rawHeaderKey].(map[string]interface{})
+	require.True(t, ok, "the raw header map must not be replaced by a query parameter")
+	require.Equal(t, "prest", rawHeaders["X-Application"])
+
+	rawParams, ok := data[rawParamKey].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "keep-me", rawParams["slug"])
+
+	// The reserved names are pREST's namespace: a caller sending them is ignored
+	// rather than served, so they never reach a template as caller data.
+	require.NotContains(t, rawParams, "header")
+	require.NotContains(t, rawParams, rawHeaderKey)
+	require.NotContains(t, rawParams, rawParamKey)
+
+	// Ordinary parameters are unaffected.
+	require.Equal(t, "keep-me", data["slug"])
+}

--- a/controllers/script_test.go
+++ b/controllers/script_test.go
@@ -257,6 +257,34 @@ func TestExtractHeaders_SanitizesUnsafeValues(t *testing.T) {
 	require.Equal(t, []string{"good", ""}, headers["X-Multi"])
 }
 
+func TestExtractHeaders_DropsCredentialHeaders(t *testing.T) {
+	t.Parallel()
+
+	// A JWT passes sanitizeScriptParam's allow-list unchanged (base64url, dots
+	// and the space in "Bearer " are all permitted), so without an explicit
+	// drop a template referencing {{.header.Authorization}} would interpolate
+	// the caller's token into the SQL text — which is logged at debug level.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJnb3BoZXIifQ.c2ln")
+	req.Header.Set("Cookie", "session=abc123")
+	req.Header.Set("Proxy-Authorization", "Basic Z29waGVyOnMzY3JldA")
+	req.Header.Set("X-Api-Key", "k3y")
+	req.Header.Set("X-Application", "prest")
+
+	data := map[string]interface{}{}
+	extractHeaders(req, data)
+
+	headers := data["header"].(map[string]interface{})
+	// The key stays so existing templates still render an empty literal, but it
+	// never carries the credential.
+	require.Equal(t, "", headers["Authorization"])
+	require.Equal(t, "", headers["Cookie"])
+	require.Equal(t, "", headers["Proxy-Authorization"])
+	require.Equal(t, "", headers["X-Api-Key"])
+	// Non-credential headers keep working.
+	require.Equal(t, "prest", headers["X-Application"])
+}
+
 func TestExtractQueryParameters(t *testing.T) {
 	t.Parallel()
 

--- a/integration/postgres/controllers/queries_database_params_test.go
+++ b/integration/postgres/controllers/queries_database_params_test.go
@@ -1,0 +1,133 @@
+// nolint
+package controllers_test
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/prest/prest/v2/integration/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+// The queries server stores templates in the prest_queries table instead of on
+// disk (testdata/prest_queries.toml, storage = "database"). Resolution takes a
+// different code path — a column lookup rather than a file read — but everything
+// after it, the parameter screen and the binding helpers, is shared with the
+// filesystem server. None of that was covered in database mode, so a regression
+// there would have gone unnoticed on the server where operators can author
+// templates at runtime through the registry API.
+//
+// Templates are registered under the "itest" location, which prest_queries.toml
+// already grants to the admin user, so no config change is needed.
+
+// registerQuery creates a read template through the registry API.
+func registerQuery(t *testing.T, base, token, name, readSQL string) {
+	t.Helper()
+
+	helpers.DoAuthRequest(t, base+"/_QUERIES/registry",
+		map[string]string{"location": "itest", "name": name, "read_sql": readSQL},
+		http.MethodPost, token, http.StatusCreated, "RegisterQuery")
+}
+
+// deleteQuery removes it again so the table is left as it was found.
+func deleteQuery(t *testing.T, base, token, name string) {
+	t.Helper()
+
+	helpers.DoAuthRequest(t, base+"/_QUERIES/registry/itest/"+name,
+		nil, http.MethodDelete, token, http.StatusNoContent, "DeleteQuery")
+}
+
+// authBody runs an authenticated GET and returns status and raw body, so the
+// caller can assert that something is absent (DoAuthRequest only does substring
+// presence checks).
+func authBody(t *testing.T, url, token string) (int, string) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-Application", "prest")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}
+
+// TestQueriesDatabase_ParameterScreenApplies proves a database-stored template is
+// screened exactly like a filesystem one: a single-token value carrying a SQL
+// keyword survives (issue #1030), and a multi-word injection payload fails the
+// request instead of composing SQL.
+func TestQueriesDatabase_ParameterScreenApplies(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	registerQuery(t, base, token, "screened", `SELECT * FROM test7 WHERE name = '{{.field1}}'`)
+	defer deleteQuery(t, base, token, "screened")
+
+	// A slug containing the keyword "do" reaches the query intact.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/itest/screened?field1=teste-do-abc",
+		nil, http.MethodGet, token, http.StatusOK, "DBScreenPreserves", "[]")
+
+	// An interpolated injection payload is refused, naming the parameter.
+	status, body := authBody(t,
+		base+"/_QUERIES/itest/screened?field1="+url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"),
+		token)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "field1")
+	require.NotContains(t, body, "pg_shadow")
+}
+
+// TestQueriesDatabase_BindingHelpersWork proves sqlVal reaches the caller's
+// unscreened value in database mode too — the migration path pREST documents for
+// free-form input has to work wherever templates are stored.
+func TestQueriesDatabase_BindingHelpersWork(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	registerQuery(t, base, token, "bound", `SELECT {{sqlVal "field1"}} AS echoed`)
+	defer deleteQuery(t, base, token, "bound")
+
+	// A phrase the inline screen would refuse is bound verbatim and echoed back.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/itest/bound?field1="+url.QueryEscape("compra do mes"),
+		nil, http.MethodGet, token, http.StatusOK, "DBBoundValue", "compra do mes")
+
+	// An injection payload is inert as a bound value: returned as data, not run.
+	status, body := authBody(t,
+		base+"/_QUERIES/itest/bound?field1="+url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"),
+		token)
+	require.Equal(t, http.StatusOK, status)
+	require.NotContains(t, body, "rolpassword")
+	require.Contains(t, body, "UNION",
+		"the payload is echoed as a bound string value, which is exactly the point")
+}
+
+// TestQueriesDatabase_RawMapsUnreachable is the database-mode version of the
+// containment check. This is the realistic shape of that bug: an operator with
+// registry access writes the template by hand, and `{{index ._param "x"}}` looks
+// like a reasonable way to reach a parameter. It must not yield the unscreened
+// value.
+func TestQueriesDatabase_RawMapsUnreachable(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// The template echoes whatever it can reach, so a leak is directly visible in
+	// the response. An injection-shaped payload would not be: it would return
+	// catalog *rows*, and asserting on the absence of the payload string would pass
+	// even while the injection succeeded.
+	registerQuery(t, base, token, "rawreach", `SELECT '{{index ._param "field1"}}' AS leaked`)
+	defer deleteQuery(t, base, token, "rawreach")
+
+	const marker = "unscreened-do-marker"
+
+	status, body := authBody(t, base+"/_QUERIES/itest/rawreach?field1="+url.QueryEscape(marker), token)
+
+	require.Contains(t, []int{http.StatusOK, http.StatusBadRequest}, status)
+	require.NotContains(t, body, marker,
+		"the raw parameter map must not be reachable from a database-stored template")
+}

--- a/integration/postgres/controllers/queries_database_params_test.go
+++ b/integration/postgres/controllers/queries_database_params_test.go
@@ -2,7 +2,6 @@
 package controllers_test
 
 import (
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -45,18 +44,7 @@ func deleteQuery(t *testing.T, base, token, name string) {
 func authBody(t *testing.T, url, token string) (int, string) {
 	t.Helper()
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("X-Application", "prest")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	return resp.StatusCode, string(body)
+	return queriesRequest(t, http.MethodGet, url, token, nil)
 }
 
 // TestQueriesDatabase_ParameterScreenApplies proves a database-stored template is

--- a/integration/postgres/controllers/queries_database_test.go
+++ b/integration/postgres/controllers/queries_database_test.go
@@ -2,11 +2,69 @@
 package controllers_test
 
 import (
+	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/prest/prest/v2/integration/helpers"
+	"github.com/stretchr/testify/require"
 )
+
+// The queries server runs with storage = "database": every template under
+// testdata/queries is imported into prest_queries at startup and resolved from a
+// column, not from disk. Everything after resolution — the parameter screen, the
+// header screen, the binding helpers, the template function registry — is shared
+// with the filesystem server, but only three of those shapes were covered here.
+//
+// The tests below execute the imported copy of every template shape that
+// testdata/queries contains, mirroring the filesystem-mode assertions in
+// integration/suites/controllers/scripts_test.go so a divergence between the two
+// servers shows up as a failure rather than as silence. Two cases have no
+// filesystem counterpart and only exist here: a verb column that is empty, and
+// templates authored at runtime through the registry API.
+//
+// Grants are per location+name in testdata/prest_queries.toml (restrict = true).
+
+// queriesRequest runs an authenticated request against the queries server and
+// returns status and raw body. helpers.DoAuthRequest can only assert that a body
+// CONTAINS a string and takes no header map; several templates below need both
+// the negative assertion and a custom header.
+func queriesRequest(t *testing.T, method, url, token string, headers map[string]string) (int, string) {
+	t.Helper()
+
+	req, err := http.NewRequest(method, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Application", "prest")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}
+
+// registerQueryFull creates a template carrying any subset of the four verb
+// columns; registerQuery only sends read_sql.
+func registerQueryFull(t *testing.T, base, token, name string, verbs map[string]string) {
+	t.Helper()
+
+	payload := map[string]string{"location": "itest", "name": name}
+	for column, sql := range verbs {
+		payload[column] = sql
+	}
+
+	helpers.DoAuthRequest(t, base+"/_QUERIES/registry", payload,
+		http.MethodPost, token, http.StatusCreated, "RegisterQueryFull")
+}
 
 func TestQueriesDatabaseExecution(t *testing.T) {
 	base := helpers.QueriesServerURL(t)
@@ -47,4 +105,454 @@ func TestQueriesDatabaseExecution(t *testing.T) {
 	helpers.DoAuthRequest(
 		t, base+"/_QUERIES/itest/ephemeral",
 		nil, http.MethodGet, token, http.StatusBadRequest, "QueriesDBMissingAfterDelete")
+}
+
+// TestQueriesDatabase_HeaderHelpers covers the two templates that interpolate a
+// header inline. The credential case is stronger on this server than on the
+// filesystem one: every request here carries a real JWT, so the blanking of
+// Authorization is exercised with an actual secret rather than a fixture string.
+func TestQueriesDatabase_HeaderHelpers(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// get_header is `SELECT '{{index .header "X-Application"}}'`. A quote breakout
+	// in the header must be screened to an empty literal, not composed into SQL.
+	status, body := queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/fulltable/get_header", token,
+		map[string]string{"X-Application": "' UNION SELECT rolpassword::text FROM pg_authid --"})
+	require.Equal(t, http.StatusOK, status)
+	require.Contains(t, body, `""`, "the screened header renders as an empty literal")
+	require.NotContains(t, body, "rolpassword")
+
+	// A benign header value still reaches the query untouched.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/get_header",
+		nil, http.MethodGet, token, http.StatusOK, "DBHeaderInline", `"prest"`)
+
+	// get_auth_header is the same shape reading Authorization. The caller's token
+	// must never be interpolated into the SQL text (it is logged at debug level).
+	status, body = queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/fulltable/get_auth_header", token, nil)
+	require.Equal(t, http.StatusOK, status)
+	require.NotContains(t, body, token, "a bearer token must never reach the SQL text")
+}
+
+// TestQueriesDatabase_BoundHeaderValues covers `{{sqlVal "header.X"}}`, which
+// binds the UNSCREENED header value. Binding must not become a way around the
+// credential blanking, which is about secrecy rather than SQL composition.
+func TestQueriesDatabase_BoundHeaderValues(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// A phrase the inline screen would blank is bound verbatim and echoed back.
+	status, body := queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/fulltable/get_bound_header", token,
+		map[string]string{"X-Application": "compra do mes"})
+	require.Equal(t, http.StatusOK, status)
+	require.Contains(t, body, "compra do mes")
+
+	// The credential header binds empty even though a live token was sent.
+	status, body = queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/fulltable/get_bound_auth_header", token, nil)
+	require.Equal(t, http.StatusOK, status)
+	require.NotContains(t, body, token, "a bearer token must never be bindable into a query")
+}
+
+// TestQueriesDatabase_BoundPlaceholderOrdering checks that two bound values arrive
+// as $1 and $2 in the order the template names them, not in query-string order.
+// Wrong pairing would silently answer with another record's rows.
+func TestQueriesDatabase_BoundPlaceholderOrdering(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// get_bound_two: WHERE name = {{sqlVal "field1"}} AND surname = {{sqlVal "field2"}}.
+	// The seeded row is ('gopher', 'da silva'); matching it proves the pairing.
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/get_bound_two?field1=gopher&field2="+url.QueryEscape("da silva"),
+		nil, http.MethodGet, token, http.StatusOK, "DBBoundOrdering", "da silva")
+
+	// Swapping the values must match nothing — if the order were wrong, this is the
+	// request that would succeed.
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/get_bound_two?field1="+url.QueryEscape("da silva")+"&field2=gopher",
+		nil, http.MethodGet, token, http.StatusOK, "DBBoundOrderingSwapped", "[]")
+}
+
+// TestQueriesDatabase_ListHelpers covers the two IN-list helpers, which diverge on
+// purpose: inFormat interpolates, so a rejected element fails the request rather
+// than shrinking the list; sqlList binds, so the same payload is inert data.
+func TestQueriesDatabase_ListHelpers(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// All elements survive the screen: inFormat joins them into a quoted IN list.
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/get_all_slice?field1=nobody&field1=gopher",
+		nil, http.MethodGet, token, http.StatusOK, "DBSliceAllSafe", "gopher")
+
+	// One rejected element fails the whole request instead of querying a truncated list.
+	status, body := queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/fulltable/get_all_slice?field1=gopher&field1="+
+			url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"), token, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.NotContains(t, body, "pg_shadow")
+
+	// sqlList binds every element, so the seeded row still matches through the
+	// second value and the payload is data rather than syntax.
+	status, body = queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/fulltable/get_bound_list?field1=gopher&field1="+
+			url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"), token, nil)
+	require.Equal(t, http.StatusOK, status)
+	require.Contains(t, body, "gopher")
+	require.NotContains(t, body, "passwd")
+
+	// Single value: sqlList takes the non-slice branch and still renders ($1).
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/get_bound_list?field1=gopher",
+		nil, http.MethodGet, token, http.StatusOK, "DBBoundListSingle", "gopher")
+}
+
+// TestQueriesDatabase_IdentHelper covers `{{ident "field1"}}`. An identifier cannot
+// be bound, so ident validates it against a strict charset and double-quotes it;
+// a rejected one must fail without echoing the caller's value back.
+func TestQueriesDatabase_IdentHelper(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// A valid table name resolves and the query runs.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/get_ident?field1=test7",
+		nil, http.MethodGet, token, http.StatusOK, "DBIdent", "gopher")
+
+	var rejected = []struct {
+		description string
+		value       string
+	}{
+		{"quote breakout in an identifier", `test7"; DROP TABLE test7; --`},
+		{"identifier with a hyphen", "foo-bar"},
+		{"identifier starting with a digit", "1abc"},
+		{"empty identifier", ""},
+		{"whitespace composition", "test7 UNION SELECT 1"},
+	}
+	for _, tc := range rejected {
+		t.Log("ident rejects: " + tc.description)
+		status, body := queriesRequest(t, http.MethodGet,
+			base+"/_QUERIES/fulltable/get_ident?field1="+url.QueryEscape(tc.value), token, nil)
+		require.Equal(t, http.StatusBadRequest, status, tc.description)
+
+		// The template error names the template internals and the offending value;
+		// only the safe summary may reach the caller.
+		require.NotContains(t, body, "DROP TABLE", tc.description)
+		require.NotContains(t, body, "invalid identifier", tc.description)
+		require.Contains(t, body, "check your prest logs", tc.description)
+	}
+
+	// The DDL in the payload above must never have executed: test7 still answers.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/get_ident?field1=test7",
+		nil, http.MethodGet, token, http.StatusOK, "DBIdentTableIntact", "gopher")
+}
+
+// TestQueriesDatabase_LimitOffset covers both limitOffset fixtures: the one taking
+// caller-supplied pagination and the one with literal arguments. The bad-pagination
+// case pins a sharp edge rather than a fix — the clause vanishes instead of erroring.
+func TestQueriesDatabase_LimitOffset(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// Valid pagination: the clause renders and the query succeeds.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/get_limitoffset_params?page=1&size=1",
+		nil, http.MethodGet, token, http.StatusOK, "DBLimitOffsetValid", `"name"`)
+
+	// Literal arguments: no caller input involved, so it always renders.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/limitoffset",
+		nil, http.MethodGet, token, http.StatusOK, "DBLimitOffsetLiteral", `"name"`)
+
+	// Non-numeric page: the clause is dropped rather than erroring, and every row
+	// comes back. Documented-but-undesirable; pinned so it cannot change silently.
+	status, body := queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/fulltable/get_limitoffset_params?page=abc&size=1", token, nil)
+	require.Equal(t, http.StatusOK, status)
+	require.Contains(t, body, `"name"`,
+		"limitOffset drops the clause on a parse error, returning unpaginated rows")
+}
+
+// TestQueriesDatabase_DefaultOrValue covers `defaultOrValue`, whose interaction with
+// a refused parameter is easy to get wrong: the default applies only when the key is
+// absent, and a rejected value still occupies the key, so the request must fail
+// rather than quietly answer with the default's rows.
+func TestQueriesDatabase_DefaultOrValue(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// No parameter at all: the default "gopher" applies and the seeded row returns.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/funcs",
+		nil, http.MethodGet, token, http.StatusOK, "DBDefaultApplied", "gopher")
+
+	// A value that survives the screen overrides the default.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/funcs?field1=teste-do-abc",
+		nil, http.MethodGet, token, http.StatusOK, "DBDefaultOverridden", "[]")
+
+	// A rejected value fails instead of falling through to the default.
+	status, body := queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/fulltable/funcs?field1="+
+			url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"), token, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.NotContains(t, body, "gopher",
+		"a refused parameter must not fall through to the template default")
+}
+
+// TestQueriesDatabase_UnEscape is adversarial: unEscape URL-decodes its argument, so
+// a surviving percent-escape would let a template decode `%27` back into the quote
+// the screen exists to remove. `%` is itself outside the allow-list, so the payload
+// is refused one level earlier — load-bearing and undocumented, hence pinned.
+func TestQueriesDatabase_UnEscape(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// Plain value: unEscape is a no-op on a screened value.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/get_unescape?field1=gopher",
+		nil, http.MethodGet, token, http.StatusOK, "DBUnEscapePlain", "gopher")
+
+	var payloads = []struct {
+		description string
+		value       string
+	}{
+		{"single-encoded quote breakout", "%27 OR 1=1 --"},
+		{"double-encoded quote breakout", "%2527%20OR%201%3D1"},
+		{"double-encoded UNION arm", "%25%32%37 UNION SELECT passwd FROM pg_shadow"},
+	}
+	for _, tc := range payloads {
+		t.Log("unEscape cannot reconstruct SQL syntax: " + tc.description)
+		status, body := queriesRequest(t, http.MethodGet,
+			base+"/_QUERIES/fulltable/get_unescape?field1="+url.QueryEscape(tc.value), token, nil)
+		require.Equal(t, http.StatusBadRequest, status, tc.description)
+		require.NotContains(t, body, "pg_shadow", tc.description)
+	}
+}
+
+// TestQueriesDatabase_UnquotedContextInjection covers `WHERE 1 = {{.field1}}`, where
+// letters, digits and spaces alone compose SQL because there is no surrounding
+// quote to break out of. The keyword screen must refuse those payloads.
+func TestQueriesDatabase_UnquotedContextInjection(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// Baseline: a plain numeric value still reaches the query and succeeds.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/get_unquoted?field1=1",
+		nil, http.MethodGet, token, http.StatusOK, "DBUnquotedBenign")
+
+	var payloads = []struct {
+		description string
+		value       string
+	}{
+		{"UNION arm dumping a whole row via ::text", "1 UNION SELECT test7::text FROM test7"},
+		{"catalog read of role password hashes", "1 UNION SELECT passwd FROM pg_shadow"},
+		{"row-filter bypass needing no UNION", "1 OR true"},
+	}
+	for _, tc := range payloads {
+		t.Log("unquoted context refuses: " + tc.description)
+		status, body := queriesRequest(t, http.MethodGet,
+			base+"/_QUERIES/fulltable/get_unquoted?field1="+url.QueryEscape(tc.value), token, nil)
+		require.Equal(t, http.StatusBadRequest, status, tc.description)
+		require.NotContains(t, body, "pg_shadow", tc.description)
+	}
+}
+
+// TestQueriesDatabase_RawMapsUnreachableFromImportedTemplates completes the
+// containment check for the two fixtures the runtime-registered case in
+// queries_database_params_test.go does not use: rendering the whole raw parameter
+// map, and indexing the raw header map. Either outcome is acceptable — a 400
+// because the template failed to render, or a 200 whose body simply lacks the
+// value — but the unscreened input must never appear.
+func TestQueriesDatabase_RawMapsUnreachableFromImportedTemplates(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	var fixtures = []struct {
+		description string
+		script      string
+	}{
+		{"render the whole raw param map", "get_raw_param_dot"},
+		{"index into the raw param map", "get_raw_param_index"},
+		{"index into the raw header map", "get_raw_header_index"},
+	}
+
+	const payload = "1 UNION SELECT passwd FROM pg_shadow"
+
+	for _, f := range fixtures {
+		t.Log(f.description + " must not reach the caller's unscreened value")
+		status, body := queriesRequest(t, http.MethodGet,
+			base+"/_QUERIES/fulltable/"+f.script+"?field1="+url.QueryEscape(payload), token,
+			map[string]string{"X-Application": payload})
+
+		require.Contains(t, []int{http.StatusOK, http.StatusBadRequest}, status, f.description)
+		require.NotContains(t, body, "pg_shadow", f.description)
+		require.NotContains(t, body, "UNION", f.description)
+		require.NotContains(t, body, "passwd", f.description)
+	}
+}
+
+// TestQueriesDatabase_BoundWriteVerbs exercises POST, PUT/PATCH and DELETE against
+// the bound templates. In database mode each verb reads a different column of
+// prest_queries, so this is the only test that proves the verb→column mapping is
+// right for anything other than GET.
+//
+// test7 is shared with the filesystem suite, so the row uses a marker no other
+// test touches and is deleted at the end. The values carry a keyword and spaces,
+// which means they would be refused if the templates interpolated them.
+func TestQueriesDatabase_BoundWriteVerbs(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	const (
+		name    = "dbmode do write"
+		surname = "sobrenome do teste"
+		updated = "atualizado do teste"
+	)
+
+	// INSERT through bound parameters (write_sql column). rows_affected proves the
+	// statement ran with the real values rather than blanks.
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/write_bound?field1="+url.QueryEscape(name)+
+			"&field2="+url.QueryEscape(surname),
+		nil, http.MethodPost, token, http.StatusOK, "DBBoundInsert", `"rows_affected":1`)
+
+	// Read it back: the row must carry the exact values, so nothing was blanked.
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?field1="+url.QueryEscape(name),
+		nil, http.MethodGet, token, http.StatusOK, "DBBoundInsertReadback", surname)
+
+	// UPDATE through PUT (update_sql column).
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/update_bound?field1="+url.QueryEscape(name)+
+			"&field2="+url.QueryEscape(updated),
+		nil, http.MethodPut, token, http.StatusOK, "DBBoundUpdate", `"rows_affected":1`)
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?field1="+url.QueryEscape(name),
+		nil, http.MethodGet, token, http.StatusOK, "DBBoundUpdateReadback", updated)
+
+	// PATCH resolves the same column and must behave identically.
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/update_bound?field1="+url.QueryEscape(name)+
+			"&field2="+url.QueryEscape(surname),
+		nil, http.MethodPatch, token, http.StatusOK, "DBBoundPatch", `"rows_affected":1`)
+
+	// DELETE through a bound parameter (delete_sql column), then confirm it is gone.
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/delete_bound?field1="+url.QueryEscape(name),
+		nil, http.MethodDelete, token, http.StatusOK, "DBBoundDelete", `"rows_affected":1`)
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?field1="+url.QueryEscape(name),
+		nil, http.MethodGet, token, http.StatusOK, "DBBoundDeleteReadback", "[]")
+}
+
+// TestQueriesDatabase_InterpolatedWriteVerbs covers the write_all / put_all /
+// patch_all / delete_all shapes — values interpolated into the statement text —
+// on a template authored through the registry API, which is how an operator
+// creates one on this server. The on-disk fulltable copies stay ungranted because
+// queries_acl_test.go asserts that POST fulltable/write_all is refused.
+func TestQueriesDatabase_InterpolatedWriteVerbs(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	registerQueryFull(t, base, token, "wverbs", map[string]string{
+		"read_sql":   `SELECT * FROM test7 WHERE name = '{{.field1}}'`,
+		"write_sql":  `INSERT INTO test7 (name, surname) VALUES ('{{.field1}}', '{{.field2}}')`,
+		"update_sql": `UPDATE test7 SET surname = '{{.field2}}' WHERE name = '{{.field1}}'`,
+		"delete_sql": `DELETE FROM test7 WHERE name = '{{.field1}}'`,
+	})
+	defer deleteQuery(t, base, token, "wverbs")
+
+	// Single-token values pass the screen, so the row is written with real values.
+	const marker = "dbmode-interp-marker"
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/itest/wverbs?field1="+marker+"&field2=sobrenome-um",
+		nil, http.MethodPost, token, http.StatusOK, "DBInterpInsert", `"rows_affected":1`)
+	helpers.DoAuthRequest(t, base+"/_QUERIES/itest/wverbs?field1="+marker,
+		nil, http.MethodGet, token, http.StatusOK, "DBInterpReadback", "sobrenome-um")
+
+	// PUT and PATCH both resolve update_sql.
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/itest/wverbs?field1="+marker+"&field2=sobrenome-dois",
+		nil, http.MethodPut, token, http.StatusOK, "DBInterpUpdate", `"rows_affected":1`)
+	helpers.DoAuthRequest(t,
+		base+"/_QUERIES/itest/wverbs?field1="+marker+"&field2=sobrenome-tres",
+		nil, http.MethodPatch, token, http.StatusOK, "DBInterpPatch", `"rows_affected":1`)
+	helpers.DoAuthRequest(t, base+"/_QUERIES/itest/wverbs?field1="+marker,
+		nil, http.MethodGet, token, http.StatusOK, "DBInterpPatchReadback", "sobrenome-tres")
+
+	// A payload aimed at the mutating statement is refused before it composes.
+	status, body := queriesRequest(t, http.MethodPost,
+		base+"/_QUERIES/itest/wverbs?field1="+
+			url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow")+"&field2=x", token, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "field1", "the error must name the offending parameter")
+	require.NotContains(t, body, "pg_shadow", "the error must not echo the value")
+
+	// DELETE resolves delete_sql; the marker row is removed and the readback is empty.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/itest/wverbs?field1="+marker,
+		nil, http.MethodDelete, token, http.StatusOK, "DBInterpDelete", `"rows_affected":1`)
+	helpers.DoAuthRequest(t, base+"/_QUERIES/itest/wverbs?field1="+marker,
+		nil, http.MethodGet, token, http.StatusOK, "DBInterpDeleteReadback", "[]")
+}
+
+// TestQueriesDatabase_MissingVerbTemplate has no filesystem counterpart: on disk a
+// missing verb means a missing file, while here the row exists and only the column
+// for the requested verb is empty. That must fail the request rather than execute
+// an empty statement or fall back to another verb's SQL.
+func TestQueriesDatabase_MissingVerbTemplate(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// read_sql only; the grant carries "write" so the request reaches the resolver
+	// instead of being refused by the ACL, which is what makes this a resolver test.
+	registerQuery(t, base, token, "readonly", `SELECT 1 AS ok`)
+	defer deleteQuery(t, base, token, "readonly")
+
+	// GET works: the column it needs is populated.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/itest/readonly",
+		nil, http.MethodGet, token, http.StatusOK, "DBReadOnlyGet", "ok")
+
+	// POST asks for write_sql, which is empty.
+	status, body := queriesRequest(t, http.MethodPost, base+"/_QUERIES/itest/readonly", token, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "readonly", "the error must name the script that could not be loaded")
+}
+
+// TestQueriesDatabase_TemplateAndSQLErrors covers the failure fixtures: a template
+// that does not parse, a statement the database rejects, and the DDL shape of
+// create_table.write.sql. All three must surface as a 400 carrying only the safe
+// summary — never template internals or driver detail.
+func TestQueriesDatabase_TemplateAndSQLErrors(t *testing.T) {
+	base := helpers.QueriesServerURL(t)
+	token := helpers.LoginToken(t, base, queriesAdminUser, queriesAdminPass)
+
+	// parse_syntax_invalid has an unterminated action, so rendering fails.
+	status, body := queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/fulltable/parse_syntax_invalid?field1=gopher", token, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "check your prest logs")
+	require.NotContains(t, body, "unclosed action", "template internals stay in the logs")
+
+	// error/query_w_error selects from a table that does not exist: the statement
+	// renders fine and fails in the database.
+	status, body = queriesRequest(t, http.MethodGet,
+		base+"/_QUERIES/error/query_w_error", token, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "check your prest logs")
+	require.NotContains(t, body, "non_existing_table", "driver detail stays in the logs")
+
+	// The create_table shape: DDL with an interpolated identifier. Targeting the
+	// existing test7 makes the database refuse it, so the check is non-destructive.
+	registerQueryFull(t, base, token, "ddl", map[string]string{
+		"write_sql": `CREATE TABLE {{.field1}};`,
+	})
+	defer deleteQuery(t, base, token, "ddl")
+
+	status, body = queriesRequest(t, http.MethodPost,
+		base+"/_QUERIES/itest/ddl?field1=test7", token, nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "check your prest logs")
+
+	// test7 is intact — the failed DDL neither dropped nor replaced it.
+	helpers.DoAuthRequest(t, base+"/_QUERIES/fulltable/get_all?field1=gopher",
+		nil, http.MethodGet, token, http.StatusOK, "DBTableIntactAfterDDL", "gopher")
 }

--- a/integration/suites/controllers/scripts_test.go
+++ b/integration/suites/controllers/scripts_test.go
@@ -189,6 +189,86 @@ func TestExecuteFromScripts_RejectsUnquotedContextInjection(t *testing.T) {
 	}
 }
 
+// TestExecuteFromScripts_PreservesSingleTokenValues is the regression test for
+// issue #1030. The keyword screen used to blank any value containing a token like
+// `do` or `as`, which is a large share of Portuguese slugs — the reporter measured
+// 17.5% of a 226k-article catalog. The value came back as '', the query still ran,
+// and the endpoint returned HTTP 200 with a row belonging to a different record,
+// so callers could not tell that apart from a genuine miss.
+//
+// A single-token value cannot compose SQL (space is the only separator the
+// character allow-list permits), so it now passes through untouched.
+func TestExecuteFromScripts_PreservesSingleTokenValues(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// get_all.read.sql is `SELECT * FROM test7 WHERE name = '{{.field1}}'`. The
+	// slug reaches the query verbatim, so it matches nothing rather than matching
+	// the empty-name row.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_all?field1=teste-do-abc",
+		nil, "GET", http.StatusOK, "ExecuteFromScripts", "[]")
+
+	// Same for the other tokens the reporter hit.
+	for _, slug := range []string{"teste-as-abc", "teste-select-abc", "compra-do-mes"} {
+		t.Log("slug with an embedded SQL keyword token is preserved: " + slug)
+		testutils.DoRequest(t,
+			base+"/_QUERIES/fulltable/get_all?field1="+url.QueryEscape(slug),
+			nil, "GET", http.StatusOK, "ExecuteFromScripts", "[]")
+	}
+}
+
+// TestExecuteFromScripts_RejectsInterpolatedRejectedValue covers the other half of
+// issue #1030: a value the screen still refuses (multi-word, carrying a keyword)
+// must fail the request rather than be blanked into a query that returns the
+// wrong rows under HTTP 200.
+func TestExecuteFromScripts_RejectsInterpolatedRejectedValue(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_all?field1="+url.QueryEscape("compra do mes"),
+		nil, "GET", http.StatusBadRequest, "ExecuteFromScripts")
+}
+
+// TestExecuteFromScripts_BoundValueSkipsScreen proves the supported escape hatch:
+// a template that binds with sqlVal receives the caller's value untouched, because
+// a bound value is sent out of band and cannot compose SQL. This is the migration
+// path for full-text search and any other free-form input.
+func TestExecuteFromScripts_BoundValueSkipsScreen(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// get_bound.read.sql is `SELECT * FROM test7 WHERE name = {{sqlVal "field1"}}`.
+	// The phrase would be blanked if interpolated, yet here it reaches Postgres as
+	// a bound parameter and simply matches no row.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?field1="+url.QueryEscape("compra do mes"),
+		nil, "GET", http.StatusOK, "ExecuteFromScripts", "[]")
+
+	// An injection payload is equally inert once bound — it is data, not syntax.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?field1="+url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"),
+		nil, "GET", http.StatusOK, "ExecuteFromScripts", "[]")
+
+	// And a value that does exist still comes back.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?field1=gopher",
+		nil, "GET", http.StatusOK, "ExecuteFromScripts")
+}
+
+// Ordinary browser headers fail the character allow-list (parentheses, semicolons)
+// but are only blanked and logged — never a request failure — since every inbound
+// header is screened, not just the ones a template reads.
+func TestExecuteFromScripts_TolerantOfBrowserHeaders(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	headers := map[string]string{
+		"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+		"Referer":    "https://example.com/a/b?c=d&e=f",
+	}
+	testutils.DoRequestWithHeaders(t,
+		base+"/_QUERIES/fulltable/get_all?field1=gopher",
+		nil, "GET", http.StatusOK, "ExecuteFromScripts", headers)
+}
+
 // TestExecuteFromScripts_RejectsUnregisteredDatabase guards against
 // ScriptHandler.Execute reaching the connection layer with an arbitrary,
 // attacker-chosen database name via /_QUERIES/{database}/{queriesLocation}/{script}.

--- a/integration/suites/controllers/scripts_test.go
+++ b/integration/suites/controllers/scripts_test.go
@@ -2,12 +2,15 @@
 package controllers_test
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/prest/prest/v2/integration/helpers"
 	"github.com/prest/prest/v2/integration/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExecuteScriptQuery(t *testing.T) {
@@ -326,4 +329,447 @@ func TestRenderWithXML(t *testing.T) {
 		t.Log(tc.description)
 		testutils.DoRequest(t, base+tc.url, nil, tc.method, tc.status, "GetSchemas", tc.bodies...)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Script parameter pipeline (issue #1030 and the review findings that followed)
+//
+// testutils.DoRequest can only assert that a body CONTAINS a string, which
+// cannot express "the payload must not appear". scriptBody returns the raw body
+// so containment cases can assert the negative.
+// ---------------------------------------------------------------------------
+
+// scriptBody performs the request and returns status and body, asserting nothing.
+func scriptBody(t *testing.T, url, method string, headers map[string]string) (int, string) {
+	t.Helper()
+
+	req, err := http.NewRequest(method, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Application", "prest")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}
+
+// injectionPayloads are values that must never reach the SQL text intact. Each is
+// checked against the response with NotContains, so they carry a distinctive
+// marker (pg_shadow, rolpassword) that could only appear if the payload executed.
+var injectionPayloads = []string{
+	"1 UNION SELECT passwd FROM pg_shadow",
+	"1 UNION SELECT rolpassword::text FROM pg_authid",
+	"1 OR true",
+}
+
+// TestExecuteFromScripts_RawMapsUnreachableFromTemplate is the E2E half of the
+// review finding that `_param` / `_header` sat in the template's dot: a template
+// could read them with `{{index ._param "field1"}}` and interpolate the caller's
+// UNSCREENED value straight into the SQL, bypassing the screen entirely. A local
+// reproduction rendered `WHERE 1 = 0 UNION SELECT passwd FROM pg_shadow` verbatim.
+//
+// NewFuncRegistry now moves those maps off the template data, so the fixtures
+// below cannot reach them. Either outcome is acceptable — a 400 because the
+// template failed to render, or a 200 whose body simply lacks the payload — but
+// the value must never appear in the response.
+func TestExecuteFromScripts_RawMapsUnreachableFromTemplate(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	var fixtures = []struct {
+		description string
+		script      string
+	}{
+		{"index into the raw param map", "get_raw_param_index"},
+		{"render the whole raw param map", "get_raw_param_dot"},
+		{"index into the raw header map", "get_raw_header_index"},
+	}
+
+	for _, f := range fixtures {
+		for _, payload := range injectionPayloads {
+			t.Log(f.description + " with payload: " + payload)
+			status, body := scriptBody(t,
+				base+"/_QUERIES/fulltable/"+f.script+"?field1="+url.QueryEscape(payload),
+				"GET", map[string]string{"X-Application": payload})
+
+			require.NotContains(t, body, "pg_shadow", f.description)
+			require.NotContains(t, body, "pg_authid", f.description)
+			require.NotContains(t, body, "rolpassword", f.description)
+			require.NotContains(t, body, "UNION", f.description)
+			require.Contains(t, []int{http.StatusOK, http.StatusBadRequest}, status,
+				"unexpected status for %s", f.description)
+		}
+	}
+}
+
+// TestExecuteFromScripts_BoundPlaceholderOrdering checks that two bound values
+// arrive as $1 and $2 in the order the template names them, not the map order of
+// the query string. Binding the wrong value to the wrong column would silently
+// return another record's rows.
+func TestExecuteFromScripts_BoundPlaceholderOrdering(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// get_bound_two.read.sql: WHERE name = {{sqlVal "field1"}} AND surname = {{sqlVal "field2"}}
+	// The seeded row is ('gopher', 'da silva'); matching it proves the pairing.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound_two?field1=gopher&field2="+url.QueryEscape("da silva"),
+		nil, "GET", http.StatusOK, "BoundOrdering", `"name": "gopher"`)
+
+	// Swapping the values must match nothing — if the binding order were wrong,
+	// this would be the query that succeeds.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound_two?field1="+url.QueryEscape("da silva")+"&field2=gopher",
+		nil, "GET", http.StatusOK, "BoundOrderingSwapped", "[]")
+}
+
+// TestExecuteFromScripts_BoundListValues covers sqlList, which had no coverage at
+// all. It is the supported replacement for inFormat: values are bound as
+// ($1,$2,...) rather than joined into quoted SQL text.
+func TestExecuteFromScripts_BoundListValues(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// Repeated parameter: both values are bound, so the seeded row matches through
+	// the second element.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound_list?field1=nobody&field1=gopher",
+		nil, "GET", http.StatusOK, "BoundList", `"name": "gopher"`)
+
+	// Single value: sqlList takes the non-slice branch and still renders ($1).
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound_list?field1=gopher",
+		nil, "GET", http.StatusOK, "BoundListSingle", `"name": "gopher"`)
+
+	// A value the inline screen would reject is inert once bound: it matches no
+	// row rather than composing SQL or failing the request.
+	status, body := scriptBody(t,
+		base+"/_QUERIES/fulltable/get_bound_list?field1="+url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"),
+		"GET", nil)
+	require.Equal(t, http.StatusOK, status)
+	require.NotContains(t, body, "pg_shadow")
+}
+
+// TestExecuteFromScripts_BoundHeaderValues covers `{{sqlVal "header.X"}}`, which
+// binds the header's UNSCREENED value. The credential case is the one that
+// matters: blanking Authorization is about secrecy rather than SQL composition,
+// so binding must not become a way to read the caller's token back out.
+func TestExecuteFromScripts_BoundHeaderValues(t *testing.T) {
+	base := helpers.ServerURL(t)
+	token := "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJnb3BoZXIifQ.c2ln"
+
+	// A non-credential header binds its real value, spaces and all — the value
+	// would be blanked if it were interpolated instead.
+	testutils.DoRequestWithHeaders(t,
+		base+"/_QUERIES/fulltable/get_bound_header", nil, "GET", http.StatusOK,
+		"BoundHeader", map[string]string{"X-Application": "compra do mes"},
+		"compra do mes")
+
+	// The credential header binds empty even though a token was sent.
+	_, body := scriptBody(t, base+"/_QUERIES/fulltable/get_bound_auth_header", "GET",
+		map[string]string{"Authorization": token})
+	require.NotContains(t, body, "eyJhbGciOiJIUzI1NiJ9",
+		"a bearer token must never be bindable into a query")
+}
+
+// TestExecuteFromScripts_IdentQuotesIdentifiers covers the ident helper, which had
+// no coverage. An identifier cannot be bound as a parameter, so ident validates it
+// against a strict charset and double-quotes it instead.
+func TestExecuteFromScripts_IdentQuotesIdentifiers(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// A valid table name resolves and the query runs.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_ident?field1=test7",
+		nil, "GET", http.StatusOK, "Ident", `"name": "gopher"`)
+
+	var rejected = []struct {
+		description string
+		value       string
+	}{
+		{"quote breakout in an identifier", `test7"; DROP TABLE test7; --`},
+		{"identifier with a hyphen", "foo-bar"},
+		{"identifier starting with a digit", "1abc"},
+		{"empty identifier", ""},
+		{"whitespace composition", "test7 UNION SELECT 1"},
+	}
+	for _, tc := range rejected {
+		t.Log("ident rejects: " + tc.description)
+		status, body := scriptBody(t,
+			base+"/_QUERIES/fulltable/get_ident?field1="+url.QueryEscape(tc.value), "GET", nil)
+		require.Equal(t, http.StatusBadRequest, status, tc.description)
+
+		// The template error names the template internals and the offending value;
+		// it must not be reflected back to the caller, matching the policy applied
+		// to rejected parameters and to SQL failures.
+		require.NotContains(t, body, "DROP TABLE", tc.description)
+		require.NotContains(t, body, "invalid identifier", tc.description)
+		require.Contains(t, body, "check your prest logs", tc.description)
+	}
+
+	// The DDL in the payload above must never have executed: test7 still answers.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_ident?field1=test7",
+		nil, "GET", http.StatusOK, "IdentTableIntact", `"name": "gopher"`)
+}
+
+// TestExecuteFromScripts_ScreenedCharsetSurvives pins the characters the allow-list
+// permits. These are ordinary data — emails, dates, paths — and a regression that
+// blanked them would resurface issue #1030 in a different shape.
+func TestExecuteFromScripts_ScreenedCharsetSurvives(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	var values = []struct {
+		description string
+		value       string
+	}{
+		{"email address", "user@example.com"},
+		{"ISO date", "2024-01-01"},
+		{"path-like value", "a/b.c"},
+		{"identifier prefixed by a keyword", "order66"},
+		{"keyword joined by an underscore", "union_member"},
+		{"slug carrying a keyword token", "estatua-do-diabo"},
+	}
+	for _, tc := range values {
+		t.Log("value survives the screen: " + tc.description)
+		// get_all.read.sql interpolates into a quoted literal, so a surviving value
+		// simply matches no row; a blanked one would match the empty-name record.
+		testutils.DoRequest(t,
+			base+"/_QUERIES/fulltable/get_all?field1="+url.QueryEscape(tc.value),
+			nil, "GET", http.StatusOK, "CharsetSurvives", "[]")
+	}
+}
+
+// TestExecuteFromScripts_RejectionNamesParameterOnly checks the shape of the 400:
+// it must identify which parameter was refused so a caller can fix the request,
+// and must never echo the value back, which is attacker-controlled and may carry a
+// credential (CodeQL go/clear-text-logging).
+func TestExecuteFromScripts_RejectionNamesParameterOnly(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	status, body := scriptBody(t,
+		base+"/_QUERIES/fulltable/get_all?field1="+url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"),
+		"GET", nil)
+
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "field1", "the error must name the offending parameter")
+	require.NotContains(t, body, "pg_shadow", "the error must not echo the value")
+	require.Contains(t, body, "sqlVal", "the error should point at the supported alternative")
+
+	// The body must still be parseable JSON — a message containing quotes used to
+	// be interpolated raw and produced a body no client could decode.
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(body), &decoded))
+	require.NotEmpty(t, decoded["error"])
+}
+
+// TestExecuteFromScripts_ReservedKeysNotCallerControlled guards the collision the
+// review surfaced. `header`, `_header` and `_param` are template-data slots pREST
+// fills itself; a query parameter used to be able to overwrite them:
+//   - ?header=x replaced the screened header map with a string, so every template
+//     doing {{index .header "..."}} failed to render — a 400 on demand.
+//   - ?_header=x replaced the raw header map, so {{sqlVal "header.X"}} fell back
+//     to the screened value and bound "" for any header the charset screen
+//     rejects: wrong rows under HTTP 200, the failure class of issue #1030.
+func TestExecuteFromScripts_ReservedKeysNotCallerControlled(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// Inline header interpolation keeps working while the caller tries to clobber
+	// the map that backs it.
+	testutils.DoRequestWithHeaders(t,
+		base+"/_QUERIES/fulltable/get_header?header=x&_header=x&_param=x",
+		nil, "GET", http.StatusOK, "ReservedInline",
+		map[string]string{"X-Application": "prest"}, `"prest"`)
+
+	// Header binding still reaches the real, unscreened value.
+	testutils.DoRequestWithHeaders(t,
+		base+"/_QUERIES/fulltable/get_bound_header?_header=x",
+		nil, "GET", http.StatusOK, "ReservedBinding",
+		map[string]string{"X-Application": "compra do mes"}, "compra do mes")
+
+	// And parameter binding is likewise undisturbed.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?_param=x&field1=gopher",
+		nil, "GET", http.StatusOK, "ReservedParamBinding", `"name": "gopher"`)
+}
+
+// TestExecuteFromScripts_BoundWriteVerbs covers the bound path for the verbs that
+// mutate: POST, PUT/PATCH and DELETE all share the same screen and binding code
+// as GET, but none of them had coverage through sqlVal. The values used here would
+// be refused if interpolated (they carry a keyword and a space), which is exactly
+// what makes them worth writing with.
+//
+// test7 is shared mutable state across this suite, so these rows use a marker no
+// other test touches and are deleted at the end.
+func TestExecuteFromScripts_BoundWriteVerbs(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	const (
+		name    = "bound do write"    // rejected inline: keyword "do" plus spaces
+		surname = "sobrenome do teste"
+		updated = "atualizado do teste"
+	)
+
+	// INSERT through bound parameters. rows_affected proves the statement ran with
+	// the real values rather than blanks.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/write_bound?field1="+url.QueryEscape(name)+"&field2="+url.QueryEscape(surname),
+		nil, "POST", http.StatusOK, "BoundInsert", `"rows_affected":1`)
+
+	// Read it back through a bound SELECT: the row must carry the exact values,
+	// which also proves nothing was blanked on the way in.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?field1="+url.QueryEscape(name),
+		nil, "GET", http.StatusOK, "BoundInsertReadback", surname)
+
+	// UPDATE through bound parameters (PUT and PATCH share update_bound.update.sql).
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/update_bound?field1="+url.QueryEscape(name)+"&field2="+url.QueryEscape(updated),
+		nil, "PUT", http.StatusOK, "BoundUpdate", `"rows_affected":1`)
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?field1="+url.QueryEscape(name),
+		nil, "GET", http.StatusOK, "BoundUpdateReadback", updated)
+
+	// PATCH resolves to the same template; it must behave identically.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/update_bound?field1="+url.QueryEscape(name)+"&field2="+url.QueryEscape(surname),
+		nil, "PATCH", http.StatusOK, "BoundPatch", `"rows_affected":1`)
+
+	// DELETE through a bound parameter, then confirm the row is gone.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/delete_bound?field1="+url.QueryEscape(name),
+		nil, "DELETE", http.StatusOK, "BoundDelete", `"rows_affected":1`)
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_bound?field1="+url.QueryEscape(name),
+		nil, "GET", http.StatusOK, "BoundDeleteReadback", "[]")
+}
+
+// TestExecuteFromScripts_MultiValueParameterMatrix pins how a repeated query
+// parameter behaves in each helper. The type handed to the template changes when
+// one element is rejected ([]string becomes []interface{} so the marker can report
+// itself), and the two list helpers diverge deliberately: inFormat interpolates
+// and therefore fails, while sqlList binds and therefore succeeds.
+func TestExecuteFromScripts_MultiValueParameterMatrix(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// All elements survive the screen: inFormat joins them into a quoted IN list.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_all_slice?field1=nobody&field1=gopher",
+		nil, "GET", http.StatusOK, "SliceAllSafe", `"name": "gopher"`)
+
+	// One element is rejected. inFormat interpolates, so the marker renders and the
+	// request fails rather than silently querying a truncated list.
+	status, body := scriptBody(t,
+		base+"/_QUERIES/fulltable/get_all_slice?field1=gopher&field1="+url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"),
+		"GET", nil)
+	require.Equal(t, http.StatusBadRequest, status,
+		"a rejected element must fail the request, not shrink the IN list")
+	require.NotContains(t, body, "pg_shadow")
+
+	// The same request against the bound helper succeeds: every element is bound,
+	// so the payload is data and matches nothing.
+	status, body = scriptBody(t,
+		base+"/_QUERIES/fulltable/get_bound_list?field1=gopher&field1="+url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"),
+		"GET", nil)
+	require.Equal(t, http.StatusOK, status,
+		"bound list values are never screened, so the request must succeed")
+	require.Contains(t, body, `"name": "gopher"`)
+	require.NotContains(t, body, "passwd")
+}
+
+// TestExecuteFromScripts_UnEscapeCannotReintroduceQuotes is adversarial: unEscape
+// URL-decodes its argument, so if a percent-escape could survive the screen a
+// template using it would decode `%27` back into the quote the screen exists to
+// remove. It cannot, because `%` is itself outside the character allow-list — a
+// double-encoded payload is refused one level earlier. That is load-bearing and
+// undocumented, so it is pinned here.
+func TestExecuteFromScripts_UnEscapeCannotReintroduceQuotes(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// Plain value: unEscape is a no-op on a screened value (no percent-escape can
+	// survive the charset screen), so the query behaves like any quoted template.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_unescape?field1=gopher",
+		nil, "GET", http.StatusOK, "UnEscapePlain", `"name": "gopher"`)
+
+	var payloads = []struct {
+		description string
+		value       string
+	}{
+		{"single-encoded quote breakout", "%27 OR 1=1 --"},
+		{"double-encoded quote breakout", "%2527%20OR%201%3D1"},
+		{"double-encoded UNION arm", "%25%32%37 UNION SELECT passwd FROM pg_shadow"},
+	}
+	for _, tc := range payloads {
+		t.Log("unEscape cannot reconstruct SQL syntax: " + tc.description)
+		status, body := scriptBody(t,
+			base+"/_QUERIES/fulltable/get_unescape?field1="+url.QueryEscape(tc.value), "GET", nil)
+		require.Equal(t, http.StatusBadRequest, status, tc.description)
+		require.NotContains(t, body, "pg_shadow", tc.description)
+	}
+}
+
+// TestExecuteFromScripts_LimitOffsetSwallowsBadPagination documents a sharp edge
+// rather than a fix: limitOffset returns an empty string when its arguments do not
+// parse, so the whole LIMIT clause disappears and the script returns every row.
+// A caller sending ?page=abc turns a paginated endpoint into a full-table read.
+// Pinned so the behavior cannot change silently; worth revisiting separately.
+func TestExecuteFromScripts_LimitOffsetSwallowsBadPagination(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// Valid pagination: the clause renders and the query succeeds.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_limitoffset_params?page=1&size=1",
+		nil, "GET", http.StatusOK, "LimitOffsetValid", `"name"`)
+
+	// Non-numeric page: the clause vanishes instead of erroring, and every row is
+	// returned. This is the documented-but-undesirable behavior.
+	status, body := scriptBody(t,
+		base+"/_QUERIES/fulltable/get_limitoffset_params?page=abc&size=1", "GET", nil)
+	require.Equal(t, http.StatusOK, status)
+	require.Contains(t, body, `"name"`,
+		"limitOffset drops the clause on a parse error, returning unpaginated rows")
+}
+
+// TestExecuteFromScripts_DefaultOrValueWithRejectedParam covers an interaction that
+// is easy to get wrong: defaultOrValue applies its default only when the key is
+// absent, and a rejected value still occupies the key. So a refused parameter does
+// not quietly fall back to the default — the request fails, which is the right
+// outcome (falling back would answer with rows the caller did not ask for).
+func TestExecuteFromScripts_DefaultOrValueWithRejectedParam(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	// No parameter at all: the default applies and the seeded row comes back.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/funcs",
+		nil, "GET", http.StatusOK, "DefaultApplied", `"name": "gopher"`)
+
+	// A value that survives the screen overrides the default.
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/funcs?field1=teste-do-abc",
+		nil, "GET", http.StatusOK, "DefaultOverridden", "[]")
+
+	// A rejected value fails rather than silently reverting to "gopher".
+	status, body := scriptBody(t,
+		base+"/_QUERIES/fulltable/funcs?field1="+url.QueryEscape("1 UNION SELECT passwd FROM pg_shadow"),
+		"GET", nil)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.NotContains(t, body, "gopher",
+		"a refused parameter must not fall through to the template default")
+}
+
+// TestExecuteFromScripts_EmptyParameterIsNotRejected documents that an explicitly
+// empty value (?field1=) is legitimate input, not a rejection: it interpolates as
+// an empty literal and the request succeeds. Worth pinning because it is the one
+// case that still produces "no rows" without an error, and it must not be confused
+// with the blanking bug issue #1030 was about.
+func TestExecuteFromScripts_EmptyParameterIsNotRejected(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	testutils.DoRequest(t,
+		base+"/_QUERIES/fulltable/get_all?field1=",
+		nil, "GET", http.StatusOK, "EmptyParam", "[]")
 }

--- a/integration/suites/controllers/scripts_test.go
+++ b/integration/suites/controllers/scripts_test.go
@@ -77,6 +77,68 @@ func TestExecuteFromScripts_RejectsHeaderInjection(t *testing.T) {
 	)
 }
 
+// TestExecuteFromScripts_RejectsPathTraversal guards the path-injection alert
+// (CodeQL go/path-injection): the queries location and script name are joined onto
+// the configured queries directory to locate a .sql file on disk. A traversing
+// segment must never resolve to a file outside that directory — the request is
+// rejected, not served.
+func TestExecuteFromScripts_RejectsPathTraversal(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	var testCases = []struct {
+		description string
+		url         string
+		status      int
+	}{
+		// Backslash traversal: not a URL path separator, so unlike "../.." this
+		// reaches the handler as a literal segment instead of being path-cleaned
+		// into a redirect by the router. IsSafeSegment rejects it.
+		{
+			"GET script with backslash traversal in the location is rejected",
+			"/_QUERIES/" + url.PathEscape(`..\..`) + "/get_all?field1=gopher",
+			http.StatusBadRequest,
+		},
+		{
+			"GET script with backslash traversal in the name is rejected",
+			"/_QUERIES/fulltable/" + url.PathEscape(`..\..\get_all`),
+			http.StatusBadRequest,
+		},
+		// A dot is outside IsSafeSegment's allow-list, so a caller cannot name the
+		// on-disk file directly (get_all.read.sql) to sidestep the verb suffixing.
+		{
+			"GET script with a dotted segment is rejected",
+			"/_QUERIES/fulltable/get_all.read",
+			http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Log(tc.description)
+		testutils.DoRequest(t, base+tc.url, nil, "GET", tc.status, "ExecuteFromScripts")
+	}
+}
+
+// TestExecuteFromScripts_DropsCredentialHeaders guards the credential leak where
+// a script template referencing a credential header interpolated the caller's
+// bearer token into the SQL text, which the adapter then logged at debug level
+// (CodeQL go/clear-text-logging, adapters/postgres/postgres.go QueryCtx).
+// sanitizeScriptParam does not help here: a JWT is plain base64url and passes its
+// allow-list untouched. extractHeaders now blanks credential headers, so the
+// template renders an empty literal and the token never reaches the SQL string.
+func TestExecuteFromScripts_DropsCredentialHeaders(t *testing.T) {
+	base := helpers.ServerURL(t)
+
+	token := "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJnb3BoZXIifQ.c2ln"
+
+	// get_auth_header.read.sql is `SELECT '{{index .header "Authorization"}}'`.
+	// The request still succeeds; the echoed column is empty, not the token.
+	testutils.DoRequestWithHeaders(
+		t, base+"/_QUERIES/fulltable/get_auth_header", nil, "GET", http.StatusOK,
+		"ExecuteFromScripts", map[string]string{"Authorization": token},
+		`[{"?column?": ""}]`,
+	)
+}
+
 // TestExecuteFromScripts_RejectsUnquotedContextInjection guards the
 // unauthenticated read-only SQL injection that survived the CVE-2025-58450 fix:
 // sanitizeScriptParam's character allow-list blocks quotes, commas and

--- a/template/funcregistry.go
+++ b/template/funcregistry.go
@@ -92,17 +92,60 @@ func (fr *FuncRegistry) limitOffset(pageNumber, pageSize string) (value string) 
 	return
 }
 
+// Reserved TemplateData keys holding the caller's unscreened values, published by
+// the controller. Kept in sync with controllers.rawParamKey / rawHeaderKey.
+const (
+	rawParamKey  = "_param"
+	rawHeaderKey = "_header"
+)
+
+// headerKeyPrefix addresses a header from the binding helpers, e.g.
+// {{sqlVal "header.X-Application"}}, mirroring the `header` map templates read
+// for inline interpolation.
+const headerKeyPrefix = "header."
+
+// boundValue resolves the value to bind for key.
+//
+// The controller screens values for SQL syntax before a template sees them,
+// because an interpolated value becomes part of the SQL text. A bound value never
+// does — the driver sends it separately — so binding the screened version would
+// discard the caller's data for no safety gain: searching for a phrase containing
+// a SQL keyword would bind an empty string (issue #1030). The raw maps are
+// therefore consulted first, falling back to TemplateData for keys the template
+// author set itself (defaultOrValue, split, and so on).
+//
+// Credential headers are already blanked in the raw map by the controller, so
+// binding cannot be used to smuggle one into a query.
+func (fr *FuncRegistry) boundValue(key string) interface{} {
+	if name, ok := strings.CutPrefix(key, headerKeyPrefix); ok {
+		if headers, ok := fr.TemplateData[rawHeaderKey].(map[string]interface{}); ok {
+			if v, ok := headers[name]; ok {
+				return v
+			}
+		}
+		if headers, ok := fr.TemplateData["header"].(map[string]interface{}); ok {
+			return headers[name]
+		}
+		return nil
+	}
+	if params, ok := fr.TemplateData[rawParamKey].(map[string]interface{}); ok {
+		if v, ok := params[key]; ok {
+			return v
+		}
+	}
+	return fr.TemplateData[key]
+}
+
 // sqlVal returns a positional placeholder for a single value and stores it in Args
 func (fr *FuncRegistry) sqlVal(key string) string {
-	v := fr.TemplateData[key]
-	fr.Args = append(fr.Args, v)
+	fr.Args = append(fr.Args, fr.boundValue(key))
 	fr.next++
 	return fmt.Sprintf("$%d", fr.next)
 }
 
 // sqlList returns a parenthesized, comma-separated list of placeholders for a slice value
 func (fr *FuncRegistry) sqlList(key string) string {
-	if s, ok := fr.TemplateData[key].([]string); ok {
+	if s, ok := fr.boundValue(key).([]string); ok {
 		ph := make([]string, len(s))
 		for i := range s {
 			fr.Args = append(fr.Args, s[i])
@@ -111,13 +154,19 @@ func (fr *FuncRegistry) sqlList(key string) string {
 		}
 		return fmt.Sprintf("(%s)", strings.Join(ph, ","))
 	}
-	fr.Args = append(fr.Args, fr.TemplateData[key])
+	fr.Args = append(fr.Args, fr.boundValue(key))
 	fr.next++
 	return fmt.Sprintf("($%d)", fr.next)
 }
 
-// ident validates and safely quotes an identifier (optionally dotted path)
+// ident validates and safely quotes an identifier (optionally dotted path).
+//
+// Resolves the raw value like the binding helpers: an identifier cannot be bound,
+// but ident.Quote validates it against a strict charset and quotes it, which is a
+// stronger guarantee than the keyword screen — a table legitimately named `order`
+// is quoted rather than blanked. An invalid identifier returns an error, which
+// aborts template rendering.
 func (fr *FuncRegistry) ident(key string) (string, error) {
-	s, _ := fr.TemplateData[key].(string)
+	s, _ := fr.boundValue(key).(string)
 	return ident.Quote(s)
 }

--- a/template/funcregistry.go
+++ b/template/funcregistry.go
@@ -10,11 +10,54 @@ import (
 	"github.com/prest/prest/v2/internal/ident"
 )
 
+// Keys under which the controller hands over the caller's unscreened values.
+// NewFuncRegistry removes them from TemplateData immediately, so they exist only
+// in transit. Kept in sync with controllers.rawParamKey / rawHeaderKey.
+const (
+	rawParamKey  = "_param"
+	rawHeaderKey = "_header"
+	// headerKeyPrefix addresses a header from the binding helpers, e.g.
+	// {{sqlVal "header.X-Application"}}, mirroring the `header` map templates read
+	// for inline interpolation.
+	headerKeyPrefix = "header."
+)
+
 // FuncRegistry registry func for templates
 type FuncRegistry struct {
 	TemplateData map[string]interface{}
 	Args         []interface{}
 	next         int
+
+	// Unscreened request values, reachable only through the binding helpers.
+	// Deliberately not in TemplateData: that map is the template's dot, so a
+	// template could otherwise reach them with `{{index ._param "x"}}` and
+	// interpolate an unscreened value straight into the SQL text — silently
+	// bypassing the very screen the helpers exist to make unnecessary.
+	rawParams  map[string]interface{}
+	rawHeaders map[string]interface{}
+}
+
+// NewFuncRegistry builds a registry for templateData, moving the reserved raw
+// value maps out of it so they can be bound but never interpolated.
+func NewFuncRegistry(templateData map[string]interface{}) *FuncRegistry {
+	fr := &FuncRegistry{TemplateData: templateData}
+	fr.rawParams = takeRawMap(templateData, rawParamKey)
+	fr.rawHeaders = takeRawMap(templateData, rawHeaderKey)
+	return fr
+}
+
+// takeRawMap removes key from data and returns it as a map.
+func takeRawMap(data map[string]interface{}, key string) map[string]interface{} {
+	if data == nil {
+		return nil
+	}
+	value, ok := data[key]
+	if !ok {
+		return nil
+	}
+	delete(data, key)
+	m, _ := value.(map[string]interface{})
+	return m
 }
 
 // RegistryAllFuncs for template
@@ -92,18 +135,6 @@ func (fr *FuncRegistry) limitOffset(pageNumber, pageSize string) (value string) 
 	return
 }
 
-// Reserved TemplateData keys holding the caller's unscreened values, published by
-// the controller. Kept in sync with controllers.rawParamKey / rawHeaderKey.
-const (
-	rawParamKey  = "_param"
-	rawHeaderKey = "_header"
-)
-
-// headerKeyPrefix addresses a header from the binding helpers, e.g.
-// {{sqlVal "header.X-Application"}}, mirroring the `header` map templates read
-// for inline interpolation.
-const headerKeyPrefix = "header."
-
 // boundValue resolves the value to bind for key.
 //
 // The controller screens values for SQL syntax before a template sees them,
@@ -118,20 +149,16 @@ const headerKeyPrefix = "header."
 // binding cannot be used to smuggle one into a query.
 func (fr *FuncRegistry) boundValue(key string) interface{} {
 	if name, ok := strings.CutPrefix(key, headerKeyPrefix); ok {
-		if headers, ok := fr.TemplateData[rawHeaderKey].(map[string]interface{}); ok {
-			if v, ok := headers[name]; ok {
-				return v
-			}
+		if v, ok := fr.rawHeaders[name]; ok {
+			return v
 		}
 		if headers, ok := fr.TemplateData["header"].(map[string]interface{}); ok {
 			return headers[name]
 		}
 		return nil
 	}
-	if params, ok := fr.TemplateData[rawParamKey].(map[string]interface{}); ok {
-		if v, ok := params[key]; ok {
-			return v
-		}
+	if v, ok := fr.rawParams[key]; ok {
+		return v
 	}
 	return fr.TemplateData[key]
 }

--- a/template/funcregistry_test.go
+++ b/template/funcregistry_test.go
@@ -142,3 +142,115 @@ func TestLimitOffset(t *testing.T) {
 		t.Errorf("expected '%s', bug got %s", "", value)
 	}
 }
+
+// The controller screens values for SQL syntax before they reach a template,
+// because an interpolated value lands in the SQL text. A bound value does not:
+// the driver sends it out of band, so composition is impossible by construction.
+// sqlVal must therefore bind the caller's real value, not the screened one —
+// otherwise searching for "compra do mes" binds an empty string (issue #1030).
+func TestSQLVal_BindsRawValue(t *testing.T) {
+	t.Parallel()
+
+	funcs := &FuncRegistry{
+		TemplateData: map[string]interface{}{
+			"phrase":  "", // screened to empty by the controller
+			"_param":  map[string]interface{}{"phrase": "compra do mes"},
+			"another": "kept",
+		},
+	}
+
+	if got := funcs.sqlVal("phrase"); got != "$1" {
+		t.Errorf("expected placeholder $1, got %s", got)
+	}
+	if got := funcs.sqlVal("another"); got != "$2" {
+		t.Errorf("expected placeholder $2, got %s", got)
+	}
+
+	if len(funcs.Args) != 2 {
+		t.Fatalf("expected 2 bound args, got %d", len(funcs.Args))
+	}
+	if funcs.Args[0] != "compra do mes" {
+		t.Errorf("expected the raw value to be bound, got %v", funcs.Args[0])
+	}
+	// A key with no raw entry falls back to TemplateData, so template-author
+	// supplied keys keep working.
+	if funcs.Args[1] != "kept" {
+		t.Errorf("expected fallback to TemplateData, got %v", funcs.Args[1])
+	}
+}
+
+func TestSQLVal_BindsRawHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	funcs := &FuncRegistry{
+		TemplateData: map[string]interface{}{
+			"_header": map[string]interface{}{"X-Application": "prest do brasil"},
+		},
+	}
+
+	if got := funcs.sqlVal("header.X-Application"); got != "$1" {
+		t.Errorf("expected placeholder $1, got %s", got)
+	}
+	if len(funcs.Args) != 1 || funcs.Args[0] != "prest do brasil" {
+		t.Errorf("expected the raw header value to be bound, got %v", funcs.Args)
+	}
+}
+
+func TestSQLList_BindsRawValues(t *testing.T) {
+	t.Parallel()
+
+	funcs := &FuncRegistry{
+		TemplateData: map[string]interface{}{
+			"tags":   []string{"", ""},
+			"_param": map[string]interface{}{"tags": []string{"a or b", "plain"}},
+		},
+	}
+
+	if got := funcs.sqlList("tags"); got != "($1,$2)" {
+		t.Errorf("expected ($1,$2), got %s", got)
+	}
+	if len(funcs.Args) != 2 || funcs.Args[0] != "a or b" || funcs.Args[1] != "plain" {
+		t.Errorf("expected the raw values to be bound in order, got %v", funcs.Args)
+	}
+}
+
+func TestSQLList_NonSliceBindsSingleValue(t *testing.T) {
+	t.Parallel()
+
+	funcs := &FuncRegistry{
+		TemplateData: map[string]interface{}{
+			"_param": map[string]interface{}{"tag": "solo"},
+		},
+	}
+
+	if got := funcs.sqlList("tag"); got != "($1)" {
+		t.Errorf("expected ($1), got %s", got)
+	}
+	if len(funcs.Args) != 1 || funcs.Args[0] != "solo" {
+		t.Errorf("expected the raw value to be bound, got %v", funcs.Args)
+	}
+}
+
+func TestIdent_QuotesAndRejects(t *testing.T) {
+	t.Parallel()
+
+	funcs := &FuncRegistry{
+		TemplateData: map[string]interface{}{
+			"good": "public.users",
+			"bad":  `users"; DROP TABLE x; --`,
+		},
+	}
+
+	got, err := funcs.ident("good")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != `"public"."users"` {
+		t.Errorf(`expected "public"."users", got %s`, got)
+	}
+
+	// An identifier cannot be bound, so an invalid one must abort rendering.
+	if _, err := funcs.ident("bad"); err == nil {
+		t.Error("expected an error for an unsafe identifier")
+	}
+}

--- a/template/funcregistry_test.go
+++ b/template/funcregistry_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"text/template"
 )
 
 func TestIsSet(t *testing.T) {
@@ -151,13 +152,11 @@ func TestLimitOffset(t *testing.T) {
 func TestSQLVal_BindsRawValue(t *testing.T) {
 	t.Parallel()
 
-	funcs := &FuncRegistry{
-		TemplateData: map[string]interface{}{
-			"phrase":  "", // screened to empty by the controller
-			"_param":  map[string]interface{}{"phrase": "compra do mes"},
-			"another": "kept",
-		},
-	}
+	funcs := NewFuncRegistry(map[string]interface{}{
+		"phrase":  "", // screened to empty by the controller
+		"_param":  map[string]interface{}{"phrase": "compra do mes"},
+		"another": "kept",
+	})
 
 	if got := funcs.sqlVal("phrase"); got != "$1" {
 		t.Errorf("expected placeholder $1, got %s", got)
@@ -182,11 +181,9 @@ func TestSQLVal_BindsRawValue(t *testing.T) {
 func TestSQLVal_BindsRawHeaderValue(t *testing.T) {
 	t.Parallel()
 
-	funcs := &FuncRegistry{
-		TemplateData: map[string]interface{}{
-			"_header": map[string]interface{}{"X-Application": "prest do brasil"},
-		},
-	}
+	funcs := NewFuncRegistry(map[string]interface{}{
+		"_header": map[string]interface{}{"X-Application": "prest do brasil"},
+	})
 
 	if got := funcs.sqlVal("header.X-Application"); got != "$1" {
 		t.Errorf("expected placeholder $1, got %s", got)
@@ -199,12 +196,10 @@ func TestSQLVal_BindsRawHeaderValue(t *testing.T) {
 func TestSQLList_BindsRawValues(t *testing.T) {
 	t.Parallel()
 
-	funcs := &FuncRegistry{
-		TemplateData: map[string]interface{}{
-			"tags":   []string{"", ""},
-			"_param": map[string]interface{}{"tags": []string{"a or b", "plain"}},
-		},
-	}
+	funcs := NewFuncRegistry(map[string]interface{}{
+		"tags":   []string{"", ""},
+		"_param": map[string]interface{}{"tags": []string{"a or b", "plain"}},
+	})
 
 	if got := funcs.sqlList("tags"); got != "($1,$2)" {
 		t.Errorf("expected ($1,$2), got %s", got)
@@ -217,11 +212,9 @@ func TestSQLList_BindsRawValues(t *testing.T) {
 func TestSQLList_NonSliceBindsSingleValue(t *testing.T) {
 	t.Parallel()
 
-	funcs := &FuncRegistry{
-		TemplateData: map[string]interface{}{
-			"_param": map[string]interface{}{"tag": "solo"},
-		},
-	}
+	funcs := NewFuncRegistry(map[string]interface{}{
+		"_param": map[string]interface{}{"tag": "solo"},
+	})
 
 	if got := funcs.sqlList("tag"); got != "($1)" {
 		t.Errorf("expected ($1), got %s", got)
@@ -234,12 +227,15 @@ func TestSQLList_NonSliceBindsSingleValue(t *testing.T) {
 func TestIdent_QuotesAndRejects(t *testing.T) {
 	t.Parallel()
 
-	funcs := &FuncRegistry{
-		TemplateData: map[string]interface{}{
+	// "good" is empty in TemplateData, so a passing assertion proves ident
+	// resolved the raw value rather than the screened one.
+	funcs := NewFuncRegistry(map[string]interface{}{
+		"good": "",
+		"bad":  `users"; DROP TABLE x; --`,
+		"_param": map[string]interface{}{
 			"good": "public.users",
-			"bad":  `users"; DROP TABLE x; --`,
 		},
-	}
+	})
 
 	got, err := funcs.ident("good")
 	if err != nil {
@@ -252,5 +248,63 @@ func TestIdent_QuotesAndRejects(t *testing.T) {
 	// An identifier cannot be bound, so an invalid one must abort rendering.
 	if _, err := funcs.ident("bad"); err == nil {
 		t.Error("expected an error for an unsafe identifier")
+	}
+}
+
+// The raw values must never be reachable from the template's dot. They live in
+// TemplateData only in transit from the controller: if a template could read
+// `{{index ._param "x"}}`, it would interpolate an unscreened value straight into
+// the SQL text, bypassing the screen the binding helpers exist to replace.
+func TestNewFuncRegistry_RawValuesUnreachableFromTemplate(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]interface{}{
+		"field1":  "", // screened to empty by the controller
+		"_param":  map[string]interface{}{"field1": "0 UNION SELECT passwd FROM pg_shadow"},
+		"_header": map[string]interface{}{"X-Application": "0 OR true"},
+	}
+	funcs := NewFuncRegistry(data)
+
+	if _, ok := funcs.TemplateData["_param"]; ok {
+		t.Error("_param must be removed from the template data")
+	}
+	if _, ok := funcs.TemplateData["_header"]; ok {
+		t.Error("_header must be removed from the template data")
+	}
+
+	// Reaching for them now either fails the template or renders nothing; what
+	// matters is that the value never lands in the SQL text.
+	for _, body := range []string{
+		`WHERE 1 = {{index ._param "field1"}}`,
+		`WHERE 1 = {{._param}}`,
+		`WHERE 1 = {{index ._header "X-Application"}}`,
+	} {
+		tpl, err := template.New("t").Funcs(funcs.RegistryAllFuncs()).Parse(body)
+		if err != nil {
+			t.Fatalf("unexpected parse error for %s: %v", body, err)
+		}
+		var buf strings.Builder
+		if err := tpl.Execute(&buf, funcs.TemplateData); err != nil {
+			continue // rendering failed outright, which is stronger than empty
+		}
+		if got := buf.String(); strings.Contains(got, "UNION") || strings.Contains(got, "OR true") {
+			t.Errorf("unscreened value leaked into the rendered SQL for %s: %s", body, got)
+		}
+	}
+
+	// Binding still reaches the raw value, which is the whole point.
+	tpl, err := template.New("bound").Funcs(funcs.RegistryAllFuncs()).Parse(`WHERE name = {{sqlVal "field1"}}`)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	var buf strings.Builder
+	if err := tpl.Execute(&buf, funcs.TemplateData); err != nil {
+		t.Fatalf("unexpected execute error: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "$1") {
+		t.Errorf("expected sqlVal to render a placeholder, got: %s", got)
+	}
+	if len(funcs.Args) != 1 || funcs.Args[0] != "0 UNION SELECT passwd FROM pg_shadow" {
+		t.Errorf("expected the raw value to be bound, got %v", funcs.Args)
 	}
 }

--- a/testdata/prest_queries.toml
+++ b/testdata/prest_queries.toml
@@ -38,6 +38,26 @@ location = "itest"
 name = "ephemeral"
 permissions = ["read"]
 
+# Templates registered at runtime by the script-parameter tests
+# (integration/postgres/controllers/queries_database_params_test.go). They verify
+# that the parameter screen and the sqlVal binding helpers behave identically when
+# a template lives in prest_queries instead of on disk. Grants are per
+# location+name, so each needs an entry.
+[[queries.scripts]]
+location = "itest"
+name = "screened"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "itest"
+name = "bound"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "itest"
+name = "rawreach"
+permissions = ["read"]
+
 [[queries.users]]
 name = "test@postgres.rest"
   [[queries.users.scripts]]
@@ -47,4 +67,16 @@ name = "test@postgres.rest"
   [[queries.users.scripts]]
   location = "itest"
   name = "ephemeral"
+  permissions = ["read"]
+  [[queries.users.scripts]]
+  location = "itest"
+  name = "screened"
+  permissions = ["read"]
+  [[queries.users.scripts]]
+  location = "itest"
+  name = "bound"
+  permissions = ["read"]
+  [[queries.users.scripts]]
+  location = "itest"
+  name = "rawreach"
   permissions = ["read"]

--- a/testdata/prest_queries.toml
+++ b/testdata/prest_queries.toml
@@ -58,6 +58,148 @@ location = "itest"
 name = "rawreach"
 permissions = ["read"]
 
+# Templates imported from testdata/queries at startup (import_on_startup) and
+# executed in database mode by integration/postgres/controllers/queries_database_test.go,
+# which mirrors the filesystem-mode coverage in integration/suites/controllers/scripts_test.go.
+# Grants are per location+name and default-deny, so every template exercised needs
+# an entry here. Only the global block is needed: a [[queries.users.scripts]] rule
+# replaces the global verdict when it matches, and none of the names below match one.
+#
+# fulltable/write_all deliberately stays ungranted — queries_acl_test.go asserts
+# that POST on it is refused. The interpolated write verbs are covered with
+# runtime-registered itest templates instead.
+[[queries.scripts]]
+location = "fulltable"
+name = "get_bound"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_bound_two"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_bound_list"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_bound_header"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_bound_auth_header"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_all_slice"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_header"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_auth_header"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_ident"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_limitoffset_params"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "limitoffset"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "funcs"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_unescape"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_unquoted"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_raw_param_dot"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_raw_param_index"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "get_raw_header_index"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "parse_syntax_invalid"
+permissions = ["read"]
+
+[[queries.scripts]]
+location = "error"
+name = "query_w_error"
+permissions = ["read"]
+
+# Write verbs through bound parameters. PUT and PATCH resolve the update_sql
+# column but ask for the "write" permission — there is no "update" permission
+# string (middlewares/statements/permissions.go) — so update_bound is granted write.
+[[queries.scripts]]
+location = "fulltable"
+name = "write_bound"
+permissions = ["write"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "update_bound"
+permissions = ["write"]
+
+[[queries.scripts]]
+location = "fulltable"
+name = "delete_bound"
+permissions = ["delete"]
+
+# Registered at runtime by queries_database_test.go: wverbs carries all four verb
+# columns (the interpolated write-verb shapes), readonly carries read_sql only so
+# a POST reaches the resolver and fails on the missing column, and ddl reproduces
+# create_table.write.sql.
+[[queries.scripts]]
+location = "itest"
+name = "wverbs"
+permissions = ["read", "write", "delete"]
+
+[[queries.scripts]]
+location = "itest"
+name = "readonly"
+permissions = ["read", "write"]
+
+[[queries.scripts]]
+location = "itest"
+name = "ddl"
+permissions = ["write"]
+
 [[queries.users]]
 name = "test@postgres.rest"
   [[queries.users.scripts]]

--- a/testdata/queries/fulltable/delete_bound.delete.sql
+++ b/testdata/queries/fulltable/delete_bound.delete.sql
@@ -1,0 +1,1 @@
+DELETE FROM test7 WHERE name = {{sqlVal "field1"}}

--- a/testdata/queries/fulltable/get_auth_header.read.sql
+++ b/testdata/queries/fulltable/get_auth_header.read.sql
@@ -1,0 +1,1 @@
+SELECT '{{index .header "Authorization"}}'

--- a/testdata/queries/fulltable/get_bound.read.sql
+++ b/testdata/queries/fulltable/get_bound.read.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test7 WHERE name = {{sqlVal "field1"}}

--- a/testdata/queries/fulltable/get_bound_auth_header.read.sql
+++ b/testdata/queries/fulltable/get_bound_auth_header.read.sql
@@ -1,0 +1,1 @@
+SELECT {{sqlVal "header.Authorization"}} AS bound_auth

--- a/testdata/queries/fulltable/get_bound_header.read.sql
+++ b/testdata/queries/fulltable/get_bound_header.read.sql
@@ -1,0 +1,1 @@
+SELECT {{sqlVal "header.X-Application"}} AS bound_header

--- a/testdata/queries/fulltable/get_bound_list.read.sql
+++ b/testdata/queries/fulltable/get_bound_list.read.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test7 WHERE name IN {{sqlList "field1"}}

--- a/testdata/queries/fulltable/get_bound_two.read.sql
+++ b/testdata/queries/fulltable/get_bound_two.read.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test7 WHERE name = {{sqlVal "field1"}} AND surname = {{sqlVal "field2"}}

--- a/testdata/queries/fulltable/get_ident.read.sql
+++ b/testdata/queries/fulltable/get_ident.read.sql
@@ -1,0 +1,1 @@
+SELECT * FROM {{ident "field1"}}

--- a/testdata/queries/fulltable/get_limitoffset_params.read.sql
+++ b/testdata/queries/fulltable/get_limitoffset_params.read.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test7 {{limitOffset .page .size}}

--- a/testdata/queries/fulltable/get_raw_header_index.read.sql
+++ b/testdata/queries/fulltable/get_raw_header_index.read.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test7 WHERE 1 = {{index ._header "X-Application"}}

--- a/testdata/queries/fulltable/get_raw_param_dot.read.sql
+++ b/testdata/queries/fulltable/get_raw_param_dot.read.sql
@@ -1,0 +1,1 @@
+SELECT '{{._param}}' AS leaked

--- a/testdata/queries/fulltable/get_raw_param_index.read.sql
+++ b/testdata/queries/fulltable/get_raw_param_index.read.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test7 WHERE 1 = {{index ._param "field1"}}

--- a/testdata/queries/fulltable/get_unescape.read.sql
+++ b/testdata/queries/fulltable/get_unescape.read.sql
@@ -1,0 +1,1 @@
+SELECT * FROM test7 WHERE name = '{{unEscape .field1}}'

--- a/testdata/queries/fulltable/update_bound.update.sql
+++ b/testdata/queries/fulltable/update_bound.update.sql
@@ -1,0 +1,1 @@
+UPDATE test7 SET surname = {{sqlVal "field2"}} WHERE name = {{sqlVal "field1"}}

--- a/testdata/queries/fulltable/write_bound.write.sql
+++ b/testdata/queries/fulltable/write_bound.write.sql
@@ -1,0 +1,1 @@
+INSERT INTO test7 (name, surname) VALUES ({{sqlVal "field1"}}, {{sqlVal "field2"}})


### PR DESCRIPTION
- Added permissions for write access to contents and issues in build and duplicate issue detector workflows.
- Updated lint workflow to include read permissions for contents.
- Enhanced SQL logging in the Postgres adapter to avoid logging sensitive parameter values, replacing them with a count of parameters.
- Implemented path traversal protection in script handling to prevent unauthorized file access.
- Added tests to ensure credential headers are dropped and path traversal is rejected, enhancing security measures.

fixes #1030 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Blocked SQL script path traversal and unsafe external symlinks.
  * Prevented credential headers from being exposed to SQL templates.
  * Reduced sensitive data exposure in database logs.
  * Improved handling of user-supplied values through safe SQL binding and interpolation checks.

* **Bug Fixes**
  * Improved database execution error handling.
  * Ensured error responses remain valid JSON, including messages with special characters.

* **Documentation**
  * Added guidance for safely passing values and handling headers in SQL scripts.

* **Tests**
  * Added coverage for security protections, safe parameter binding, and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->