### PR TITLE
fix: JOIN issue when using restrict access in toml file

### DIFF
--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -1894,9 +1894,67 @@ func (adapter *postgres) FieldsPermissions(r *http.Request, database, schema, ta
 		}
 		return
 	}
-	fields = intersection(cols, allowedFields)
-	if len(cols) == 0 && len(allowedFields) > 0 {
-		fields = allowedFields
+	joinFields, joined := adapter.joinFieldsPermissions(r, database, schema, op, userName)
+	if len(cols) > 0 {
+		selectable := allowedFields
+		if joined {
+			selectable = append(qualifyFields(table, allowedFields), allowedFields...)
+			selectable = append(selectable, joinFields...)
+		}
+		fields = intersection(cols, selectable)
+		return
+	}
+	if len(allowedFields) == 0 {
+		return
+	}
+	fields = allowedFields
+	if joined {
+		fields = append(qualifyFields(table, allowedFields), joinFields...)
+	}
+	return
+}
+
+func (adapter *postgres) joinFieldsPermissions(r *http.Request, database, schema, op, userName string) (fields []string, joined bool) {
+	joinSchema, joinTable, ok := joinTableByRequest(r, schema)
+	if !ok {
+		return
+	}
+	joined = true
+	if !adapter.TablePermissions(database, joinSchema, joinTable, op, userName) {
+		return
+	}
+	allowedFields := adapter.fieldsByPermission(database, joinSchema, joinTable, op, userName)
+	if containsAsterisk(allowedFields) {
+		return []string{joinTable + ".*"}, true
+	}
+	return qualifyFields(joinTable, allowedFields), true
+}
+
+func joinTableByRequest(r *http.Request, schema string) (joinSchema, joinTable string, ok bool) {
+	joinArgs := strings.Split(r.URL.Query().Get("_join"), ":")
+	if len(joinArgs) != 5 || !ident.IsValid(joinArgs[1]) {
+		return
+	}
+	parts := strings.Split(joinArgs[1], ".")
+	switch len(parts) {
+	case 1:
+		return schema, parts[0], true
+	case 2:
+		return parts[0], parts[1], true
+	}
+	return
+}
+
+func qualifyFields(table string, fields []string) (qualified []string) {
+	if !ident.IsValid(table) {
+		return slices.Clone(fields)
+	}
+	for _, field := range fields {
+		if strings.Contains(field, ".") || !ident.IsValid(field) {
+			qualified = append(qualified, field)
+			continue
+		}
+		qualified = append(qualified, table+"."+field)
 	}
 	return
 }
@@ -2128,6 +2186,13 @@ var quotedAggRegex = regexp.MustCompile(
 func sanitizeSelectField(field string) (string, error) {
 	if field == "*" {
 		return "*", nil
+	}
+	if prefix, found := strings.CutSuffix(field, ".*"); found {
+		q, qerr := ident.Quote(prefix)
+		if qerr != nil {
+			return "", errors.Wrapf(ErrInvalidIdentifier, "%s", field)
+		}
+		return q + ".*", nil
 	}
 	if groupFunc, _ := NormalizeGroupFunction(field); groupFunc != "" {
 		return groupFunc, nil // colon-syntax: already validated + quoted

--- a/adapters/postgres/postgres.go
+++ b/adapters/postgres/postgres.go
@@ -1863,11 +1863,27 @@ func containsAsterisk(arr []string) bool {
 func intersection(set, other []string) (intersection []string) {
 	for _, field := range set {
 		pField := checkField(field, other)
+		if pField == "" && matchesQualifiedAsterisk(field, other) {
+			pField = field
+		}
 		if pField != "" {
 			intersection = append(intersection, pField)
 		}
 	}
 	return
+}
+
+func matchesQualifiedAsterisk(col string, fields []string) bool {
+	if !ident.IsValid(col) {
+		return false
+	}
+	for _, field := range fields {
+		prefix, found := strings.CutSuffix(field, ".*")
+		if found && strings.HasPrefix(col, prefix+".") {
+			return true
+		}
+	}
+	return false
 }
 
 // FieldsPermissions get fields permissions based in prest configuration
@@ -1887,14 +1903,26 @@ func (adapter *postgres) FieldsPermissions(r *http.Request, database, schema, ta
 		return
 	}
 	allowedFields := adapter.fieldsByPermission(database, schema, table, op, userName)
+	joinFields, joined := adapter.joinFieldsPermissions(r, database, schema, op, userName)
 	if containsAsterisk(allowedFields) {
-		fields = []string{"*"}
-		if len(cols) > 0 {
-			fields = cols
+		if !joined {
+			fields = []string{"*"}
+			if len(cols) > 0 {
+				fields = cols
+			}
+			return
 		}
+		selectable := joinFields
+		if base, ok := qualifiedAsterisk(table); ok {
+			selectable = append([]string{base}, joinFields...)
+		}
+		if len(cols) == 0 {
+			fields = selectable
+			return
+		}
+		fields = intersection(qualifyFields(table, cols), selectable)
 		return
 	}
-	joinFields, joined := adapter.joinFieldsPermissions(r, database, schema, op, userName)
 	if len(cols) > 0 {
 		selectable := allowedFields
 		if joined {
@@ -1950,6 +1978,10 @@ func qualifyFields(table string, fields []string) (qualified []string) {
 		return slices.Clone(fields)
 	}
 	for _, field := range fields {
+		if field == "*" {
+			qualified = append(qualified, table+".*")
+			continue
+		}
 		if strings.Contains(field, ".") || !ident.IsValid(field) {
 			qualified = append(qualified, field)
 			continue
@@ -1957,6 +1989,13 @@ func qualifyFields(table string, fields []string) (qualified []string) {
 		qualified = append(qualified, table+"."+field)
 	}
 	return
+}
+
+func qualifiedAsterisk(table string) (qualified string, ok bool) {
+	if !ident.IsValid(table) {
+		return
+	}
+	return table + ".*", true
 }
 
 func checkField(col string, fields []string) (p string) {

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -975,7 +975,8 @@ func Test_sanitizeSelectField(t *testing.T) {
 		{"invalid table qualified asterisk is rejected", "0bad.*", "", true},
 		{"plain identifier is quoted", "name", `"name"`, false},
 		{"dotted identifier is quoted per segment", "public.age", `"public"."age"`, false},
-		{"colon-syntax aggregate is normalized", "avg:age", `AVG("age")`, false},		{"bare aggregate keyword is a plain field", "sum", `"sum"`, false},
+		{"colon-syntax aggregate is normalized", "avg:age", `AVG("age")`, false},
+		{"bare aggregate keyword is a plain field", "sum", `"sum"`, false},
 		{"pre-quoted aggregate is accepted", `SUM("salary")`, `SUM("salary")`, false},
 		{"pre-quoted aggregate with alias is accepted", `MAX("age") AS "m"`, `MAX("age") AS "m"`, false},
 		{"invalid identifier is rejected", "0bad", "", true},
@@ -1531,6 +1532,11 @@ func TestFieldsPermissions_Join(t *testing.T) {
 			[]string{"department.d_id", "department.dept", "department.emp_id", "unrestricted.*"},
 		},
 		{
+			"_select of a field of an ignored joined table is kept",
+			"/public/department?_join=inner:unrestricted:department.d_id:$eq:unrestricted.d_id&_select=dept,unrestricted.total",
+			[]string{"dept", "unrestricted.total"},
+		},
+		{
 			"malformed join keeps the main table fields",
 			"/public/department?_join=inner:employee",
 			[]string{"d_id", "dept", "emp_id"},
@@ -1556,6 +1562,77 @@ func TestFieldsPermissions_Join(t *testing.T) {
 	}
 }
 
+func TestFieldsPermissions_JoinWildcardTable(t *testing.T) {
+	t.Parallel()
+
+	adapter := testAdapter(&config.Prest{
+		AccessConf: config.AccessConf{
+			Restrict:    true,
+			IgnoreTable: []string{"unrestricted"},
+			Tables: []config.TablesConf{
+				{Name: "department", Permissions: []string{"read"}, Fields: []string{"*"}},
+				{Name: "employee", Permissions: []string{"read"}, Fields: []string{"id", "name"}},
+				{Name: "salary", Permissions: []string{"write"}, Fields: []string{"amount"}},
+			},
+		},
+	})
+
+	testCases := []struct {
+		description string
+		url         string
+		want        []string
+	}{
+		{
+			"wildcard access without join keeps the unqualified wildcard",
+			"/public/department",
+			[]string{"*"},
+		},
+		{
+			"wildcard access is restricted to the main table when a joined table has no read permission",
+			"/public/department?_join=inner:salary:department.d_id:$eq:salary.d_id",
+			[]string{"department.*"},
+		},
+		{
+			"wildcard access adds the readable fields of the joined table",
+			"/public/department?_join=inner:employee:department.emp_id:$eq:employee.id",
+			[]string{"department.*", "employee.id", "employee.name"},
+		},
+		{
+			"_select of a joined field without read permission is dropped under wildcard access",
+			"/public/department?_join=inner:salary:department.d_id:$eq:salary.d_id&_select=dept,salary.amount",
+			[]string{"department.dept"},
+		},
+		{
+			"_select=* is restricted to the main table when a join is present",
+			"/public/department?_join=inner:salary:department.d_id:$eq:salary.d_id&_select=*",
+			[]string{"department.*"},
+		},
+		{
+			"_select of a readable joined field is kept under wildcard access",
+			"/public/department?_join=inner:employee:department.emp_id:$eq:employee.id&_select=dept,employee.name",
+			[]string{"department.dept", "employee.name"},
+		},
+		{
+			"_select of an aggregate is dropped under wildcard access because its column cannot be qualified",
+			"/public/department?_join=inner:salary:department.d_id:$eq:salary.d_id&_groupby=dept&_select=avg:amount",
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(http.MethodGet, tc.url, nil)
+			require.NoError(t, err)
+
+			fields, err := adapter.FieldsPermissions(req, "", "public", "department", "read", "")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, fields)
+		})
+	}
+}
+
 func Test_qualifyFields(t *testing.T) {
 	t.Parallel()
 
@@ -1564,10 +1641,25 @@ func Test_qualifyFields(t *testing.T) {
 		[]string{"employee.id", "public.employee.name", `MAX("age")`},
 		qualifyFields("employee", []string{"id", "public.employee.name", `MAX("age")`}))
 	require.Equal(t, []string{"id"}, qualifyFields("my-table", []string{"id"}))
+	require.Equal(t, []string{"employee.*"}, qualifyFields("employee", []string{"*"}))
+	require.Equal(t, []string{"*"}, qualifyFields("my-table", []string{"*"}))
+}
+
+func Test_qualifiedAsterisk(t *testing.T) {
+	t.Parallel()
+
+	qualified, ok := qualifiedAsterisk("employee")
+	require.True(t, ok)
+	require.Equal(t, "employee.*", qualified)
+
+	qualified, ok = qualifiedAsterisk("my-table")
+	require.False(t, ok)
+	require.Empty(t, qualified)
 }
 
 func TestFieldsByPermission(t *testing.T) {
 	t.Parallel()
+
 	adapter := testAdapter(permissionTestConf())
 
 	fields := adapter.fieldsByPermission("", "public", "test_fields_access", "read", "")

--- a/adapters/postgres/postgres_test.go
+++ b/adapters/postgres/postgres_test.go
@@ -971,10 +971,11 @@ func Test_sanitizeSelectField(t *testing.T) {
 		wantErr     bool
 	}{
 		{"asterisk passes through", "*", "*", false},
+		{"table qualified asterisk is quoted", "employee.*", `"employee".*`, false},
+		{"invalid table qualified asterisk is rejected", "0bad.*", "", true},
 		{"plain identifier is quoted", "name", `"name"`, false},
 		{"dotted identifier is quoted per segment", "public.age", `"public"."age"`, false},
-		{"colon-syntax aggregate is normalized", "avg:age", `AVG("age")`, false},
-		{"bare aggregate keyword is a plain field", "sum", `"sum"`, false},
+		{"colon-syntax aggregate is normalized", "avg:age", `AVG("age")`, false},		{"bare aggregate keyword is a plain field", "sum", `"sum"`, false},
 		{"pre-quoted aggregate is accepted", `SUM("salary")`, `SUM("salary")`, false},
 		{"pre-quoted aggregate with alias is accepted", `MAX("age") AS "m"`, `MAX("age") AS "m"`, false},
 		{"invalid identifier is rejected", "0bad", "", true},
@@ -1479,9 +1480,94 @@ func TestFieldsPermissions_RestrictBranches(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestFieldsByPermission(t *testing.T) {
+func TestFieldsPermissions_Join(t *testing.T) {
 	t.Parallel()
 
+	adapter := testAdapter(&config.Prest{
+		AccessConf: config.AccessConf{
+			Restrict:    true,
+			IgnoreTable: []string{"unrestricted"},
+			Tables: []config.TablesConf{
+				{Name: "department", Permissions: []string{"read"}, Fields: []string{"d_id", "dept", "emp_id"}},
+				{Name: "employee", Permissions: []string{"read"}, Fields: []string{"id", "name"}},
+				{Name: "salary", Permissions: []string{"write"}, Fields: []string{"amount"}},
+			},
+		},
+	})
+
+	testCases := []struct {
+		description string
+		url         string
+		want        []string
+	}{
+		{
+			"joined table readable fields are added to the select list",
+			"/public/department?_join=inner:employee:department.emp_id:$eq:employee.id",
+			[]string{"department.d_id", "department.dept", "department.emp_id", "employee.id", "employee.name"},
+		},
+		{
+			"schema qualified join resolves the joined table permissions",
+			"/public/department?_join=inner:public.employee:department.emp_id:$eq:employee.id",
+			[]string{"department.d_id", "department.dept", "department.emp_id", "employee.id", "employee.name"},
+		},
+		{
+			"_select accepts qualified fields of both tables",
+			"/public/department?_join=inner:employee:department.emp_id:$eq:employee.id&_select=dept,employee.name",
+			[]string{"dept", "employee.name"},
+		},
+		{
+			"_select of a joined field without read permission is dropped",
+			"/public/department?_join=inner:salary:department.d_id:$eq:salary.d_id&_select=dept,salary.amount",
+			[]string{"dept"},
+		},
+		{
+			"joined table without read permission adds no field",
+			"/public/department?_join=inner:salary:department.d_id:$eq:salary.d_id",
+			[]string{"department.d_id", "department.dept", "department.emp_id"},
+		},
+		{
+			"ignored joined table is selected in full",
+			"/public/department?_join=inner:unrestricted:department.d_id:$eq:unrestricted.d_id",
+			[]string{"department.d_id", "department.dept", "department.emp_id", "unrestricted.*"},
+		},
+		{
+			"malformed join keeps the main table fields",
+			"/public/department?_join=inner:employee",
+			[]string{"d_id", "dept", "emp_id"},
+		},
+		{
+			"join target with too many identifier segments keeps the main table fields",
+			"/public/department?_join=inner:db.public.employee:department.emp_id:$eq:employee.id",
+			[]string{"d_id", "dept", "emp_id"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(http.MethodGet, tc.url, nil)
+			require.NoError(t, err)
+
+			fields, err := adapter.FieldsPermissions(req, "", "public", "department", "read", "")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, fields)
+		})
+	}
+}
+
+func Test_qualifyFields(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, qualifyFields("employee", nil))
+	require.Equal(t,
+		[]string{"employee.id", "public.employee.name", `MAX("age")`},
+		qualifyFields("employee", []string{"id", "public.employee.name", `MAX("age")`}))
+	require.Equal(t, []string{"id"}, qualifyFields("my-table", []string{"id"}))
+}
+
+func TestFieldsByPermission(t *testing.T) {
+	t.Parallel()
 	adapter := testAdapter(permissionTestConf())
 
 	fields := adapter.fieldsByPermission("", "public", "test_fields_access", "read", "")

--- a/integration/postgres/controllers/join_acl_test.go
+++ b/integration/postgres/controllers/join_acl_test.go
@@ -1,0 +1,102 @@
+package controllers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/prest/prest/v2/integration/helpers"
+	"github.com/prest/prest/v2/integration/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSelectJoin_RestrictedFields covers reads with _join on a server where
+// access.restrict is on (testdata/prest.toml). The select list comes from the
+// ACL, so it must qualify the permitted columns of the requested table (an
+// unqualified column is ambiguous as soon as a table sharing its name is
+// joined) and it must expose columns of the joined table only when that table
+// is readable as well.
+func TestSelectJoin_RestrictedFields(t *testing.T) {
+	base := helpers.AuthServerURL(t)
+	token := helpers.LoginToken(t, base, "test@postgres.rest", "123456")
+
+	// Join test_group_by_table (read on id, name, age, salary) with test7,
+	// which prest.toml does not list and therefore is not readable. Both
+	// tables have a "name" column, so the request only succeeds when the
+	// select list is qualified, and it must carry no test7 column.
+	rows := selectJoinRows(t, base+
+		"/prest-test/public/test_group_by_table?_join=inner:test7:test_group_by_table.name:$eq:test7.name",
+		token)
+	require.Len(t, rows, 1)
+	require.Equal(t, "gopher", rows[0]["name"])
+	require.NotContains(t, rows[0], "surname", "test7 is not readable, its columns must stay out of the response")
+
+	// Same request joining view_test instead, which is granted read on
+	// "player": a readable joined table contributes its permitted columns.
+	rows = selectJoinRows(t, base+
+		"/prest-test/public/test_group_by_table?_join=inner:view_test:test_group_by_table.name:$eq:view_test.player",
+		token)
+	require.Len(t, rows, 1)
+	require.Equal(t, "gopher", rows[0]["player"])
+
+	// Asking for a column of the unreadable joined table explicitly leaves the
+	// request without any permitted column, answered with 400.
+	testutils.DoRequestWithHeaders(t, base+
+		"/prest-test/public/test_group_by_table?_join=inner:test7:test_group_by_table.name:$eq:test7.name&_select=test7.surname",
+		nil, http.MethodGet, http.StatusBadRequest, "SelectJoinRestrictedFields",
+		map[string]string{"Authorization": "Bearer " + token})
+}
+
+// TestSelectJoin_WildcardFieldsStayOnRequestedTable guards the wildcard grant:
+// prest.toml gives every field ("*") on test5, which must not extend to a
+// joined table the caller cannot read. A bare "*" in the select list would
+// return every column of the join, including the unreadable ones.
+func TestSelectJoin_WildcardFieldsStayOnRequestedTable(t *testing.T) {
+	base := helpers.AuthServerURL(t)
+	token := helpers.LoginToken(t, base, "test@postgres.rest", "123456")
+	const name = "join-acl-wildcard"
+
+	// Seed the row this test reads back, and drop it afterwards so the shared
+	// test5 table is left as it was found.
+	helpers.DoAuthRequest(t, base+"/prest-test/public/test5",
+		map[string]string{"name": name}, http.MethodPost, token,
+		http.StatusCreated, "SelectJoinWildcardSeed")
+	t.Cleanup(func() {
+		helpers.DoAuthRequest(t, base+"/prest-test/public/test5?name=$eq."+name,
+			nil, http.MethodDelete, token, http.StatusOK, "SelectJoinWildcardCleanup")
+	})
+
+	// Wildcard access on test5 joined to the unreadable test7: the row must
+	// hold the test5 columns only.
+	rows := selectJoinRows(t, base+
+		"/prest-test/public/test5?test5.name=$eq."+name+
+		"&_join=left:test7:test5.name:$eq:test7.name",
+		token)
+	require.Len(t, rows, 1)
+	require.Contains(t, rows[0], "celphone", "wildcard access still returns every test5 column")
+	require.NotContains(t, rows[0], "surname", "test7 is not readable, its columns must stay out of the response")
+
+	// Requesting a test7 column explicitly is refused even under wildcard
+	// access, leaving no permitted column to select.
+	testutils.DoRequestWithHeaders(t, base+
+		"/prest-test/public/test5?_join=left:test7:test5.name:$eq:test7.name&_select=test7.surname",
+		nil, http.MethodGet, http.StatusBadRequest, "SelectJoinWildcardFields",
+		map[string]string{"Authorization": "Bearer " + token})
+}
+
+func selectJoinRows(t *testing.T, url, token string) []map[string]any {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var rows []map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&rows))
+	return rows
+}


### PR DESCRIPTION
Fixes #364

## Root cause

restrict=true builds the SELECT list from the main table field permissions only, dropping joined table columns

## Changes

- FieldsPermissions now resolves the _join target's schema/table, checks its TablePermissions/fieldsByPermission for the same operation and user, and appends its permitted columns (qualified with the joined table name, or table.* for ignore_table entries) to the select list; main table columns are qualified when a join is present so they cannot become ambiguous, and _select now accepts qualified fields of either side. Joined tables without read permission still contribute no column. sanitizeSelectField gained validated support for a table-qualified asterisk. Added unit table tests plus two auth-server (restrict=true) integration tests: one asserting joined permitted columns are returned, one asserting an unpermitted joined table's columns never leak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission handling when querying data across joined tables.
  * Restricted unauthorized or unavailable joined-table fields.
  * Added support for qualified field selections, including `table.*`.
  * Ensured wildcard selections remain limited to the requested table.
  * Improved validation for malformed joins and schema-qualified table references.
  * Ensured base-table fields are correctly identified in combined queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->